### PR TITLE
fix: improve save hook activation for new users

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -484,7 +484,7 @@ def cmd_auto_save(args):
             output_hook_success()
 
         last_msg = input_data.get("last_assistant_message", "")
-        if not last_msg or len(last_msg) < 100:
+        if not last_msg or len(last_msg.strip()) < 10:
             output_hook_success()
 
         # Throttle: only save every Nth response
@@ -506,7 +506,7 @@ def cmd_auto_save(args):
         except Exception:
             pass
 
-        if count % every != 0:
+        if count > 1 and count % every != 0:
             output_hook_success()
 
         # Extract last user message from transcript


### PR DESCRIPTION
## Summary
- First response of every session now always saves (skip throttle for count=1)
- Lowered minimum message length from 100 to 10 chars — quality filtering done server-side by LLM extraction

## Problem
30 free users had 100-500 searches but 0 adds. The search hook (UserPromptSubmit) fires on every prompt, but the save hook (Stop) required 3 responses before first save, and filtered out messages under 100 chars. Users who tried 1-2 prompts never got anything saved → empty memory → "doesn't work" → churned.

## Test plan
- [ ] New session: first response (>10 chars) triggers save immediately
- [ ] Second response: skipped (throttle)
- [ ] Third response: saved (count=3, 3%3=0)
- [ ] Response under 10 chars: skipped
- [ ] Short but useful response (e.g. 45 chars): saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)