### PR TITLE
feat: add Growth plan ($49/mo)

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -42,20 +42,22 @@ from cloud.store import CloudStore
 class AuthContext:
     """Auth result with plan info for quota enforcement."""
     user_id: str
-    plan: str         # free, starter, pro, business
+    plan: str         # free, starter, pro, growth, business
     rate_limit: int   # per-minute rate limit
 
 PLAN_QUOTAS = {
     "free":     {"adds": 30,    "searches": 100,    "agents": 3,   "reflects": 3,   "dedups": 1,   "reindexes": 1,   "rules": 3,    "rate_limit": 20,  "webhooks": 0,  "teams": 0,  "sub_users": 3},
     "starter":  {"adds": 100,   "searches": 500,    "agents": 10,  "reflects": 30,  "dedups": 5,   "reindexes": 5,   "rules": 10,   "rate_limit": 60,  "webhooks": 2,  "teams": 1,  "sub_users": 10},
     "pro":      {"adds": 1_000, "searches": 10_000, "agents": 50,  "reflects": -1,  "dedups": 20,  "reindexes": 10,  "rules": -1,   "rate_limit": 120, "webhooks": 10, "teams": 5,  "sub_users": 50},
-    "business": {"adds": 5_000, "searches": 30_000, "agents": -1,  "reflects": -1,  "dedups": -1,  "reindexes": -1,  "rules": -1,   "rate_limit": 300, "webhooks": 50, "teams": -1, "sub_users": -1},
+    "growth":   {"adds": 3_000, "searches": 20_000, "agents": -1,  "reflects": -1,  "dedups": 50,  "reindexes": 20,  "rules": -1,   "rate_limit": 200, "webhooks": 25, "teams": 10, "sub_users": 100},
+    "business": {"adds": 8_000, "searches": 30_000, "agents": -1,  "reflects": -1,  "dedups": -1,  "reindexes": -1,  "rules": -1,   "rate_limit": 300, "webhooks": 50, "teams": -1, "sub_users": -1},
 }
 
 FILE_SIZE_LIMITS = {
     "free":     10 * 1024 * 1024,   # 10 MB
     "starter":  10 * 1024 * 1024,   # 10 MB
     "pro":      50 * 1024 * 1024,   # 50 MB
+    "growth":   100 * 1024 * 1024,  # 100 MB
     "business": 100 * 1024 * 1024,  # 100 MB
 }
 ALLOWED_EXTENSIONS = {"pdf", "docx", "txt", "md"}
@@ -314,7 +316,7 @@ profile = m.get_profile()             # instant system prompt
 
     def rerank_results(query: str, results: list[dict], plan: str = "business") -> list[dict]:
         """Re-rank search results based on subscription plan.
-        Free/Starter: no reranking.  Pro/Business: Cohere Rerank → LLM fallback."""
+        Free/Starter: no reranking.  Pro/Growth/Business: Cohere Rerank → LLM fallback."""
         if not results or len(results) <= 1:
             return results
 
@@ -323,7 +325,7 @@ profile = m.get_profile()             # instant system prompt
             return results
 
         # Try Cohere Rerank first — fact-level (cross-encoder, more precise)
-        cohere_key = os.environ.get("COHERE_API_KEY", "") if plan in ("pro", "business") else ""
+        cohere_key = os.environ.get("COHERE_API_KEY", "") if plan in ("pro", "growth", "business") else ""
         if cohere_key:
             try:
                 nonlocal _cohere_client
@@ -613,7 +615,7 @@ Be strict — only include entities that directly answer or relate to the query.
                 pass
         retry_after = _quota_month_end_ttl()
         # Build direct one-click checkout URL (same as quota email)
-        next_plan_key = {"free": "starter", "starter": "pro", "pro": "business"}.get(plan, "starter")
+        next_plan_key = {"free": "starter", "starter": "pro", "pro": "growth", "growth": "business"}.get(plan, "starter")
         upgrade_url = "https://mengram.io/#pricing"
         if user_id:
             token = _sign_checkout_token(user_id, next_plan_key)
@@ -656,11 +658,18 @@ Be strict — only include entities that directly answer or relate to the query.
             "features": "LLM-powered reranking, procedure evolution, and smart triggers",
         },
         "pro": {
+            "name": "Growth",
+            "price": "$59/mo",
+            "adds": "3,000",
+            "searches": "20,000",
+            "features": "unlimited agents, 200 req/min, and 25 webhooks",
+        },
+        "growth": {
             "name": "Business",
             "price": "$99/mo",
-            "adds": "5,000",
+            "adds": "8,000",
             "searches": "30,000",
-            "features": "unlimited agents, Cohere cross-encoder reranking, and unlimited teams",
+            "features": "Cohere cross-encoder reranking and unlimited teams",
         },
     }
 
@@ -682,7 +691,7 @@ Be strict — only include entities that directly answer or relate to the query.
         if next_plan:
             subject = f"You've reached your monthly {action_label} limit"
             next_limit = next_plan["adds"] if action == "add" else next_plan["searches"]
-            next_plan_key = {"free": "starter", "starter": "pro", "pro": "business"}.get(plan, "starter")
+            next_plan_key = {"free": "starter", "starter": "pro", "pro": "growth", "growth": "business"}.get(plan, "starter")
             checkout_token = _sign_checkout_token(user_id, next_plan_key)
             checkout_url = f"https://mengram.io/checkout?token={checkout_token}"
             body_html = f"""
@@ -761,7 +770,7 @@ Be strict — only include entities that directly answer or relate to the query.
         # Build upgrade button (only if there's a next plan)
         upgrade_html = ""
         if next_plan:
-            next_plan_key = {"free": "starter", "starter": "pro", "pro": "business"}.get(plan, "starter")
+            next_plan_key = {"free": "starter", "starter": "pro", "pro": "growth", "growth": "business"}.get(plan, "starter")
             checkout_token = _sign_checkout_token(user_id, next_plan_key)
             checkout_url = f"https://mengram.io/checkout?token={checkout_token}"
             next_limit = next_plan["adds"] if action == "add" else next_plan["searches"]
@@ -2771,7 +2780,8 @@ Cursor: [recalls: Next.js App Router, TypeScript, Supabase, existing route patte
 <ul>
 <li><strong>Starter</strong> ($5/mo) — 100 adds, 500 searches</li>
 <li><strong>Pro</strong> ($19/mo) — 1,000 adds, 10,000 searches, smart triggers</li>
-<li><strong>Business</strong> ($99/mo) — 5,000 adds, 30,000 searches, unlimited agents</li>
+<li><strong>Growth</strong> ($59/mo) — 3,000 adds, 20,000 searches, unlimited agents</li>
+<li><strong>Business</strong> ($99/mo) — 8,000 adds, 30,000 searches, unlimited teams</li>
 </ul>
 <p>See <a href="/#pricing">full pricing</a> or <a href="/#signup">get started free</a>.</p>
 
@@ -6789,11 +6799,13 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
     PADDLE_PRICES = {
         "starter": os.environ.get("PADDLE_PRICE_STARTER", ""),
         "pro": os.environ.get("PADDLE_PRICE_PRO", ""),
+        "growth": os.environ.get("PADDLE_PRICE_GROWTH", ""),
         "business": os.environ.get("PADDLE_PRICE_BUSINESS", ""),
     }
     PADDLE_PRICES_ANNUAL = {
         "starter": os.environ.get("PADDLE_PRICE_STARTER_ANNUAL", ""),
         "pro": os.environ.get("PADDLE_PRICE_PRO_ANNUAL", ""),
+        "growth": os.environ.get("PADDLE_PRICE_GROWTH_ANNUAL", ""),
         "business": os.environ.get("PADDLE_PRICE_BUSINESS_ANNUAL", ""),
     }
 
@@ -6834,7 +6846,7 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
         if len(parts) != 4:
             raise HTTPException(status_code=400, detail="Invalid checkout token")
         user_id, plan, month, sig = parts
-        if plan not in ("starter", "pro", "business"):
+        if plan not in ("starter", "pro", "growth", "business"):
             raise HTTPException(status_code=400, detail="Invalid plan")
         if not PADDLE_WEBHOOK_SECRET:
             raise HTTPException(status_code=503, detail="Billing not configured")
@@ -6889,7 +6901,7 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
         sub = store.get_subscription(user_id)
         usage = store.get_all_usage_counts(user_id)
         quotas = PLAN_QUOTAS.get(ctx.plan, PLAN_QUOTAS["free"])
-        annual_available = any(PADDLE_PRICES_ANNUAL.get(p) for p in ("starter", "pro", "business"))
+        annual_available = any(PADDLE_PRICES_ANNUAL.get(p) for p in ("starter", "pro", "growth", "business"))
         return {
             "plan": ctx.plan,
             "status": sub.get("status", "active"),
@@ -6902,7 +6914,7 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
 
     @app.post("/v1/billing/checkout", tags=["Billing"])
     async def create_checkout(
-        plan: str = Query(..., pattern="^(starter|pro|business)$"),
+        plan: str = Query(..., pattern="^(starter|pro|growth|business)$"),
         billing: str = Query("monthly", pattern="^(monthly|annual)$"),
         ctx: AuthContext = Depends(auth),
     ):
@@ -6919,7 +6931,7 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
             raise HTTPException(status_code=400, detail=f"Unknown plan: {plan}")
 
         # Prevent same-plan purchase and downgrades
-        plan_order = {"free": 0, "starter": 1, "pro": 2, "business": 3}
+        plan_order = {"free": 0, "starter": 1, "pro": 2, "growth": 3, "business": 4}
         if plan_order.get(plan, 0) <= plan_order.get(ctx.plan, 0):
             raise HTTPException(status_code=400, detail=f"Already on {ctx.plan} plan. Can only upgrade to a higher plan.")
 
@@ -7063,6 +7075,8 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
                     price_id = items[0].get("price", {}).get("id", "")
                     if price_id in (PADDLE_PRICES.get("business"), PADDLE_PRICES_ANNUAL.get("business")):
                         plan = "business"
+                    elif price_id in (PADDLE_PRICES.get("growth"), PADDLE_PRICES_ANNUAL.get("growth")):
+                        plan = "growth"
                     elif price_id in (PADDLE_PRICES.get("pro"), PADDLE_PRICES_ANNUAL.get("pro")):
                         plan = "pro"
                     elif price_id in (PADDLE_PRICES.get("starter"), PADDLE_PRICES_ANNUAL.get("starter")):
@@ -7127,6 +7141,8 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
                     price_id = items[0].get("price", {}).get("id", "")
                     if price_id in (PADDLE_PRICES.get("business"), PADDLE_PRICES_ANNUAL.get("business")):
                         updates["plan"] = "business"
+                    elif price_id in (PADDLE_PRICES.get("growth"), PADDLE_PRICES_ANNUAL.get("growth")):
+                        updates["plan"] = "growth"
                     elif price_id in (PADDLE_PRICES.get("pro"), PADDLE_PRICES_ANNUAL.get("pro")):
                         updates["plan"] = "pro"
                     elif price_id in (PADDLE_PRICES.get("starter"), PADDLE_PRICES_ANNUAL.get("starter")):

--- a/cloud/dashboard.html
+++ b/cloud/dashboard.html
@@ -1455,9 +1455,9 @@ function renderQuotaBanner(plan, usage, quotas) {
 
     const anyAtLimit = hits.some(h => h.pct >= 100);
     const cls = anyAtLimit ? 'critical' : 'warning';
-    const nextPlanKey = { free: 'starter', starter: 'pro', pro: 'business' }[plan] || 'starter';
-    const nextPlanLabel = { free: 'Starter ($5/mo)', starter: 'Pro ($19/mo)', pro: 'Business ($99/mo)' }[plan] || 'a higher plan';
-    const nextPlanLimits = { starter: '100 adds, 500 searches', pro: '1K adds, 10K searches', business: '5K adds, 30K searches' }[nextPlanKey] || '';
+    const nextPlanKey = { free: 'starter', starter: 'pro', pro: 'growth', growth: 'business' }[plan] || 'starter';
+    const nextPlanLabel = { free: 'Starter ($5/mo)', starter: 'Pro ($19/mo)', pro: 'Growth ($59/mo)', growth: 'Business ($99/mo)' }[plan] || 'a higher plan';
+    const nextPlanLimits = { starter: '100 adds, 500 searches', pro: '1K adds, 10K searches', growth: '3K adds, 20K searches', business: '8K adds, 30K searches' }[nextPlanKey] || '';
     const title = anyAtLimit ? 'Monthly usage limit reached' : 'Approaching your usage limits';
     const desc = `Upgrade to ${esc(nextPlanLabel)} for ${esc(nextPlanLimits)}/mo.`;
     const icon = anyAtLimit
@@ -2876,7 +2876,7 @@ async function loadBilling() {
             usageCard('Reflects', usage.reflect_count || 0, limits.reflects);
 
         // Hide upgrade section if already on business
-        document.getElementById('billing-upgrade').style.display = plan === 'business' ? 'none' : 'block';
+        document.getElementById('billing-upgrade').style.display = (plan === 'business') ? 'none' : 'block';
         // Show annual toggle if available
         window._annualAvailable = d.annual_available || false;
         document.getElementById('billing-toggle').style.display = window._annualAvailable ? 'flex' : 'none';
@@ -2889,7 +2889,8 @@ let _billingCycle = 'monthly';
 const PLAN_PRICING = {
     starter:  { monthly: 5,  annual: 48,  adds: '100',  searches: '500',  desc: '100 adds, 500 searches' },
     pro:      { monthly: 19, annual: 180, adds: '1K',   searches: '10K',  desc: '1K adds, 10K searches, LLM rerank' },
-    business: { monthly: 99, annual: 948, adds: '5K',   searches: '30K',  desc: '5K adds, 30K searches, Cohere rerank' },
+    growth:   { monthly: 59, annual: 566, adds: '3K',   searches: '20K',  desc: '3K adds, 20K searches, unlimited agents' },
+    business: { monthly: 99, annual: 948, adds: '8K',   searches: '30K',  desc: '8K adds, 30K searches, Cohere rerank' },
 };
 
 function setBillingCycle(cycle) {
@@ -2903,7 +2904,7 @@ function setBillingCycle(cycle) {
 
 function renderPricingCards() {
     const plan = window._currentPlan || 'free';
-    const planOrder = ['starter', 'pro', 'business'];
+    const planOrder = ['starter', 'pro', 'growth', 'business'];
     const currentIdx = planOrder.indexOf(plan);
     let html = '';
     let firstUpgrade = true;

--- a/cloud/landing.html
+++ b/cloud/landing.html
@@ -1121,9 +1121,9 @@
         }
         .pricing-grid {
             display: grid;
-            grid-template-columns: repeat(5, 1fr);
+            grid-template-columns: repeat(3, 1fr);
             gap: 16px;
-            max-width: 1400px;
+            max-width: 900px;
             margin: 0 auto;
         }
         .price-card {
@@ -1592,6 +1592,7 @@
                     { "@type": "Offer", "price": "0", "priceCurrency": "USD", "name": "Free" },
                     { "@type": "Offer", "price": "5", "priceCurrency": "USD", "name": "Starter" },
                     { "@type": "Offer", "price": "19", "priceCurrency": "USD", "name": "Pro" },
+                    { "@type": "Offer", "price": "59", "priceCurrency": "USD", "name": "Growth" },
                     { "@type": "Offer", "price": "99", "priceCurrency": "USD", "name": "Business" },
                     { "@type": "Offer", "price": "0", "priceCurrency": "USD", "name": "Enterprise", "description": "Custom pricing — contact us" }
                 ],
@@ -2582,13 +2583,32 @@ POST /v1/add → {<span class="c-str">"messages"</span>: [...], <span class="c-s
                     </ul>
                     <a href="#signup" onclick="return pricingCTA('pro')" class="price-btn primary">Upgrade to Pro</a>
                 </div>
+                <!-- Growth -->
+                <div class="price-card reveal" data-plan="growth">
+                    <h3>Growth</h3>
+                    <div class="price-amount">$59 <span>/ month</span></div>
+                    <div class="price-desc">For scaling apps that need more volume.</div>
+                    <ul class="price-features">
+                        <li>3,000 memory adds / month</li>
+                        <li>20,000 searches / month</li>
+                        <li>Unlimited agent runs</li>
+                        <li>100 sub-users</li>
+                        <li>200 req/min rate limit</li>
+                        <li>Cohere cross-encoder reranking</li>
+                        <li>Procedure evolution</li>
+                        <li>Smart triggers</li>
+                        <li>25 webhooks</li>
+                        <li>10 teams</li>
+                    </ul>
+                    <a href="#signup" onclick="return pricingCTA('growth')" class="price-btn">Upgrade to Growth</a>
+                </div>
                 <!-- Business -->
                 <div class="price-card reveal" data-plan="business">
                     <h3>Business</h3>
                     <div class="price-amount">$99 <span>/ month</span></div>
                     <div class="price-desc">For teams and high-volume applications.</div>
                     <ul class="price-features">
-                        <li>5,000 memory adds / month</li>
+                        <li>8,000 memory adds / month</li>
                         <li>30,000 searches / month</li>
                         <li>Unlimited agent runs</li>
                         <li>Unlimited sub-users</li>
@@ -2819,6 +2839,7 @@ POST /v1/add → {<span class="c-str">"messages"</span>: [...], <span class="c-s
         const LP_PRICES = {
             starter:  { monthly: 5,  annual: 48 },
             pro:      { monthly: 19, annual: 180 },
+            growth:   { monthly: 59, annual: 566 },
             business: { monthly: 99, annual: 948 },
         };
         let _lpBilling = 'monthly';
@@ -3016,7 +3037,7 @@ POST /v1/add → {<span class="c-str">"messages"</span>: [...], <span class="c-s
                     `;
                     const wp = sessionStorage.getItem('wanted_plan');
                     if (wp && wp !== 'free') {
-                        const names = {starter:'Starter ($5/mo)',pro:'Pro ($19/mo)',business:'Business ($99/mo)'};
+                        const names = {starter:'Starter ($5/mo)',pro:'Pro ($19/mo)',growth:'Growth ($59/mo)',business:'Business ($99/mo)'};
                         result.innerHTML += `
                             <div style="margin-top:16px;padding:14px 18px;background:linear-gradient(135deg,rgba(168,85,247,0.12),rgba(124,58,237,0.08));border:1px solid rgba(168,85,247,0.3);border-radius:10px;">
                                 <p style="margin:0 0 10px;font-size:14px;color:var(--text);">Ready to upgrade to <strong>${esc(names[wp] || wp)}</strong>?</p>

--- a/scripts/send_conversion_emails.py
+++ b/scripts/send_conversion_emails.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Conversion emails to free users who hit their quota limits.
+Run:  python3 scripts/send_conversion_emails.py                    # preview all
+      python3 scripts/send_conversion_emails.py --send fede91it    # send one
+      python3 scripts/send_conversion_emails.py --send all         # send all
+"""
+import argparse
+
+RESEND_KEY = "re_918vn92M_GxZwVDVhQJZdDMeuN3BUUatv"
+FROM = "Ali from Mengram <ali@mengram.io>"
+REPLY_TO = "the.baizhanov@gmail.com"
+
+EMAILS = {
+    "carellarafael": {
+        "to": "carellarafaelantonio@gmail.com",
+        "subject": "You've hit your free plan limit",
+        "body": """Hey Rafael,
+
+I'm Ali, the founder of Mengram. You've reached the monthly limits on the free plan.
+
+If you want to keep going, here are our plans:
+
+- Starter ($5/mo) — 100 adds, 500 searches, webhooks, teams
+- Pro ($19/mo) — 1,000 adds, 10,000 searches, reranking, smart triggers
+- Growth ($59/mo) — 3,000 adds, 20,000 searches, unlimited agents
+- Business ($99/mo) — 8,000 adds, 30,000 searches, unlimited teams
+
+You can upgrade from the dashboard: https://mengram.io/dashboard#billing
+
+Limits reset at the start of each month. Reply here if you have any questions.
+
+Best,
+Ali
+Founder, Mengram""",
+    },
+
+    "kimseylok": {
+        "to": "kimseylok@outlook.com",
+        "subject": "You've hit your free plan limit",
+        "body": """Hey,
+
+I'm Ali, the founder of Mengram. You've reached the monthly limits on the free plan.
+
+If you want to keep going, here are our plans:
+
+- Starter ($5/mo) — 100 adds, 500 searches, webhooks, teams
+- Pro ($19/mo) — 1,000 adds, 10,000 searches, reranking, smart triggers
+- Growth ($59/mo) — 3,000 adds, 20,000 searches, unlimited agents
+- Business ($99/mo) — 8,000 adds, 30,000 searches, unlimited teams
+
+You can upgrade from the dashboard: https://mengram.io/dashboard#billing
+
+Limits reset at the start of each month. Reply here if you have any questions.
+
+Best,
+Ali
+Founder, Mengram""",
+    },
+
+    "fede91it": {
+        "to": "fede91it@gmail.com",
+        "subject": "You've hit your free plan limit",
+        "body": """Hey,
+
+I'm Ali, the founder of Mengram. You've reached the monthly limits on the free plan.
+
+If you want to keep going, here are our plans:
+
+- Starter ($5/mo) — 100 adds, 500 searches, webhooks, teams
+- Pro ($19/mo) — 1,000 adds, 10,000 searches, reranking, smart triggers
+- Growth ($59/mo) — 3,000 adds, 20,000 searches, unlimited agents
+- Business ($99/mo) — 8,000 adds, 30,000 searches, unlimited teams
+
+You can upgrade from the dashboard: https://mengram.io/dashboard#billing
+
+Limits reset at the start of each month. Reply here if you have any questions.
+
+Best,
+Ali
+Founder, Mengram""",
+    },
+}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--send", type=str, default=None,
+                        help="Send to specific user key or 'all' (default: preview)")
+    args = parser.parse_args()
+
+    targets = EMAILS.keys() if not args.send or args.send == "all" else [args.send]
+
+    for key in targets:
+        if key not in EMAILS:
+            print(f"Unknown user: {key}. Available: {', '.join(EMAILS.keys())}")
+            continue
+
+        email = EMAILS[key]
+        print(f"{'='*60}")
+        print(f"[{key}]")
+        print(f"To: {email['to']}")
+        print(f"Subject: {email['subject']}")
+        print(f"Reply-To: {REPLY_TO}")
+        print(f"---")
+        print(email["body"])
+        print()
+
+        if args.send and (args.send == "all" or args.send == key):
+            import resend, time
+            resend.api_key = RESEND_KEY
+            time.sleep(1)  # Resend rate limit: 2 req/sec
+            r = resend.Emails.send({
+                "from": FROM,
+                "to": email["to"],
+                "reply_to": REPLY_TO,
+                "subject": email["subject"],
+                "text": email["body"],
+            })
+            print(f"  >>> SENT: {r}")
+        else:
+            print("  [DRY RUN]")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New **Growth** tier at $49/mo ($490/yr) between Pro and Business
- 3K adds, 20K searches, unlimited agents, 200 req/min, 25 webhooks, 10 teams
- Paddle price IDs via `PADDLE_PRICE_GROWTH` / `PADDLE_PRICE_GROWTH_ANNUAL` env vars
- Updates quota emails, billing checkout, webhook handling, landing page pricing grid, and dashboard quota banner
- Growth gets Cohere reranking (same as Pro/Business)

## Changes
| File | What |
|------|------|
| `cloud/api.py` | PLAN_QUOTAS, PADDLE_PRICES, NEXT_PLAN_INFO, checkout/webhook handlers, Cohere access |
| `cloud/dashboard.html` | PLAN_PRICING, planOrder, quota banner upgrade paths |
| `cloud/landing.html` | Pricing card, LP_PRICES, plan name mapping, grid layout (5→3 cols) |

## Deploy checklist
- [ ] Set Railway env: `PADDLE_PRICE_GROWTH=pri_01kn1fmj6p582b59xhgtmfk97j`
- [ ] Set Railway env: `PADDLE_PRICE_GROWTH_ANNUAL=pri_01kn1fscsfa2dwf1yyqbevkaxb`