### PR TITLE
Fix: Add retry logic with exponential backoff to JS SDK

### DIFF
--- a/sdk/js/index.d.ts
+++ b/sdk/js/index.d.ts
@@ -1,6 +1,7 @@
 export interface MengramOptions {
   baseUrl?: string;
   timeout?: number;
+  retries?: number;
 }
 
 export interface Message {

--- a/sdk/js/index.js
+++ b/sdk/js/index.js
@@ -21,12 +21,14 @@ class MengramClient {
    * @param {object} [options]
    * @param {string} [options.baseUrl] - API base URL (default: https://mengram.io)
    * @param {number} [options.timeout] - Request timeout in ms (default: 30000)
+   * @param {number} [options.retries] - Max retry attempts on transient errors (default: 3)
    */
   constructor(apiKey, options = {}) {
     if (!apiKey) throw new Error('API key is required');
     this.apiKey = apiKey;
     this.baseUrl = (options.baseUrl || 'https://mengram.io').replace(/\/$/, '');
     this.timeout = options.timeout || 30000;
+    this.retries = options.retries ?? 3;
   }
 
   get quota() {
@@ -60,8 +62,10 @@ class MengramClient {
       'Content-Type': 'application/json',
     };
 
+    const RETRY_STATUSES = [429, 500, 502, 503];
+    const maxAttempts = this.retries;
     let lastErr;
-    for (let attempt = 0; attempt < 3; attempt++) {
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), this.timeout);
 
@@ -77,9 +81,13 @@ class MengramClient {
         this._lastHeaders = res.headers;
         if (!res.ok) {
           // Retry on transient errors
-          if ([429, 502, 503, 504].includes(res.status) && attempt < 2) {
+          if (RETRY_STATUSES.includes(res.status) && attempt < maxAttempts - 1) {
             lastErr = new MengramError(data.detail || `HTTP ${res.status}`, res.status);
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+            const retryAfter = res.headers.get('Retry-After');
+            const delay = retryAfter
+              ? Math.max(parseFloat(retryAfter) * 1000, 0)
+              : Math.pow(2, attempt) * 1000;
+            await new Promise(r => setTimeout(r, delay));
             continue;
           }
           // Quota exceeded — structured error
@@ -91,9 +99,9 @@ class MengramClient {
         return data;
       } catch (err) {
         if (err instanceof MengramError) {
-          if ([429, 502, 503, 504].includes(err.statusCode) && attempt < 2) {
+          if (RETRY_STATUSES.includes(err.statusCode) && attempt < maxAttempts - 1) {
             lastErr = err;
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+            await new Promise(r => setTimeout(r, Math.pow(2, attempt) * 1000));
             continue;
           }
           throw err;
@@ -102,9 +110,9 @@ class MengramClient {
           throw new MengramError(`Request timeout after ${this.timeout}ms`, 408);
         }
         // Retry on network errors
-        if (attempt < 2) {
+        if (attempt < maxAttempts - 1) {
           lastErr = err;
-          await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+          await new Promise(r => setTimeout(r, Math.pow(2, attempt) * 1000));
           continue;
         }
         throw new MengramError(err.message, 0);
@@ -112,7 +120,7 @@ class MengramClient {
         clearTimeout(timer);
       }
     }
-    throw lastErr || new MengramError('Request failed after 3 attempts', 0);
+    throw lastErr || new MengramError(`Request failed after ${maxAttempts} attempts`, 0);
   }
 
   // ---- Memory ----
@@ -209,8 +217,10 @@ class MengramClient {
     if (options.runId) formData.append('run_id', options.runId);
     if (options.appId) formData.append('app_id', options.appId);
 
+    const RETRY_STATUSES = [429, 500, 502, 503];
+    const maxAttempts = this.retries;
     let lastErr;
-    for (let attempt = 0; attempt < 3; attempt++) {
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), this.timeout);
 
@@ -225,9 +235,13 @@ class MengramClient {
         const data = await res.json();
         this._lastHeaders = res.headers;
         if (!res.ok) {
-          if ([429, 502, 503, 504].includes(res.status) && attempt < 2) {
+          if (RETRY_STATUSES.includes(res.status) && attempt < maxAttempts - 1) {
             lastErr = new MengramError(data.detail || `HTTP ${res.status}`, res.status);
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+            const retryAfter = res.headers.get('Retry-After');
+            const delay = retryAfter
+              ? Math.max(parseFloat(retryAfter) * 1000, 0)
+              : Math.pow(2, attempt) * 1000;
+            await new Promise(r => setTimeout(r, delay));
             continue;
           }
           if (res.status === 402 && data.detail && typeof data.detail === 'object') {
@@ -241,9 +255,9 @@ class MengramClient {
         if (err.name === 'AbortError') {
           throw new MengramError(`Request timeout after ${this.timeout}ms`, 408);
         }
-        if (attempt < 2) {
+        if (attempt < maxAttempts - 1) {
           lastErr = err;
-          await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+          await new Promise(r => setTimeout(r, Math.pow(2, attempt) * 1000));
           continue;
         }
         throw new MengramError(err.message, 0);
@@ -251,7 +265,7 @@ class MengramClient {
         clearTimeout(timer);
       }
     }
-    throw lastErr || new MengramError('Request failed after 3 attempts', 0);
+    throw lastErr || new MengramError(`Request failed after ${maxAttempts} attempts`, 0);
   }
 
   /**

--- a/sdk/js/index.test.js
+++ b/sdk/js/index.test.js
@@ -1,0 +1,207 @@
+/**
+ * Tests for MengramClient retry logic with exponential backoff.
+ * Run with: node --test sdk/js/index.test.js  (Node 18+)
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// Load the SDK — it exports via module.exports at the bottom
+const { MengramClient, MengramError } = require('./index.js');
+
+// Minimal fetch mock factory
+function makeFetch(responses) {
+  let call = 0;
+  return async function mockFetch(_url, _opts) {
+    const { status, body, headers: extraHeaders = {} } = responses[Math.min(call++, responses.length - 1)];
+    const headersMap = new Map(Object.entries(extraHeaders));
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: { get: (k) => headersMap.get(k) ?? null },
+      json: async () => body,
+    };
+  };
+}
+
+test('constructor stores retries option', () => {
+  const m = new MengramClient('om-test', { retries: 5 });
+  assert.equal(m.retries, 5);
+});
+
+test('constructor defaults retries to 3', () => {
+  const m = new MengramClient('om-test');
+  assert.equal(m.retries, 3);
+});
+
+test('retries on 429 and succeeds on 3rd attempt', async () => {
+  const responses = [
+    { status: 429, body: { detail: 'rate limited' } },
+    { status: 429, body: { detail: 'rate limited' } },
+    { status: 200, body: { results: [] } },
+  ];
+
+  const m = new MengramClient('om-test');
+  // Override fetch globally for this test
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = makeFetch(responses);
+
+  try {
+    const result = await m._request('GET', '/v1/test');
+    assert.deepEqual(result, { results: [] });
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test('retries on 500 and succeeds', async () => {
+  const responses = [
+    { status: 500, body: { detail: 'internal error' } },
+    { status: 200, body: { status: 'ok' } },
+  ];
+
+  const m = new MengramClient('om-test');
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = makeFetch(responses);
+
+  try {
+    const result = await m._request('POST', '/v1/add', { messages: [] });
+    assert.deepEqual(result, { status: 'ok' });
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test('throws after exhausting all retries', async () => {
+  const responses = [
+    { status: 503, body: { detail: 'unavailable' } },
+    { status: 503, body: { detail: 'unavailable' } },
+    { status: 503, body: { detail: 'unavailable' } },
+  ];
+
+  const m = new MengramClient('om-test', { retries: 3 });
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = makeFetch(responses);
+
+  try {
+    await assert.rejects(
+      () => m._request('GET', '/v1/test'),
+      (err) => {
+        assert.ok(err instanceof MengramError);
+        assert.equal(err.statusCode, 503);
+        return true;
+      }
+    );
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test('respects Retry-After header', async () => {
+  const delays = [];
+  const origSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = (fn, ms) => {
+    if (typeof fn === 'function' && ms > 0) delays.push(ms);
+    return origSetTimeout(fn, 0); // execute immediately in tests
+  };
+
+  const responses = [
+    { status: 429, body: { detail: 'slow down' }, headers: { 'Retry-After': '2' } },
+    { status: 200, body: { ok: true } },
+  ];
+
+  const m = new MengramClient('om-test');
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = makeFetch(responses);
+
+  try {
+    await m._request('GET', '/v1/test');
+    // Should have used 2000ms from Retry-After header (2 seconds)
+    assert.ok(delays.some(d => d === 2000), `Expected delay of 2000ms, got: ${JSON.stringify(delays)}`);
+  } finally {
+    globalThis.fetch = origFetch;
+    globalThis.setTimeout = origSetTimeout;
+  }
+});
+
+test('uses exponential backoff without Retry-After', async () => {
+  const delays = [];
+  const origSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = (fn, ms) => {
+    if (typeof fn === 'function' && ms > 0) delays.push(ms);
+    return origSetTimeout(fn, 0);
+  };
+
+  const responses = [
+    { status: 503, body: { detail: 'unavailable' } },
+    { status: 503, body: { detail: 'unavailable' } },
+    { status: 200, body: { ok: true } },
+  ];
+
+  const m = new MengramClient('om-test', { retries: 3 });
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = makeFetch(responses);
+
+  try {
+    await m._request('GET', '/v1/test');
+    // attempt 0 → 1s (2^0*1000), attempt 1 → 2s (2^1*1000)
+    assert.ok(delays.includes(1000), `Expected 1000ms delay, got: ${JSON.stringify(delays)}`);
+    assert.ok(delays.includes(2000), `Expected 2000ms delay, got: ${JSON.stringify(delays)}`);
+  } finally {
+    globalThis.fetch = origFetch;
+    globalThis.setTimeout = origSetTimeout;
+  }
+});
+
+test('does not retry on 404', async () => {
+  let callCount = 0;
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    callCount++;
+    return {
+      ok: false,
+      status: 404,
+      headers: { get: () => null },
+      json: async () => ({ detail: 'not found' }),
+    };
+  };
+
+  const m = new MengramClient('om-test');
+
+  try {
+    await assert.rejects(
+      () => m._request('GET', '/v1/missing'),
+      (err) => {
+        assert.ok(err instanceof MengramError);
+        assert.equal(err.statusCode, 404);
+        return true;
+      }
+    );
+    assert.equal(callCount, 1, 'Should not retry on 404');
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test('configurable retries: retries=1 means no retries', async () => {
+  let callCount = 0;
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    callCount++;
+    return {
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+      json: async () => ({ detail: 'error' }),
+    };
+  };
+
+  const m = new MengramClient('om-test', { retries: 1 });
+
+  try {
+    await assert.rejects(() => m._request('GET', '/v1/test'));
+    assert.equal(callCount, 1);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});


### PR DESCRIPTION
## What changed

Updated `sdk/js/index.js` and `sdk/js/index.d.ts` to add proper retry logic with exponential backoff to the JS SDK:

- Added `retries` constructor option (default: 3) to make retry count configurable
- Changed retryable HTTP statuses to `[429, 500, 502, 503]` (was `[429, 502, 503, 504]`)
- Switched backoff from linear (`1s, 2s`) to exponential (`1s, 2s, 4s` via `2^attempt * 1000ms`)
- Added `Retry-After` header support — uses the server-provided delay when present
- Applied same fixes to `addFile()` which had the same pattern
- Added `retries?: number` to the `MengramOptions` TypeScript interface
- Added `sdk/js/index.test.js` with 9 tests covering all retry scenarios

## Why

Fixes #20 — the JS SDK was not retrying on 500 errors, used linear backoff instead of exponential, and ignored `Retry-After` headers, making it less resilient against transient API failures and rate limiting.

Fixes #20

## Testing

- `node --test sdk/js/index.test.js` — all 9 tests pass
- Tests cover: 429 retry with success on 3rd attempt, 500 retry, exhausting retries throws, `Retry-After` header respected, exponential delays (1s/2s), no retry on 404, configurable `retries: 1` skips retries
