### PR TITLE
fix: normalize facts in api.py rerank (missed in PR #11)

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -33,7 +33,7 @@ from fastapi.responses import HTMLResponse, FileResponse, PlainTextResponse, Red
 from dataclasses import dataclass
 from pydantic import BaseModel
 
-from cloud.store import CloudStore
+from cloud.store import CloudStore, _normalize_fact
 
 
 # ---- Auth Context ----
@@ -388,7 +388,7 @@ profile = m.get_profile()             # instant system prompt
 
             candidates = []
             for i, r in enumerate(results):
-                facts_str = "; ".join(r.get("facts", [])[:5])
+                facts_str = "; ".join(_normalize_fact(f) for f in r.get("facts", [])[:5])
                 rels_str = "; ".join(
                     f"{rel.get('type', '')} {rel.get('target', '')}"
                     for rel in r.get("relations", [])[:3]


### PR DESCRIPTION
## Summary
- `api.py:391` had `"; ".join(r.get("facts", [])[:5])` without `_normalize_fact`
- Same bug pattern as store.py (PR #11), just in the rerank code path
- Import `_normalize_fact` from `store.py` and apply

## Test plan
- [ ] Search with Cohere rerank still works for Pro users

🤖 Generated with [Claude Code](https://claude.com/claude-code)