### PR TITLE
fix: resolve hook credentials from ~/.mengram/config.json + add --verbose status markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 2026-06-14
+
+### Fixed
+- `auto-recall`, `auto-context`, and `auto-save` Claude Code hooks now resolve
+  the API key and base URL from `~/.mengram/config.json` as a fallback when
+  `MENGRAM_API_KEY`/`MENGRAM_URL` env vars are unset (fixes self-hosted setups
+  on Windows, where `setup --key` only persists to config.json).
+
+### Added
+- `--verbose` flag for `auto-recall`, `auto-context`, and `auto-save` hooks —
+  emits a one-line `[mengram:<hook>] <status>` marker via `systemMessage` so
+  hook activity is visible in Claude Code. Off by default.

--- a/cli.py
+++ b/cli.py
@@ -476,24 +476,26 @@ def cmd_auto_context(args):
 
 def cmd_auto_save(args):
     """Hook handler — called by Claude Code on Stop event. Reads stdin, saves to Mengram."""
+    HOOK = "auto-save"
+    EVENT = "Stop"
     try:
-        api_key = os.environ.get("MENGRAM_API_KEY", "")
+        api_key = _load_cloud_api_key()
         if not api_key:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "no API key")
 
         # Read hook input from stdin
         try:
             input_data = json.loads(sys.stdin.read())
         except Exception:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "no input")
 
         # Avoid infinite loops
         if input_data.get("stop_hook_active"):
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "skipped (stop_hook_active)")
 
         last_msg = input_data.get("last_assistant_message", "")
         if not last_msg or len(last_msg.strip()) < 10:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "skipped (short response)")
 
         # Throttle: only save every Nth response
         session_id = input_data.get("session_id", "unknown")
@@ -515,7 +517,7 @@ def cmd_auto_save(args):
             pass
 
         if count > 1 and count % every != 0:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, f"throttled ({count}/{every})")
 
         # Extract last user message from transcript
         user_message = ""
@@ -561,7 +563,7 @@ def cmd_auto_save(args):
 
         # Send to Mengram API
         from cloud.client import CloudMemory
-        base_url = os.environ.get("MENGRAM_URL", "https://mengram.io")
+        base_url = _load_cloud_base_url()
         user_id = getattr(args, "user_id", None) or os.environ.get("MENGRAM_USER_ID", "default")
 
         mem = CloudMemory(api_key=api_key, base_url=base_url)
@@ -573,24 +575,22 @@ def cmd_auto_save(args):
             run_id=session_id,
         )
 
-        output_hook_success()
+        _emit_hook_exit(EVENT, args, HOOK, "saved")
 
     except SystemExit:
         raise
     except Exception as e:
         if _is_quota_error(e):
-            # Surface quota error to user via stderr (Stop hooks don't support additionalContext)
+            # Always surface quota errors via stderr (Stop hooks don't support
+            # additionalContext), regardless of --verbose.
             print(
                 f"\n⚠️  [Mengram] Memory save failed — quota exceeded. {e}\n"
                 "   Your conversations are NOT being saved.\n"
                 "   Upgrade at https://mengram.io/dashboard\n",
                 file=sys.stderr,
             )
-            print(json.dumps({"continue": True}))
-            sys.exit(0)
-        # Never crash, never block Claude
-        print(json.dumps({"continue": True, "suppressOutput": True}))
-        sys.exit(0)
+            _emit_hook_exit(EVENT, args, HOOK, "quota exceeded")
+        _emit_hook_exit(EVENT, args, HOOK, "error")
 
 
 def cmd_hook(args):
@@ -1528,6 +1528,8 @@ def main():
     p_autosave = sub.add_parser("auto-save", help=argparse.SUPPRESS)
     p_autosave.add_argument("--every", type=int, default=3)
     p_autosave.add_argument("--user-id", default=None)
+    p_autosave.add_argument("--verbose", action="store_true",
+                             help="Emit a status marker for each hook invocation")
 
     # auto-recall (internal, called by Claude Code UserPromptSubmit hook)
     p_autorecall = sub.add_parser("auto-recall", help=argparse.SUPPRESS)

--- a/cli.py
+++ b/cli.py
@@ -439,13 +439,15 @@ def cmd_auto_recall(args):
 
 def cmd_auto_context(args):
     """Hook handler — called by Claude Code on SessionStart. Loads cognitive profile as context."""
+    HOOK = "auto-context"
+    EVENT = "SessionStart"
     try:
-        api_key = os.environ.get("MENGRAM_API_KEY", "")
+        api_key = _load_cloud_api_key()
         if not api_key:
-            sys.exit(0)
+            _emit_hook_exit(EVENT, args, HOOK, "no API key")
 
         from cloud.client import CloudMemory
-        base_url = os.environ.get("MENGRAM_URL", "https://mengram.io")
+        base_url = _load_cloud_base_url()
         user_id = getattr(args, "user_id", None) or os.environ.get("MENGRAM_USER_ID", "default")
 
         mem = CloudMemory(api_key=api_key, base_url=base_url)
@@ -453,21 +455,23 @@ def cmd_auto_context(args):
 
         system_prompt = profile.get("system_prompt", "")
         if not system_prompt:
-            sys.exit(0)
+            _emit_hook_exit(EVENT, args, HOOK, "no profile")
 
-        # For SessionStart, plain text stdout is added as context Claude sees
-        print(f"[Mengram Memory — user context loaded from past sessions]\n{system_prompt}")
-        sys.exit(0)
+        context = f"[Mengram Memory — user context loaded from past sessions]\n{system_prompt}"
+        _emit_hook_exit(EVENT, args, HOOK, f"context loaded ({len(system_prompt)} chars)", context=context)
 
     except SystemExit:
         raise
     except Exception as e:
         if _is_quota_error(e):
-            print(
-                f"[Mengram] Memory profile load failed — quota exceeded. {e} "
-                "Upgrade at https://mengram.io/dashboard"
+            _emit_hook_exit(
+                EVENT, args, HOOK, "quota exceeded",
+                context=(
+                    f"[Mengram] Memory profile load failed — quota exceeded. {e} "
+                    "Upgrade at https://mengram.io/dashboard"
+                ),
             )
-        sys.exit(0)
+        _emit_hook_exit(EVENT, args, HOOK, "error")
 
 
 def cmd_auto_save(args):
@@ -1534,6 +1538,8 @@ def main():
     # auto-context (internal, called by Claude Code SessionStart hook)
     p_autocontext = sub.add_parser("auto-context", help=argparse.SUPPRESS)
     p_autocontext.add_argument("--user-id", default=None)
+    p_autocontext.add_argument("--verbose", action="store_true",
+                                help="Emit a status marker for each hook invocation")
 
     # web
     p_web = sub.add_parser("web", help="Start Web UI (chat + knowledge graph)")

--- a/cli.py
+++ b/cli.py
@@ -376,36 +376,38 @@ def _is_quota_error(e: Exception) -> bool:
 
 def cmd_auto_recall(args):
     """Hook handler — called by Claude Code on UserPromptSubmit. Searches Mengram for relevant context."""
+    HOOK = "auto-recall"
+    EVENT = "UserPromptSubmit"
     try:
-        api_key = os.environ.get("MENGRAM_API_KEY", "")
+        api_key = _load_cloud_api_key()
         if not api_key:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "no API key")
 
         # Read hook input from stdin
         try:
             input_data = json.loads(sys.stdin.read())
         except Exception:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "no input")
 
         prompt = input_data.get("prompt", "")
         if not prompt or len(prompt) < 10:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "skipped (short/command prompt)")
 
         # Skip common non-question prompts
         skip_prefixes = ["/", "yes", "no", "ok", "y", "n", "da", "нет", "да"]
         prompt_lower = prompt.strip().lower()
         if any(prompt_lower == p or prompt_lower.startswith(p + " ") for p in skip_prefixes):
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "skipped (short/command prompt)")
 
         from cloud.client import CloudMemory
-        base_url = os.environ.get("MENGRAM_URL", "https://mengram.io")
+        base_url = _load_cloud_base_url()
         user_id = getattr(args, "user_id", None) or os.environ.get("MENGRAM_USER_ID", "default")
 
         mem = CloudMemory(api_key=api_key, base_url=base_url)
         results = mem.search(prompt, user_id=user_id, limit=3, graph_depth=1)
 
         if not results:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "no memories found")
 
         # Format context
         lines = ["[Mengram Memory — relevant context from past sessions]"]
@@ -418,32 +420,21 @@ def cmd_auto_recall(args):
                     lines.append(f"  - {fact}")
 
         context = "\n".join(lines)
-
-        # Return additionalContext for Claude to see
-        print(json.dumps({
-            "hookSpecificOutput": {
-                "hookEventName": "UserPromptSubmit",
-                "additionalContext": context,
-            }
-        }))
-        sys.exit(0)
+        _emit_hook_exit(EVENT, args, HOOK, f"found {len(results)} memories", context=context)
 
     except SystemExit:
         raise
     except Exception as e:
         if _is_quota_error(e):
-            print(json.dumps({
-                "hookSpecificOutput": {
-                    "hookEventName": "UserPromptSubmit",
-                    "additionalContext": (
-                        "[Mengram] Memory search quota exceeded — recall is disabled. "
-                        f"{e} "
-                        "Upgrade at https://mengram.io/dashboard"
-                    ),
-                }
-            }))
-            sys.exit(0)
-        output_hook_success()
+            _emit_hook_exit(
+                EVENT, args, HOOK, "quota exceeded",
+                context=(
+                    "[Mengram] Memory search quota exceeded — recall is disabled. "
+                    f"{e} "
+                    "Upgrade at https://mengram.io/dashboard"
+                ),
+            )
+        _emit_hook_exit(EVENT, args, HOOK, "error")
 
 
 def cmd_auto_context(args):
@@ -1537,6 +1528,8 @@ def main():
     # auto-recall (internal, called by Claude Code UserPromptSubmit hook)
     p_autorecall = sub.add_parser("auto-recall", help=argparse.SUPPRESS)
     p_autorecall.add_argument("--user-id", default=None)
+    p_autorecall.add_argument("--verbose", action="store_true",
+                               help="Emit a status marker for each hook invocation")
 
     # auto-context (internal, called by Claude Code SessionStart hook)
     p_autocontext = sub.add_parser("auto-context", help=argparse.SUPPRESS)

--- a/cli.py
+++ b/cli.py
@@ -783,6 +783,23 @@ def _load_cloud_api_key() -> str:
     return ""
 
 
+def _load_cloud_base_url() -> str:
+    """Resolve base URL in this order: env var, ~/.mengram/config.json, default."""
+    url = os.environ.get("MENGRAM_URL", "").strip()
+    if url:
+        return url.rstrip("/")
+    path = _cloud_config_path()
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+            cfg_url = (data.get("base_url") or "").strip()
+            if cfg_url:
+                return cfg_url.rstrip("/")
+        except Exception:
+            pass
+    return "https://mengram.io"
+
+
 def _save_and_report_key(api_key: str, label: str) -> None:
     """Persist API key to ~/.mengram/config.json + shell profile, print success.
     Shared by all CLI paths that successfully obtain a key."""

--- a/cli.py
+++ b/cli.py
@@ -800,6 +800,48 @@ def _load_cloud_base_url() -> str:
     return "https://mengram.io"
 
 
+def _hook_marker(hook_name: str, status: str) -> str:
+    """Build a one-line status marker for verbose hook output."""
+    return f"[mengram:{hook_name}] {status}"
+
+
+def _emit_hook_exit(hook_event_name, args, hook_name, status, context=None):
+    """Emit a Claude Code hook JSON response and exit(0).
+
+    Non-verbose (default): preserves prior silent behavior — suppressOutput
+    when there's no context, or just the additionalContext when there is.
+
+    Verbose (--verbose): adds a one-line status marker via `systemMessage`
+    (shown to the user for any hook type), and for UserPromptSubmit /
+    SessionStart also prefixes it onto `additionalContext` so Claude sees it.
+    Stop hooks don't support additionalContext, so verbose Stop output is
+    systemMessage only.
+    """
+    verbose = getattr(args, "verbose", False)
+    payload = {"continue": True}
+
+    if context:
+        payload["hookSpecificOutput"] = {
+            "hookEventName": hook_event_name,
+            "additionalContext": context,
+        }
+
+    if verbose:
+        marker = _hook_marker(hook_name, status)
+        payload["systemMessage"] = marker
+        if hook_event_name in ("UserPromptSubmit", "SessionStart"):
+            existing = payload.get("hookSpecificOutput", {}).get("additionalContext", "")
+            payload["hookSpecificOutput"] = {
+                "hookEventName": hook_event_name,
+                "additionalContext": marker + (("\n\n" + existing) if existing else ""),
+            }
+    elif not context:
+        payload["suppressOutput"] = True
+
+    print(json.dumps(payload))
+    sys.exit(0)
+
+
 def _save_and_report_key(api_key: str, label: str) -> None:
     """Persist API key to ~/.mengram/config.json + shell profile, print success.
     Shared by all CLI paths that successfully obtain a key."""

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -463,6 +463,33 @@ Tell the user:
   'Bearer <api-key>'."
 
 ================================================================
+STEP 4.9 — CONFIRM CREDENTIALS BEFORE VERIFYING
+================================================================
+
+Before running Step 5 (`mengram doctor`), make sure $MENGRAM_API_KEY is
+resolvable — otherwise `doctor` fails with 401/403.
+
+4.9.1  Check: is $MENGRAM_API_KEY set in the current shell, OR does
+       ~/.mengram/config.json contain a non-empty `api_key`?
+       - YES -> continue to Step 5, no action needed.
+       - NO  -> continue with 4.9.2.
+
+4.9.2  This can happen if Step 3 couldn't write the key automatically (no
+       shell/file access, self-hosted signup didn't return a key, etc).
+       Tell the user, WITHOUT ever asking for or printing the key value:
+
+         "I couldn't automatically save your Mengram API key. Please paste
+         it yourself into:
+           - ~/.mengram/config.json -> {"api_key": "<your-key>", "base_url": "<base-url>"}
+           - <host MCP config file from Step 4> -> the env.MENGRAM_API_KEY
+             field (and env.MENGRAM_URL for self-hosted)
+
+         Reply 'done' once it's in place."
+
+4.9.3  Wait for explicit confirmation from the user before proceeding to
+       Step 5. Do not guess or retry without it.
+
+================================================================
 STEP 5 — VERIFY THE INSTALL WORKS
 ================================================================
 

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -180,6 +180,43 @@ STEP 2 — INSTALL THE PACKAGE
      use the absolute path to the executable instead.
 
 ================================================================
+STEP 2.5 — DETERMINE THE MCP LAUNCHER PATTERN
+================================================================
+
+Based on how `mengram-ai` ended up installed in Step 2, derive two
+placeholders used by every Step 4 host config below:
+
+  <LAUNCHER_CMD>          — the command to run
+  <LAUNCHER_ARGS_PREFIX>  — a list of args prepended before "server", "--cloud"
+
+Resolution:
+  - `uv tool install mengram-ai`, `pipx install mengram-ai`, or
+    `<PYTHON_CMD> -m pip install --user mengram-ai` (mengram resolvable on
+    PATH, or fixed via Step 2.2):
+       <LAUNCHER_CMD>         = mengram   (or the absolute path from Step 2.2
+                                 if PATH could not be fixed)
+       <LAUNCHER_ARGS_PREFIX> = []
+
+  - `uvx` (no persistent install, package run on demand):
+       <LAUNCHER_CMD>         = uvx
+       <LAUNCHER_ARGS_PREFIX> = ["--from", "mengram-ai", "mengram"]
+
+  - Poetry-managed environment (no global `mengram` script on PATH):
+       Resolve the absolute path to `mengram` inside that environment, e.g.:
+         poetry run python -c "import shutil,sys; print(shutil.which('mengram'))"
+       <LAUNCHER_CMD>         = <that absolute path>
+       <LAUNCHER_ARGS_PREFIX> = []
+
+The full "args" array for any Step 4 MCP server entry is:
+  <LAUNCHER_ARGS_PREFIX> + ["server", "--cloud"]
+
+For example, with uvx this is:
+  ["--from", "mengram-ai", "mengram", "server", "--cloud"]
+
+Every Step 4 section below uses <LAUNCHER_CMD> / <LAUNCHER_ARGS_PREFIX> —
+substitute the resolved values when writing the actual config file.
+
+================================================================
 STEP 3 — DETERMINE API BASE + AUTHENTICATE
 ================================================================
 

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -379,9 +379,12 @@ context) into Claude Code's settings:
 Run:    mengram hook install
 
 This requires $MENGRAM_API_KEY (and $MENGRAM_URL for self-hosted) to be set
-in the CURRENT shell, not just a shell profile. If Step 3 only wrote them to
-~/.mengram/config.json or a profile file that hasn't been re-sourced yet,
-export them in this shell first using the saved values (do not print them):
+in the CURRENT shell, not just a shell profile. First check whether
+$MENGRAM_API_KEY is already set in this shell (e.g. `echo $MENGRAM_API_KEY` /
+`echo %MENGRAM_API_KEY%` / `echo $env:MENGRAM_API_KEY` depending on shell) —
+if it returns a non-empty value, skip the export step below. Otherwise,
+export the values saved in Step 3 into this shell first (without printing
+them):
   - macOS/Linux/WSL:       export MENGRAM_API_KEY=...   [export MENGRAM_URL=...]
   - Windows (cmd):         set MENGRAM_API_KEY=...      [set MENGRAM_URL=...]
   - Windows (PowerShell):  $env:MENGRAM_API_KEY="..."   [$env:MENGRAM_URL="..."]

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -12,8 +12,16 @@ the install works end-to-end. Then report success.
 
 CRITICAL RULES:
 - Do not ask the user for confirmation between every step. Just execute.
-- Ask the user ONLY for: (a) their email (once, if no API key exists yet) and
-  (b) the 6-digit verification code that arrives in their inbox.
+- Ask the user ONLY for:
+  (a) whether they want hosted Mengram or a self-hosted Mengram instance,
+  (b) the self-hosted base URL if they choose self-hosted and no base URL is
+      already obvious,
+  (c) their email (once, if no API key exists yet), and
+  (d) the 6-digit verification code that arrives in their inbox for the hosted
+      flow only.
+- Never print, echo, paste, mask, or repeat a real API key in user-visible
+  text. Save secrets to files or config as needed, but describe them only as
+  "saved" or "configured" in status updates and final reports.
 - If you cannot run shell commands in this environment, STOP and tell the user
   to run the commands themselves, listed below in Section M (Manual Fallback).
 - Report each completed step with a one-line status update so the user sees
@@ -132,11 +140,15 @@ STEP 2 — INSTALL THE PACKAGE
 STEP 3 — DETERMINE API BASE + AUTHENTICATE
 ================================================================
 
-3.1  Determine the API base URL you should target for ALL remaining steps:
-     - Default: https://mengram.io
-     - If $MENGRAM_URL is already set, use that value.
-     - If the user explicitly says they use a self-hosted Mengram instance and
-       no base URL is obvious, ask ONCE: "What is your Mengram base URL?"
+3.1  Determine which Mengram deployment the user wants to use for THIS
+     install:
+     - If the user already explicitly said hosted or self-hosted, use that.
+     - Otherwise ask ONCE:
+       "Do you want to use hosted Mengram at https://mengram.io or a
+       self-hosted Mengram instance?"
+     - Hosted => set <base-url> = https://mengram.io
+     - Self-hosted => if $MENGRAM_URL is already set, use that value;
+       otherwise ask ONCE: "What is your Mengram base URL?"
 
      Treat any base URL other than https://mengram.io as self-hosted.
      IMPORTANT: this guide does NOT deploy self-hosted Mengram. It only
@@ -145,6 +157,7 @@ STEP 3 — DETERMINE API BASE + AUTHENTICATE
 3.2  First check if the user already has a key:
      - Look for $MENGRAM_API_KEY env var.
      - Look at file ~/.mengram/config.json — field `api_key`.
+     - Look at file ~/.mengram/.env — field `MENGRAM_API_KEY`.
      - If a key starting with "om-" is found, SKIP to Step 4.
 
 3.3  If no key exists, ask the user ONCE:
@@ -154,27 +167,43 @@ STEP 3 — DETERMINE API BASE + AUTHENTICATE
 3.4  Trigger signup against the base URL from 3.1:
      Run:   mengram signup --email <user-email>
 
-     Hosted default (https://mengram.io):
+     Hosted (https://mengram.io):
      - This sends a 6-digit verification code to the user's inbox.
+     - Continue with 3.5.
 
      Self-hosted:
-     - The instance may return an API key immediately, require a 6-digit code,
-       or use a custom verification flow configured by that instance owner.
-     - If the command immediately prints an `om-` key, save it and continue
-       without asking for a verification code.
-     - If it says a 6-digit code is required, continue with 3.5.
-     - If it says verification is unavailable or handled outside email, stop
-       and tell the user exactly what is needed from their self-hosted setup.
+     - Self-hosted signup still uses the user's email address.
+     - Expected behavior: the instance returns an API key immediately and does
+       NOT require a 6-digit verification code.
+     - Capture the returned key without printing it back to the user.
+     - Ensure directory ~/.mengram exists first.
+     - Save it to ~/.mengram/.env as:
+         MENGRAM_API_KEY=<api-key>
+         MENGRAM_URL=<base-url>
+     - If ~/.mengram/.env already exists, update or replace the existing
+       MENGRAM_API_KEY and MENGRAM_URL lines instead of appending duplicates.
+     - Also save it to ~/.mengram/config.json when the CLI supports that.
+     - If the self-hosted instance asks for a 6-digit code or uses some other
+       verification flow, STOP and tell the user their self-hosted setup does
+       not match this install guide.
 
-3.5  If a 6-digit code is required, ask the user:
+3.5  Hosted only: ask the user:
      "Check your inbox for an email from Mengram. Paste the 6-digit code."
      Wait for their answer. Strip whitespace. Code is 6 digits.
 
-3.6  Complete signup:
+3.6  Hosted only: complete signup:
      Run:   mengram signup --email <user-email> --code <code>
-     On success this prints the API key (starts with "om-") and saves it to
-     ~/.mengram/config.json automatically. It also writes the key into the
-     user's shell profile so $MENGRAM_API_KEY is set in future sessions.
+     On success this prints the API key (starts with "om-"). Capture it
+     without showing it in chat. Save it to:
+      - ~/.mengram/config.json
+      - Ensure directory ~/.mengram exists first.
+      - ~/.mengram/.env as:
+           MENGRAM_API_KEY=<api-key>
+           MENGRAM_URL=https://mengram.io
+      - If ~/.mengram/.env already exists, update or replace the existing
+        MENGRAM_API_KEY and MENGRAM_URL lines instead of appending duplicates.
+     It may also write the key into the user's shell profile so
+     $MENGRAM_API_KEY is set in future sessions.
 
      If the code is rejected, ask the user to paste it again. Allow 3 attempts
      before stopping and reporting the failure.
@@ -252,7 +281,7 @@ Append (TOML, NOT JSON):
   args = ["server", "--cloud"]
 
   [mcp_servers.mengram.env]
-  MENGRAM_API_KEY = "<api-key>"
+  MENGRAM_API_KEY = "<api-key-from-saved-secret-store>"
   MENGRAM_URL = "<base-url-from-step-3>"
 
 Tell user: "Restart Codex."
@@ -271,7 +300,7 @@ added through the Settings UI. STOP the install flow and tell the user:
     4. Fill in:
          Name:      Mengram
          URL:       <base-url-from-step-3>/mcp
-         Headers:   Authorization: Bearer <api-key-from-step-3>
+         Headers:   Authorization: Bearer <api-key-from-saved-secret-store>
     5. Save. The 30 Mengram tools appear in this same chat after a refresh.
 
   This is a one-time UI step — Claude.ai's settings live outside
@@ -284,7 +313,7 @@ Tell the user:
   "Add this MCP server entry to your host tool's config:
     name:    mengram
     command: mengram server --cloud
-    env:     MENGRAM_API_KEY=<api-key>, MENGRAM_URL=<base-url>
+    env:     MENGRAM_API_KEY=<api-key-from-saved-secret-store>, MENGRAM_URL=<base-url>
   Refer to your tool's MCP docs for the exact config location.
   For HTTP-only hosts (Claude.ai web, ChatGPT, custom apps), use the
   remote URL instead: <base-url>/mcp with Authorization header
@@ -311,7 +340,7 @@ STEP 6 — REPORT TO USER
 On success, write a final message in this exact shape (substitute the values):
 
   Mengram installed successfully.
-  - API key: om-XXXX...XXXX (saved to ~/.mengram/config.json)
+  - Credentials: saved to ~/.mengram/.env
   - MCP server: registered in <host>
   - API base URL: <base-url-from-step-3>
   - Round-trip test: passed
@@ -329,25 +358,38 @@ block to the user verbatim and stop:
   Mengram needs shell access to install. Run these commands in your terminal,
   then I can continue:
 
-    0. If you use self-hosted Mengram, set MENGRAM_URL in your shell to your
-       base URL first (for example: http://localhost:8420)
+    0. Decide whether you are using hosted Mengram or a self-hosted instance.
+       If self-hosted, set MENGRAM_URL in your shell to your base URL first
+       (for example: http://localhost:8420)
     1. Install `mengram-ai` with any Python 3.10+ launcher/tool that already
        works in your environment (for example:
        `python3 -m pip install --user mengram-ai`)
     2. mengram signup --email YOUR_EMAIL@example.com
-    3. (check your inbox for a 6-digit code)
-    4. mengram signup --email YOUR_EMAIL@example.com --code 123456
-    5. Open your AI tool's MCP config file (see Appendix A for the JSON
+    3. Hosted only: check your inbox for a 6-digit code
+    4. Hosted only: `mengram signup --email YOUR_EMAIL@example.com --code 123456`
+    5. Self-hosted only: the command in step 2 should print an API key
+       immediately without a 6-digit code. Create `~/.mengram` if needed, then
+       save it to `~/.mengram/.env` as:
+         MENGRAM_API_KEY=YOUR_REAL_KEY
+         MENGRAM_URL=YOUR_BASE_URL
+       If the file already exists, replace the existing lines instead of
+       adding duplicates.
+    6. Open your AI tool's MCP config file (see Appendix A for the JSON
        template and Step 4 of this guide for the path on your tool/OS).
-       Paste the template, replace the api-key placeholder with the key
-       printed by step 4, and save.
-    6. mengram doctor
+       Paste the template, replace the api-key placeholder with the saved key
+       from your local `.env` file, and save. Do not paste the real key into
+       any AI chat.
+    7. mengram doctor
 
   Reply "done" when finished and I'll confirm everything is wired correctly.
 
 ================================================================
 APPENDIX A — JSON CONFIG TEMPLATE (for hosts that use JSON)
 ================================================================
+
+This template is for local config files only. The real API key must be read
+from the saved local secret (for example `~/.mengram/.env`) and must never be
+printed back into AI chat output.
 
 {
   "mcpServers": {

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -26,13 +26,22 @@ STEP 1 — DETECT ENVIRONMENT
 1.1  Determine OS by running:    uname -s    (or `ver` on Windows cmd)
      Map: Darwin = macOS, Linux = Linux, MINGW/MSYS/CYGWIN/Windows = Windows.
 
-1.2  Determine Python availability:
-     - Try: python3 --version
-     - If absent on Windows, try: python --version
-     - REQUIRED: Python >= 3.10.
-     - If Python is missing or too old, STOP. Tell user:
-       "Mengram requires Python 3.10 or newer. Please install Python from
-       https://www.python.org/downloads/ and re-run this prompt."
+1.2  Determine whether Mengram is already installed or whether a usable Python
+     launcher/package tool is available:
+     - First try: mengram --version
+       If this works, you may skip package installation unless the user
+       explicitly wants reinstall/upgrade.
+     - Otherwise find ONE working way to run Python >= 3.10 in this
+       environment. Call it <PYTHON_CMD>.
+     - <PYTHON_CMD> may be a direct interpreter command or a launcher/tooling
+       wrapper already present in the environment.
+     - Do NOT require specific executable names like `python3` or `python`.
+       Use whatever Python launcher/tool already works in this environment.
+     - If you cannot find any working Python >= 3.10 launcher/tool capable of
+       installing `mengram-ai`, STOP. Tell user:
+       "Mengram requires Python 3.10 or newer. Please install Python 3.10+
+       or re-run this prompt in an environment that already has a working
+       Python launcher."
 
 1.3  Determine which AI tool you are running in (the "host"). Pick ONE:
      - claude-desktop   (Claude Desktop app, .app on macOS / .exe on Windows)
@@ -56,32 +65,47 @@ STEP 1 — DETECT ENVIRONMENT
 STEP 2 — INSTALL THE PACKAGE
 ================================================================
 
-2.1  Run:    python3 -m pip install --user --upgrade mengram-ai
-     (On Windows use `python -m pip` if `python3` is not aliased.)
+2.1  If `mengram --version` already works, SKIP installation unless the user
+     explicitly asked for reinstall/upgrade.
+
+     Otherwise install `mengram-ai` using the Python launcher/tool from Step
+     1.2. Prefer a user-scoped install when the chosen tool supports it.
+
+     Preferred pattern when supported:
+        <PYTHON_CMD> -m pip install --user --upgrade mengram-ai
+
+     If the chosen launcher/tool does not support `-m pip --user`, use that
+     tool's equivalent install command instead. The end result MUST make the
+     `mengram` executable callable by PATH or by absolute path.
 
 2.2  Verify the `mengram` command is on PATH:
      Run:   mengram --version
-     If the command is not found, the user's --user bin dir is not on PATH.
+     If the command is not found, the install location is not on PATH or the
+     executable name/path differs in this environment.
 
-     To find the correct directory, run:
-        python3 -m site --user-base
-     The `mengram` executable lives in <user-base>/bin (macOS/Linux) or
+     If you installed with `<PYTHON_CMD> -m pip --user`, find the correct
+     directory by running:
+        <PYTHON_CMD> -m site --user-base
+     The `mengram` executable then lives in <user-base>/bin (macOS/Linux) or
      <user-base>\Scripts (Windows). On Apple-shipped Python this is typically
      ~/Library/Python/<MAJOR.MINOR>/bin — NOT ~/.local/bin.
 
      Fix:
-     - macOS:    append `export PATH="$(python3 -m site --user-base)/bin:$PATH"`
-                 to ~/.zshrc, then `source ~/.zshrc`.
-     - Linux:    append the same line to ~/.bashrc (or ~/.zshrc if using zsh),
-                 then re-source. On most Linux distros this resolves to
-                 ~/.local/bin.
+     - macOS:    run `<PYTHON_CMD> -m site --user-base`, capture <user-base>,
+                 then append `export PATH="<user-base>/bin:$PATH"` to ~/.zshrc
+                 and `source ~/.zshrc`.
+     - Linux:    do the same in ~/.bashrc (or ~/.zshrc if using zsh), then
+                 re-source. On most Linux distros this resolves to ~/.local/bin.
      - Windows:  add `<user-base>\Scripts` to the user PATH via:
                  setx PATH "%PATH%;<user-base>\Scripts"
                  then open a new terminal.
 
+     If you installed with another launcher/tool, determine where that tool
+     placed the `mengram` executable and use that absolute path for every
+     subsequent step until PATH is fixed.
+
      Until PATH is fixed, every subsequent step that calls `mengram ...` must
-     use the absolute path printed by `python3 -m site --user-base`/bin/mengram
-     instead.
+     use the absolute path to the executable instead.
 
 ================================================================
 STEP 3 — DETERMINE API BASE + AUTHENTICATE
@@ -286,7 +310,9 @@ block to the user verbatim and stop:
 
     0. If you use self-hosted Mengram, set MENGRAM_URL in your shell to your
        base URL first (for example: http://localhost:8420)
-    1. python3 -m pip install --user mengram-ai
+    1. Install `mengram-ai` with any Python 3.10+ launcher/tool that already
+       works in your environment (for example:
+       `python3 -m pip install --user mengram-ai`)
     2. mengram signup --email YOUR_EMAIL@example.com
     3. (check your inbox for a 6-digit code)
     4. mengram signup --email YOUR_EMAIL@example.com --code 123456
@@ -319,10 +345,15 @@ APPENDIX A — JSON CONFIG TEMPLATE (for hosts that use JSON)
 APPENDIX B — DEBUGGING NOTES FOR AGENTS
 ================================================================
 
-- If `mengram` command is not found after pip install, the most likely cause
-  is that pip's user-script directory is not on PATH. Fix PATH then retry.
+- If `mengram` is not found after installation, the most likely cause is that
+  the install location is not on PATH. Fix PATH or use the absolute executable
+  path, then retry.
 
-- Do NOT use `sudo`. Always install with `--user`. Mengram does not need root.
+- Do not assume the installer is literally `python3` or `python`. Reuse
+  whichever Python launcher/tool already works in that environment.
+
+- Do NOT use `sudo`. Prefer user-scoped installs when the chosen tool supports
+  them. Mengram does not need root.
 
 - Do NOT modify the host AI tool's main settings file beyond the
   `mcpServers` (JSON) or `[mcp_servers.*]` (TOML) sections. Preserve all

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -291,9 +291,11 @@ STEP 3 — DETERMINE API BASE + AUTHENTICATE
 STEP 4 — CONFIGURE THE HOST AI TOOL (MCP server)
 ================================================================
 
-The Mengram MCP server is started by: `mengram server --cloud`. It reads
-$MENGRAM_API_KEY and, when set, $MENGRAM_URL from the environment. Use the
-host-specific block below.
+The Mengram MCP server is started with the launcher pattern derived in
+Step 2.5: <LAUNCHER_CMD> with args <LAUNCHER_ARGS_PREFIX> + ["server", "--cloud"].
+It reads $MENGRAM_API_KEY and, when set, $MENGRAM_URL from the environment.
+Use the host-specific block below — every block uses <LAUNCHER_CMD> /
+<LAUNCHER_ARGS_PREFIX> for "command"/"args".
 
 If the shell OS and the host-app OS differ (common with WSL, remote shells, or
 SSH), always edit the config for the HOST application you are actually
@@ -330,13 +332,17 @@ Steps:
   2. Parse the JSON. Ensure "mcpServers" key exists (object).
   3. Add or replace:
        "mengram": {
-         "command": "mengram",
-         "args": ["server", "--cloud"],
+         "command": "<LAUNCHER_CMD>",
+         "args": <LAUNCHER_ARGS_PREFIX> + ["server", "--cloud"],
          "env": {
            "MENGRAM_API_KEY": "<api-key-from-step-3>",
            "MENGRAM_URL": "<base-url-from-step-3>"
          }
        }
+     Substitute <LAUNCHER_CMD> and the resolved <LAUNCHER_ARGS_PREFIX> from
+     Step 2.5 — write the concrete JSON array, e.g. with uvx:
+       "command": "uvx",
+       "args": ["--from", "mengram-ai", "mengram", "server", "--cloud"]
   4. Write the file back with 2-space indent.
   5. Tell the user: "Restart Claude Desktop fully (Cmd+Q or close from tray)
      for the MCP server to load."
@@ -380,12 +386,17 @@ Tell user: "Reload Windsurf window."
 Config file path:    ~/.codex/config.toml
 Append (TOML, NOT JSON):
   [mcp_servers.mengram]
-  command = "mengram"
-  args = ["server", "--cloud"]
+  command = "<LAUNCHER_CMD>"
+  args = <LAUNCHER_ARGS_PREFIX> + ["server", "--cloud"]
 
   [mcp_servers.mengram.env]
   MENGRAM_API_KEY = "<api-key-from-saved-secret-store>"
   MENGRAM_URL = "<base-url-from-step-3>"
+
+Substitute <LAUNCHER_CMD> and the resolved <LAUNCHER_ARGS_PREFIX> from
+Step 2.5 — write the concrete TOML array, e.g. with uvx:
+  command = "uvx"
+  args = ["--from", "mengram-ai", "mengram", "server", "--cloud"]
 
 Tell user: "Restart Codex."
 
@@ -415,7 +426,9 @@ After the user confirms they've added it, proceed to Step 5 (Verify).
 Tell the user:
   "Add this MCP server entry to your host tool's config:
     name:    mengram
-    command: mengram server --cloud
+    command: <LAUNCHER_CMD>
+    args:    <LAUNCHER_ARGS_PREFIX> + [server, --cloud]   (resolved from Step 2.5,
+             e.g. with uvx: --from mengram-ai mengram server --cloud)
     env:     MENGRAM_API_KEY=<api-key-from-saved-secret-store>, MENGRAM_URL=<base-url>
   Refer to your tool's MCP docs for the exact config location.
   For HTTP-only hosts (Claude.ai web, ChatGPT, custom apps), use the

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -255,8 +255,8 @@ STEP 3 — DETERMINE API BASE + AUTHENTICATE
      - Expected behavior: the instance returns an API key immediately and does
        NOT require a 6-digit verification code.
      - Capture the returned key without printing it back to the user.
-     - `mengram signup` saves it to ~/.mengram/config.json itself (creating
-       ~/.mengram if needed) as:
+     - `mengram signup` saves it to ~/.mengram/config.json itself (mode 600,
+       creating ~/.mengram if needed) as:
          {"api_key": "<api-key>", "base_url": "<base-url>"}
        and may also export MENGRAM_API_KEY into the user's shell profile
        (~/.zshrc or ~/.bashrc).
@@ -275,7 +275,7 @@ STEP 3 — DETERMINE API BASE + AUTHENTICATE
      Run:   mengram signup --email <user-email> --code <code>
      On success this prints the API key (starts with "om-"). Capture it
      without showing it in chat. `mengram signup` saves it to
-     ~/.mengram/config.json itself (creating ~/.mengram if needed) as:
+     ~/.mengram/config.json itself (mode 600, creating ~/.mengram if needed) as:
        {"api_key": "<api-key>", "base_url": "https://mengram.io"}
      If ~/.mengram/config.json already exists, it updates the existing
      `api_key`/`base_url` fields instead of creating a duplicate file.

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -237,7 +237,6 @@ STEP 3 — DETERMINE API BASE + AUTHENTICATE
 3.2  First check if the user already has a key:
      - Look for $MENGRAM_API_KEY env var.
      - Look at file ~/.mengram/config.json — field `api_key`.
-     - Look at file ~/.mengram/.env — field `MENGRAM_API_KEY`.
      - If a key starting with "om-" is found, SKIP to Step 4.
 
 3.3  If no key exists, ask the user ONCE:
@@ -256,13 +255,14 @@ STEP 3 — DETERMINE API BASE + AUTHENTICATE
      - Expected behavior: the instance returns an API key immediately and does
        NOT require a 6-digit verification code.
      - Capture the returned key without printing it back to the user.
-     - Ensure directory ~/.mengram exists first.
-     - Save it to ~/.mengram/.env as:
-         MENGRAM_API_KEY=<api-key>
-         MENGRAM_URL=<base-url>
-     - If ~/.mengram/.env already exists, update or replace the existing
-       MENGRAM_API_KEY and MENGRAM_URL lines instead of appending duplicates.
-     - Also save it to ~/.mengram/config.json when the CLI supports that.
+     - `mengram signup` saves it to ~/.mengram/config.json itself (creating
+       ~/.mengram if needed) as:
+         {"api_key": "<api-key>", "base_url": "<base-url>"}
+       and may also export MENGRAM_API_KEY into the user's shell profile
+       (~/.zshrc or ~/.bashrc).
+     - If ~/.mengram/config.json already exists, `mengram signup` updates
+       the existing `api_key`/`base_url` fields instead of creating a
+       duplicate file.
      - If the self-hosted instance asks for a 6-digit code or uses some other
        verification flow, STOP and tell the user their self-hosted setup does
        not match this install guide.
@@ -274,16 +274,13 @@ STEP 3 — DETERMINE API BASE + AUTHENTICATE
 3.6  Hosted only: complete signup:
      Run:   mengram signup --email <user-email> --code <code>
      On success this prints the API key (starts with "om-"). Capture it
-     without showing it in chat. Save it to:
-      - ~/.mengram/config.json
-      - Ensure directory ~/.mengram exists first.
-      - ~/.mengram/.env as:
-           MENGRAM_API_KEY=<api-key>
-           MENGRAM_URL=https://mengram.io
-      - If ~/.mengram/.env already exists, update or replace the existing
-        MENGRAM_API_KEY and MENGRAM_URL lines instead of appending duplicates.
-     It may also write the key into the user's shell profile so
-     $MENGRAM_API_KEY is set in future sessions.
+     without showing it in chat. `mengram signup` saves it to
+     ~/.mengram/config.json itself (creating ~/.mengram if needed) as:
+       {"api_key": "<api-key>", "base_url": "https://mengram.io"}
+     If ~/.mengram/config.json already exists, it updates the existing
+     `api_key`/`base_url` fields instead of creating a duplicate file.
+     It may also write the key into the user's shell profile (~/.zshrc or
+     ~/.bashrc) so $MENGRAM_API_KEY is set in future sessions.
 
      If the code is rejected, ask the user to paste it again. Allow 3 attempts
      before stopping and reporting the failure.

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -330,7 +330,8 @@ Config file path:
 Steps:
   1. If the file does not exist, create it with content: {"mcpServers": {}}
   2. Parse the JSON. Ensure "mcpServers" key exists (object).
-  3. Add or replace:
+  3. Add or replace (template — substitute placeholders, do not write
+     "<LAUNCHER_CMD>" or the "+" expression literally):
        "mengram": {
          "command": "<LAUNCHER_CMD>",
          "args": <LAUNCHER_ARGS_PREFIX> + ["server", "--cloud"],
@@ -384,7 +385,8 @@ Tell user: "Reload Windsurf window."
 
 ------- 4E. codex -------
 Config file path:    ~/.codex/config.toml
-Append (TOML, NOT JSON):
+Append (TOML, NOT JSON — template, substitute placeholders below, do not
+write "<LAUNCHER_CMD>" or the "+" expression literally):
   [mcp_servers.mengram]
   command = "<LAUNCHER_CMD>"
   args = <LAUNCHER_ARGS_PREFIX> + ["server", "--cloud"]

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -482,7 +482,11 @@ resolvable — otherwise `doctor` fails with 401/403.
          it yourself into:
            - ~/.mengram/config.json -> {"api_key": "<your-key>", "base_url": "<base-url>"}
            - <host MCP config file from Step 4> -> the env.MENGRAM_API_KEY
-             field (and env.MENGRAM_URL for self-hosted)
+             field (and env.MENGRAM_URL for self-hosted), if your host uses a
+             local config file. (For hosts without one — e.g. Claude.ai web,
+             or a host covered by 4G's "other" instructions — only the first
+             bullet applies; follow your host's own credential/connector setup
+             for the rest.)
 
          Reply 'done' once it's in place."
 

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -220,6 +220,56 @@ substitute the resolved values when writing the actual config file.
 STEP 3 — DETERMINE API BASE + AUTHENTICATE
 ================================================================
 
+3.0  Before determining the base URL or signing up, ask the user ONCE:
+
+       "Do you already have a Mengram account/API key from another machine
+       that you want to reuse on this machine?
+         (a) Yes, and I have the key
+         (b) Yes, but I don't have the key right now
+         (c) No, this is my first setup"
+
+     - (c) -> continue with 3.1.
+     - (a) -> go to 3.0a, then skip the rest of Step 3 (continue at Step 4).
+     - (b) -> go to 3.0b.
+
+3.0a Reuse an existing key (no signup, no key rotation):
+
+     - If self-hosted, determine <base-url> the same way as 3.1 (use
+       $MENGRAM_URL if already set, otherwise ask ONCE for the base URL).
+     - Tell the user to run the following in their OWN terminal — NOT via
+       the agent's tool calls — so the API key never enters the agent's
+       context or transcript:
+
+         export MENGRAM_URL=<base-url>            (self-hosted only; skip
+                                                     this line for
+                                                     https://mengram.io)
+         mengram setup --key <PASTE_YOUR_API_KEY_HERE>
+
+       This writes ~/.mengram/config.json (mode 600) with the correct
+       `base_url`, exports MENGRAM_API_KEY into the user's shell profile,
+       and (on Claude Code) installs the Mengram hooks — the same end state
+       as Step 3's normal flow, without calling signup/reset-key.
+     - Wait for explicit confirmation ("done"/equivalent) before continuing.
+       Do not guess or retry without it.
+
+3.0b Existing account, but the key isn't available right now:
+
+     Before doing anything else, tell the user:
+
+       "Running signup for an account that already exists will generate a
+       NEW API key and invalidate the old one — any other machine using the
+       old key will stop working until reconfigured with the new key. If
+       possible, retrieve the existing key from ~/.mengram/config.json on
+       the other machine instead (then choose option (a) above). Otherwise,
+       confirm to proceed — you'll need to update the other machine's
+       config afterward."
+
+     Wait for explicit confirmation before proceeding. On confirmation,
+     continue with 3.1 — the normal signup/reset-key flow handles the rest
+     (no raw key handling needed here, since the verification code arrives
+     by email and the final key is written by the agent as in first-time
+     setup).
+
 3.1  Determine which Mengram deployment the user wants to use for THIS
      install:
      - If the user already explicitly said hosted or self-hosted, use that.

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -84,27 +84,48 @@ STEP 2 — INSTALL THE PACKAGE
      instead.
 
 ================================================================
-STEP 3 — AUTHENTICATE (get API key)
+STEP 3 — DETERMINE API BASE + AUTHENTICATE
 ================================================================
 
-3.1  First check if the user already has a key:
+3.1  Determine the API base URL you should target for ALL remaining steps:
+     - Default: https://mengram.io
+     - If $MENGRAM_URL is already set, use that value.
+     - If the user explicitly says they use a self-hosted Mengram instance and
+       no base URL is obvious, ask ONCE: "What is your Mengram base URL?"
+
+     Treat any base URL other than https://mengram.io as self-hosted.
+     IMPORTANT: this guide does NOT deploy self-hosted Mengram. It only
+     configures the AI tool to talk to an already running instance.
+
+3.2  First check if the user already has a key:
      - Look for $MENGRAM_API_KEY env var.
      - Look at file ~/.mengram/config.json — field `api_key`.
      - If a key starting with "om-" is found, SKIP to Step 4.
 
-3.2  If no key exists, ask the user ONCE:
+3.3  If no key exists, ask the user ONCE:
      "What email should I use for your Mengram account?"
      Wait for their answer.
 
-3.3  Trigger signup:
+3.4  Trigger signup against the base URL from 3.1:
      Run:   mengram signup --email <user-email>
-     This sends a 6-digit verification code to their inbox.
 
-3.4  Ask the user:
+     Hosted default (https://mengram.io):
+     - This sends a 6-digit verification code to the user's inbox.
+
+     Self-hosted:
+     - The instance may return an API key immediately, require a 6-digit code,
+       or use a custom verification flow configured by that instance owner.
+     - If the command immediately prints an `om-` key, save it and continue
+       without asking for a verification code.
+     - If it says a 6-digit code is required, continue with 3.5.
+     - If it says verification is unavailable or handled outside email, stop
+       and tell the user exactly what is needed from their self-hosted setup.
+
+3.5  If a 6-digit code is required, ask the user:
      "Check your inbox for an email from Mengram. Paste the 6-digit code."
      Wait for their answer. Strip whitespace. Code is 6 digits.
 
-3.5  Complete signup:
+3.6  Complete signup:
      Run:   mengram signup --email <user-email> --code <code>
      On success this prints the API key (starts with "om-") and saves it to
      ~/.mengram/config.json automatically. It also writes the key into the
@@ -113,19 +134,25 @@ STEP 3 — AUTHENTICATE (get API key)
      If the code is rejected, ask the user to paste it again. Allow 3 attempts
      before stopping and reporting the failure.
 
-3.6  Confirm:    mengram status     (should print "Configured: yes").
+3.7  Confirm:    mengram status     (should print "Configured: yes").
 
 ================================================================
 STEP 4 — CONFIGURE THE HOST AI TOOL (MCP server)
 ================================================================
 
 The Mengram MCP server is started by: `mengram server --cloud`. It reads
-$MENGRAM_API_KEY from the environment. Use the host-specific block below.
+$MENGRAM_API_KEY and, when set, $MENGRAM_URL from the environment. Use the
+host-specific block below.
+
+If the shell OS and the host-app OS differ (common with WSL, remote shells, or
+SSH), always edit the config for the HOST application you are actually
+installing into. Do not assume the shell's home directory matches the host
+tool's config location.
 
 NOTE — TWO VALID INTEGRATION PATTERNS:
   (1) Local stdio  — `mengram server --cloud` (this guide's default). Lower
       latency, no Node.js required, full feature set.
-  (2) HTTP remote  — `npx -y mcp-remote https://mengram.io/mcp --header
+  (2) HTTP remote  — `npx -y mcp-remote <base-url>/mcp --header
       "Authorization: Bearer <api-key>"`. Requires Node.js. Simpler to
       configure but adds an extra hop.
 
@@ -145,7 +172,10 @@ Steps:
        "mengram": {
          "command": "mengram",
          "args": ["server", "--cloud"],
-         "env": { "MENGRAM_API_KEY": "<api-key-from-step-3>" }
+         "env": {
+           "MENGRAM_API_KEY": "<api-key-from-step-3>",
+           "MENGRAM_URL": "<base-url-from-step-3>"
+         }
        }
   4. Write the file back with 2-space indent.
   5. Tell the user: "Restart Claude Desktop fully (Cmd+Q or close from tray)
@@ -154,6 +184,8 @@ Steps:
 ------- 4B. claude-code -------
 Run:    claude mcp add mengram -- mengram server --cloud
 (The `claude` CLI is required. If absent, tell user to install Claude Code.)
+If the base URL from Step 3 is NOT https://mengram.io, ensure the Claude Code
+MCP entry also provides:    MENGRAM_URL=<base-url-from-step-3>
 Then tell the user: "MCP server registered. Run `/mcp` inside Claude Code to
 confirm 'mengram' is listed."
 
@@ -176,6 +208,7 @@ Append (TOML, NOT JSON):
 
   [mcp_servers.mengram.env]
   MENGRAM_API_KEY = "<api-key>"
+  MENGRAM_URL = "<base-url-from-step-3>"
 
 Tell user: "Restart Codex."
 
@@ -192,7 +225,7 @@ added through the Settings UI. STOP the install flow and tell the user:
     3. Click 'Add custom connector'
     4. Fill in:
          Name:      Mengram
-         URL:       https://mengram.io/mcp
+         URL:       <base-url-from-step-3>/mcp
          Headers:   Authorization: Bearer <api-key-from-step-3>
     5. Save. The 30 Mengram tools appear in this same chat after a refresh.
 
@@ -206,10 +239,10 @@ Tell the user:
   "Add this MCP server entry to your host tool's config:
     name:    mengram
     command: mengram server --cloud
-    env:     MENGRAM_API_KEY=<api-key>
+    env:     MENGRAM_API_KEY=<api-key>, MENGRAM_URL=<base-url>
   Refer to your tool's MCP docs for the exact config location.
   For HTTP-only hosts (Claude.ai web, ChatGPT, custom apps), use the
-  remote URL instead: https://mengram.io/mcp with Authorization header
+  remote URL instead: <base-url>/mcp with Authorization header
   'Bearer <api-key>'."
 
 ================================================================
@@ -223,7 +256,7 @@ STEP 5 — VERIFY THE INSTALL WORKS
 5.2  If `doctor` fails:
      - 401 / 403: API key not loaded. Check ~/.mengram/config.json and
        $MENGRAM_API_KEY are set. Re-export and retry.
-     - Network errors: confirm https://mengram.io is reachable.
+     - Network errors: confirm the base URL from Step 3 is reachable.
      - Other: capture the full error and report to user verbatim.
 
 ================================================================
@@ -235,6 +268,7 @@ On success, write a final message in this exact shape (substitute the values):
   Mengram installed successfully.
   - API key: om-XXXX...XXXX (saved to ~/.mengram/config.json)
   - MCP server: registered in <host>
+  - API base URL: <base-url-from-step-3>
   - Round-trip test: passed
   Next step: restart <host> (or reload its window). Then in any chat, say
   "remember that I'm working on <whatever>" — Mengram will store it
@@ -250,6 +284,8 @@ block to the user verbatim and stop:
   Mengram needs shell access to install. Run these commands in your terminal,
   then I can continue:
 
+    0. If you use self-hosted Mengram, set MENGRAM_URL in your shell to your
+       base URL first (for example: http://localhost:8420)
     1. python3 -m pip install --user mengram-ai
     2. mengram signup --email YOUR_EMAIL@example.com
     3. (check your inbox for a 6-digit code)
@@ -272,7 +308,8 @@ APPENDIX A — JSON CONFIG TEMPLATE (for hosts that use JSON)
       "command": "mengram",
       "args": ["server", "--cloud"],
       "env": {
-        "MENGRAM_API_KEY": "om-REPLACE_WITH_REAL_KEY"
+        "MENGRAM_API_KEY": "om-REPLACE_WITH_REAL_KEY",
+        "MENGRAM_URL": "https://mengram.io-or-your-self-hosted-base-url"
       }
     }
   }
@@ -294,8 +331,10 @@ APPENDIX B — DEBUGGING NOTES FOR AGENTS
 - If the user has an existing MCP server named `mengram`, replace it (do not
   duplicate or rename — they want the latest).
 
-- API base URL is https://mengram.io. If the user has $MENGRAM_URL set to a
-  self-hosted URL, honor that — pass it through to the MCP server's env.
+- API base URL defaults to https://mengram.io. If the user has $MENGRAM_URL
+  set to a self-hosted URL, honor that throughout signup, doctor, and the MCP
+  server env. For HTTP-remote MCP, use <base-url>/mcp instead of hard-coding
+  mengram.io.
 
 - This document is canonical. Always fetch the latest from:
   https://mengram.io/agent-install.txt

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -31,6 +31,22 @@ CRITICAL RULES:
 STEP 1 — DETECT ENVIRONMENT
 ================================================================
 
+1.0  PATH NOTATION USED IN THIS GUIDE
+
+     This guide writes paths in Unix shorthand (`~/...`). Resolve them per
+     platform:
+
+       | Logical path               | macOS / Linux / WSL     | Windows (native shell)              |
+       |-----------------------------|--------------------------|---------------------------------------|
+       | Mengram home                | ~/.mengram               | %USERPROFILE%\.mengram                |
+       | Claude Code settings        | ~/.claude/settings.json  | %USERPROFILE%\.claude\settings.json   |
+       | Claude Code global config   | ~/.claude.json           | %USERPROFILE%\.claude.json            |
+
+     WSL note: `~` resolves to the Linux distro's home directory, NOT the
+     Windows user's home — even though both run on the same machine. Always
+     resolve `~` in the shell that will actually run `mengram` / `claude`,
+     not by assuming a shared filesystem location.
+
 1.1  Determine OS using a command that exists in the current shell:
      - On Unix-like shells: run `uname -s`
      - On Windows shells: run `cmd /c ver` (or inspect `$env:OS`)
@@ -86,6 +102,17 @@ STEP 1 — DETECT ENVIRONMENT
      of the two just because the other is already configured, already has a
      "mengram" entry, or was just set up in this same run — each has its own
      independent config file and must be checked/written independently.
+
+     ACTIVELY CHECK for Claude Desktop — do not rely on "you usually know
+     which host you're in". Even when running as Claude Code CLI, check
+     whether Claude Desktop is ALSO installed on this machine, e.g.:
+       - macOS:   test -d "/Applications/Claude.app" (or check for
+                  ~/Library/Application Support/Claude/)
+       - Windows: check for %LOCALAPPDATA%\Claude\Claude.exe or
+                  %APPDATA%\Claude\
+       - Linux:   check for ~/.config/Claude/
+     If found, run Step 4A in addition to 4B. Do not skip 4A just because
+     the host you were invoked from is claude-code.
 
      Likewise, Claude Desktop and Claude.ai (web) are different products with
      different install paths. The desktop app uses stdio MCP via a JSON config
@@ -285,12 +312,25 @@ NOTE: This configures ONLY the Claude Code CLI's own MCP config (separate
 from claude_desktop_config.json). It does NOT configure the Claude Desktop
 app — that is Section 4A. If Claude Desktop is also present, do 4A as well.
 
-Run:    claude mcp add mengram -- mengram server --cloud
+IMPORTANT — SCOPE: `claude mcp add` without `-s`/`--scope` registers the
+server LOCALLY, scoped to the current project only (written under
+`projects.<cwd>.mcpServers` in ~/.claude.json). Mengram must be available in
+EVERY project, so it MUST be added at USER scope instead — written to the
+top-level `mcpServers` key in ~/.claude.json, applying across all projects.
+
+Run:    claude mcp add mengram --scope user -- mengram server --cloud
 (The `claude` CLI is required. If absent, tell user to install Claude Code.)
 If the base URL from Step 3 is NOT https://mengram.io, ensure the Claude Code
 MCP entry also provides:    MENGRAM_URL=<base-url-from-step-3>
-Then tell the user: "MCP server registered. Run `/mcp` inside Claude Code to
-confirm 'mengram' is listed."
+(pass via `--env MENGRAM_API_KEY=... --env MENGRAM_URL=...` before the `--`).
+
+If you find an existing "mengram" entry under a project-scoped
+`projects.<path>.mcpServers` block in ~/.claude.json, move it into the
+top-level `mcpServers` block (do not duplicate it), then remove the
+project-scoped copy.
+
+Then tell the user: "MCP server registered globally. Run `/mcp` inside
+Claude Code to confirm 'mengram' is listed."
 
 ------- 4C. cursor -------
 Config file path:    ~/.cursor/mcp.json   (create if absent)

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -36,11 +36,16 @@ STEP 1 — DETECT ENVIRONMENT
      - Otherwise find ONE working way to run Python >= 3.10 in this
        environment. Call it <PYTHON_CMD>.
      - <PYTHON_CMD> may be a direct interpreter command or a launcher/tooling
-       wrapper already present in the environment.
+       wrapper already present in the environment (for example, a Python
+       interpreter, `uv`, `poetry`, or another Python-capable launcher/tool).
      - Do NOT require specific executable names like `python3` or `python`.
        Use whatever Python launcher/tool already works in this environment.
      - If you cannot find any working Python >= 3.10 launcher/tool capable of
-       installing `mengram-ai`, STOP. Tell user:
+       installing `mengram-ai`, ask the user ONCE:
+       "Which Python launcher or tool do you normally use here (for example
+       `uv`, `poetry`, `python`, `py`, or something else)?"
+     - If they do not know, or the reported tool still cannot install
+       `mengram-ai`, STOP. Tell user:
        "Mengram requires Python 3.10 or newer. Please install Python 3.10+
        or re-run this prompt in an environment that already has a working
        Python launcher."
@@ -87,6 +92,10 @@ STEP 2 — INSTALL THE PACKAGE
        `--break-system-packages`.
      - Instead, switch to that tool's own isolated/tool-install workflow and
        continue from there.
+     - Examples:
+       - `uv`: use `uv tool install mengram-ai`
+       - `poetry`: use a Poetry-managed environment, install `mengram-ai`
+         there, then invoke `mengram` from that environment
 
 2.2  Verify the `mengram` command is on PATH:
      Run:   mengram status
@@ -366,7 +375,9 @@ APPENDIX B — DEBUGGING NOTES FOR AGENTS
 
 - If a launcher/tool reports that its Python environment is externally managed,
   do not force `pip` into it. Use that tool's own isolated install workflow
-  instead, then locate the resulting `mengram` executable.
+  instead, then locate the resulting `mengram` executable. For example:
+  `uv tool install mengram-ai`, or install inside the user's Poetry-managed
+  environment and run `mengram` from there.
 
 - Do NOT use `sudo`. Prefer user-scoped installs when the chosen tool supports
   them. Mengram does not need root.

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -251,6 +251,7 @@ STEP 3 — DETERMINE API BASE + AUTHENTICATE
        as Step 3's normal flow, without calling signup/reset-key.
      - Wait for explicit confirmation ("done"/equivalent) before continuing.
        Do not guess or retry without it.
+     - Once confirmed, continue at Step 4 (skip the rest of Step 3).
 
 3.0b Existing account, but the key isn't available right now:
 

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -359,8 +359,11 @@ server LOCALLY, scoped to the current project only (written under
 EVERY project, so it MUST be added at USER scope instead — written to the
 top-level `mcpServers` key in ~/.claude.json, applying across all projects.
 
-Run:    claude mcp add mengram --scope user -- mengram server --cloud
+Run:    claude mcp add mengram --scope user -- <LAUNCHER_CMD> <LAUNCHER_ARGS_PREFIX...> server --cloud
 (The `claude` CLI is required. If absent, tell user to install Claude Code.)
+Substitute the resolved <LAUNCHER_CMD>/<LAUNCHER_ARGS_PREFIX> from Step 2.5,
+e.g. with uvx:
+   claude mcp add mengram --scope user -- uvx --from mengram-ai mengram server --cloud
 If the base URL from Step 3 is NOT https://mengram.io, ensure the Claude Code
 MCP entry also provides:    MENGRAM_URL=<base-url-from-step-3>
 (pass via `--env MENGRAM_API_KEY=... --env MENGRAM_URL=...` before the `--`).
@@ -370,8 +373,27 @@ If you find an existing "mengram" entry under a project-scoped
 top-level `mcpServers` block (do not duplicate it), then remove the
 project-scoped copy.
 
-Then tell the user: "MCP server registered globally. Run `/mcp` inside
-Claude Code to confirm 'mengram' is listed."
+Then install the Mengram memory hooks (auto-save / auto-recall / session
+context) into Claude Code's settings:
+
+Run:    mengram hook install
+
+This requires $MENGRAM_API_KEY (and $MENGRAM_URL for self-hosted) to be set
+in the CURRENT shell, not just a shell profile. If Step 3 only wrote them to
+~/.mengram/config.json or a profile file that hasn't been re-sourced yet,
+export them in this shell first using the saved values (do not print them):
+  - macOS/Linux/WSL:       export MENGRAM_API_KEY=...   [export MENGRAM_URL=...]
+  - Windows (cmd):         set MENGRAM_API_KEY=...      [set MENGRAM_URL=...]
+  - Windows (PowerShell):  $env:MENGRAM_API_KEY="..."   [$env:MENGRAM_URL="..."]
+
+`mengram hook install` writes three hooks into ~/.claude/settings.json:
+  - Stop             -> mengram auto-save --every 3   (background)
+  - UserPromptSubmit -> mengram auto-recall
+  - SessionStart     -> mengram auto-context
+
+Then tell the user: "MCP server registered globally and memory hooks
+installed. Run `/mcp` inside Claude Code to confirm 'mengram' is listed, and
+restart Claude Code for the hooks to take effect."
 
 ------- 4C. cursor -------
 Config file path:    ~/.cursor/mcp.json   (create if absent)

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -58,7 +58,8 @@ STEP 1 — DETECT ENVIRONMENT
        or re-run this prompt in an environment that already has a working
        Python launcher."
 
-1.3  Determine which AI tool you are running in (the "host"). Pick ONE:
+1.3  Determine which AI tool(s) you are running in / configuring (the
+     "host(s)"). Possible hosts:
      - claude-desktop   (Claude Desktop app, .app on macOS / .exe on Windows)
      - claude-code      (Claude Code CLI)
      - cursor           (Cursor editor)
@@ -69,9 +70,24 @@ STEP 1 — DETECT ENVIRONMENT
                           'claude-ai' AND lack of filesystem/shell tools, or
                           the URL chrome://...; see Section 4F)
      - other            (anything else — generic MCP install)
-     You usually know which host you are. If unsure, ask the user once.
+     You usually know which host you are running inside of. If unsure, ask
+     the user once.
 
-     CRITICAL: Claude Desktop and Claude.ai (web) are different products with
+     CRITICAL: Claude Desktop and Claude Code CLI are SEPARATE products with
+     SEPARATE MCP config stores (claude_desktop_config.json vs. Claude Code's
+     own config). Configuring one does NOT configure the other, even though
+     both run on the same machine and both are "Claude".
+
+     IMPORTANT — CHECK BOTH, DO NOT SKIP EITHER:
+     If the current environment is, or has access to, both Claude Desktop AND
+     Claude Code CLI (e.g. you are running as Claude Code but Claude Desktop
+     is also installed on this machine, or vice versa), configure BOTH in
+     Step 4 (4A for Claude Desktop, 4B for Claude Code CLI). Never skip one
+     of the two just because the other is already configured, already has a
+     "mengram" entry, or was just set up in this same run — each has its own
+     independent config file and must be checked/written independently.
+
+     Likewise, Claude Desktop and Claude.ai (web) are different products with
      different install paths. The desktop app uses stdio MCP via a JSON config
      file (Step 4A). The web app needs an HTTP MCP added through Settings UI
      (Step 4F) — you cannot install it programmatically.
@@ -233,7 +249,16 @@ NOTE — TWO VALID INTEGRATION PATTERNS:
 If you detect an existing entry that uses pattern (2), replace it with the
 pattern (1) block below unless the user explicitly asks to keep mcp-remote.
 
+REMINDER: If both Claude Desktop and Claude Code CLI are present/relevant on
+this machine, run BOTH 4A and 4B. They use separate config files — a
+"mengram" entry in one does not mean the other is configured. Do not skip
+either block on that basis.
+
 ------- 4A. claude-desktop -------
+NOTE: This configures ONLY the Claude Desktop app (claude_desktop_config.json).
+It does NOT configure the Claude Code CLI — that is a separate config store,
+see Section 4B. If Claude Code CLI is also present, do 4B as well.
+
 Config file path:
   macOS:    ~/Library/Application Support/Claude/claude_desktop_config.json
   Windows:  %APPDATA%\Claude\claude_desktop_config.json
@@ -256,6 +281,10 @@ Steps:
      for the MCP server to load."
 
 ------- 4B. claude-code -------
+NOTE: This configures ONLY the Claude Code CLI's own MCP config (separate
+from claude_desktop_config.json). It does NOT configure the Claude Desktop
+app — that is Section 4A. If Claude Desktop is also present, do 4A as well.
+
 Run:    claude mcp add mengram -- mengram server --cloud
 (The `claude` CLI is required. If absent, tell user to install Claude Code.)
 If the base URL from Step 3 is NOT https://mengram.io, ensure the Claude Code

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -23,12 +23,14 @@ CRITICAL RULES:
 STEP 1 — DETECT ENVIRONMENT
 ================================================================
 
-1.1  Determine OS by running:    uname -s    (or `ver` on Windows cmd)
+1.1  Determine OS using a command that exists in the current shell:
+     - On Unix-like shells: run `uname -s`
+     - On Windows shells: run `cmd /c ver` (or inspect `$env:OS`)
      Map: Darwin = macOS, Linux = Linux, MINGW/MSYS/CYGWIN/Windows = Windows.
 
 1.2  Determine whether Mengram is already installed or whether a usable Python
      launcher/package tool is available:
-     - First try: mengram --version
+     - First try: `mengram status`
        If this works, you may skip package installation unless the user
        explicitly wants reinstall/upgrade.
      - Otherwise find ONE working way to run Python >= 3.10 in this
@@ -65,7 +67,7 @@ STEP 1 — DETECT ENVIRONMENT
 STEP 2 — INSTALL THE PACKAGE
 ================================================================
 
-2.1  If `mengram --version` already works, SKIP installation unless the user
+2.1  If `mengram status` already works, SKIP installation unless the user
      explicitly asked for reinstall/upgrade.
 
      Otherwise install `mengram-ai` using the Python launcher/tool from Step
@@ -78,8 +80,16 @@ STEP 2 — INSTALL THE PACKAGE
      tool's equivalent install command instead. The end result MUST make the
      `mengram` executable callable by PATH or by absolute path.
 
+     IMPORTANT:
+     - If the preferred `pip --user` pattern fails with an
+       `externally-managed-environment` error (or any message telling you the
+       interpreter is managed by another tool), do NOT retry with
+       `--break-system-packages`.
+     - Instead, switch to that tool's own isolated/tool-install workflow and
+       continue from there.
+
 2.2  Verify the `mengram` command is on PATH:
-     Run:   mengram --version
+     Run:   mengram status
      If the command is not found, the install location is not on PATH or the
      executable name/path differs in this environment.
 
@@ -102,7 +112,9 @@ STEP 2 — INSTALL THE PACKAGE
 
      If you installed with another launcher/tool, determine where that tool
      placed the `mengram` executable and use that absolute path for every
-     subsequent step until PATH is fixed.
+     subsequent step until PATH is fixed. If needed, ask the tool for its
+     executable/tool bin directory or use the platform command search
+     (`where mengram` on Windows, `command -v mengram` on Unix-like shells).
 
      Until PATH is fixed, every subsequent step that calls `mengram ...` must
      use the absolute path to the executable instead.
@@ -351,6 +363,10 @@ APPENDIX B — DEBUGGING NOTES FOR AGENTS
 
 - Do not assume the installer is literally `python3` or `python`. Reuse
   whichever Python launcher/tool already works in that environment.
+
+- If a launcher/tool reports that its Python environment is externally managed,
+  do not force `pip` into it. Use that tool's own isolated install workflow
+  instead, then locate the resulting `mengram` executable.
 
 - Do NOT use `sudo`. Prefer user-scoped installs when the chosen tool supports
   them. Mengram does not need root.

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -447,7 +447,7 @@ added through the Settings UI. STOP the install flow and tell the user:
   This is a one-time UI step — Claude.ai's settings live outside
   what I can edit from here."
 
-After the user confirms they've added it, proceed to Step 5 (Verify).
+After the user confirms they've added it, proceed to Step 4.9, then Step 5 (Verify).
 
 ------- 4G. other -------
 Tell the user:

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -514,8 +514,10 @@ STEP 6 — REPORT TO USER
 On success, write a final message in this exact shape (substitute the values):
 
   Mengram installed successfully.
-  - Credentials: saved to ~/.mengram/.env
-  - MCP server: registered in <host>
+  - Credentials: saved to ~/.mengram/config.json (mode 600)
+  - Shell profile: MENGRAM_API_KEY exported in <profile-path-from-step-3, if any>
+  - MCP server: registered in <host> (<config file from Step 4>)
+  - Claude Code hooks: installed in ~/.claude/settings.json (claude-code only)
   - API base URL: <base-url-from-step-3>
   - Round-trip test: passed
   Next step: restart <host> (or reload its window). Then in any chat, say
@@ -541,19 +543,20 @@ block to the user verbatim and stop:
     2. mengram signup --email YOUR_EMAIL@example.com
     3. Hosted only: check your inbox for a 6-digit code
     4. Hosted only: `mengram signup --email YOUR_EMAIL@example.com --code 123456`
-    5. Self-hosted only: the command in step 2 should print an API key
-       immediately without a 6-digit code. Create `~/.mengram` if needed, then
-       save it to `~/.mengram/.env` as:
-         MENGRAM_API_KEY=YOUR_REAL_KEY
-         MENGRAM_URL=YOUR_BASE_URL
-       If the file already exists, replace the existing lines instead of
-       adding duplicates.
+    5. Self-hosted only: the command in step 2 should print an API key and
+       save it to `~/.mengram/config.json` automatically as
+       {"api_key": "YOUR_REAL_KEY", "base_url": "YOUR_BASE_URL"}. If it
+       doesn't, create `~/.mengram` if needed and write that file yourself.
     6. Open your AI tool's MCP config file (see Appendix A for the JSON
        template and Step 4 of this guide for the path on your tool/OS).
-       Paste the template, replace the api-key placeholder with the saved key
-       from your local `.env` file, and save. Do not paste the real key into
-       any AI chat.
-    7. mengram doctor
+       Paste the template, replacing the placeholders with the launcher
+       command/args you used to install `mengram-ai` in step 1 and the
+       key/base URL saved in `~/.mengram/config.json`, and save. Do not
+       paste the real key into any AI chat.
+    7. If using Claude Code, also run: mengram hook install
+       (requires MENGRAM_API_KEY set in this shell — see Step 4B in this
+       guide for export syntax per OS)
+    8. mengram doctor
 
   Reply "done" when finished and I'll confirm everything is wired correctly.
 
@@ -562,8 +565,11 @@ APPENDIX A — JSON CONFIG TEMPLATE (for hosts that use JSON)
 ================================================================
 
 This template is for local config files only. The real API key must be read
-from the saved local secret (for example `~/.mengram/.env`) and must never be
-printed back into AI chat output.
+from the saved local secret (`~/.mengram/config.json`) and must never be
+printed back into AI chat output. Replace "command"/"args" with the
+<LAUNCHER_CMD>/<LAUNCHER_ARGS_PREFIX> resolved in Step 2.5 — the example
+below shows the plain-PATH case; with uvx it would be
+"command": "uvx", "args": ["--from", "mengram-ai", "mengram", "server", "--cloud"].
 
 {
   "mcpServers": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,32 @@
+"""Unit tests for cli.py helper functions used by Claude Code hooks."""
+
+import json
+import sys
+
+import pytest
+
+import cli
+
+
+def test_load_cloud_base_url_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("MENGRAM_URL", "http://192.168.2.99:8420/")
+    monkeypatch.setattr(cli, "DEFAULT_HOME", tmp_path / ".mengram")
+    assert cli._load_cloud_base_url() == "http://192.168.2.99:8420"
+
+
+def test_load_cloud_base_url_from_config(monkeypatch, tmp_path):
+    monkeypatch.delenv("MENGRAM_URL", raising=False)
+    home = tmp_path / ".mengram"
+    home.mkdir()
+    (home / "config.json").write_text(json.dumps({
+        "api_key": "om-test",
+        "base_url": "http://192.168.2.99:8420/",
+    }))
+    monkeypatch.setattr(cli, "DEFAULT_HOME", home)
+    assert cli._load_cloud_base_url() == "http://192.168.2.99:8420"
+
+
+def test_load_cloud_base_url_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("MENGRAM_URL", raising=False)
+    monkeypatch.setattr(cli, "DEFAULT_HOME", tmp_path / ".mengram")
+    assert cli._load_cloud_base_url() == "https://mengram.io"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,3 +30,60 @@ def test_load_cloud_base_url_default(monkeypatch, tmp_path):
     monkeypatch.delenv("MENGRAM_URL", raising=False)
     monkeypatch.setattr(cli, "DEFAULT_HOME", tmp_path / ".mengram")
     assert cli._load_cloud_base_url() == "https://mengram.io"
+
+
+def test_hook_marker_format():
+    assert cli._hook_marker("auto-recall", "no API key") == "[mengram:auto-recall] no API key"
+
+
+def _run_emit(monkeypatch, capsys, **kwargs):
+    """Helper: call _emit_hook_exit, capture stdout, return parsed JSON payload."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli._emit_hook_exit(**kwargs)
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out.strip()
+    return json.loads(out)
+
+
+class Args:
+    def __init__(self, verbose=False):
+        self.verbose = verbose
+
+
+def test_emit_hook_exit_silent_no_context(capsys):
+    payload = _run_emit(None, capsys, hook_event_name="Stop", args=Args(verbose=False),
+                         hook_name="auto-save", status="no API key")
+    assert payload == {"continue": True, "suppressOutput": True}
+
+
+def test_emit_hook_exit_verbose_no_context(capsys):
+    payload = _run_emit(None, capsys, hook_event_name="Stop", args=Args(verbose=True),
+                         hook_name="auto-save", status="saved")
+    assert payload["continue"] is True
+    assert payload["systemMessage"] == "[mengram:auto-save] saved"
+    assert "suppressOutput" not in payload
+
+
+def test_emit_hook_exit_with_context_silent(capsys):
+    payload = _run_emit(None, capsys, hook_event_name="UserPromptSubmit", args=Args(verbose=False),
+                         hook_name="auto-recall", status="found 1 memories", context="some context")
+    assert payload["hookSpecificOutput"] == {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": "some context",
+    }
+    assert "systemMessage" not in payload
+
+
+def test_emit_hook_exit_with_context_verbose(capsys):
+    payload = _run_emit(None, capsys, hook_event_name="UserPromptSubmit", args=Args(verbose=True),
+                         hook_name="auto-recall", status="found 1 memories", context="some context")
+    assert payload["systemMessage"] == "[mengram:auto-recall] found 1 memories"
+    assert payload["hookSpecificOutput"]["additionalContext"] == (
+        "[mengram:auto-recall] found 1 memories\n\nsome context"
+    )
+
+
+def test_emit_hook_exit_verbose_stop_has_no_additional_context(capsys):
+    payload = _run_emit(None, capsys, hook_event_name="Stop", args=Args(verbose=True),
+                         hook_name="auto-save", status="saved")
+    assert "hookSpecificOutput" not in payload


### PR DESCRIPTION
## Summary
- Add `_load_cloud_base_url()` (mirrors `_load_cloud_api_key()`): resolves base URL from env var → `~/.mengram/config.json` → default `https://mengram.io`.
- `cmd_auto_recall`, `cmd_auto_context`, `cmd_auto_save` now use `_load_cloud_api_key()`/`_load_cloud_base_url()` instead of raw `os.environ.get(...)`, fixing self-hosted setups (e.g. Windows, where `setup --key` only persists to config.json, not shell profiles).
- Add opt-in `--verbose` flag to all three hooks. When set, every exit path emits a `[mengram:<hook>] <status>` marker via `systemMessage` (folded into `additionalContext` for UserPromptSubmit/SessionStart). Default behavior unchanged (silent).
- New `tests/test_cli.py` (9 tests) covering `_load_cloud_base_url` and the new `_hook_marker`/`_emit_hook_exit` helpers.
- CHANGELOG.md entry.

## Known limitation

The `--verbose` `systemMessage` output is only visible in the **Claude Code CLI** (terminal). The **VS Code extension** and **Claude Desktop app** do not currently render hook `systemMessage` output anywhere in their UI — see [anthropics/claude-code#63360](https://github.com/anthropics/claude-code/issues/63360). This is a Claude Code platform limitation, not something fixable from this CLI. Non-verbose (default) behavior is unaffected either way.

## Test plan
- [x] `uv run pytest -q` — 85 passed, 3 pre-existing unrelated failures in `tests/test_parser.py::TestParseVault` (Cyrillic vault fixtures, StopIteration — unrelated to this change)
- [x] Manual smoke test against live self-hosted instance: `auto-recall`/`auto-context`/`auto-save` with and without `--verbose`, confirmed markers present/absent and successful CloudMemory calls
- [x] `uv tool install --force --reinstall .` — confirmed reinstalled CLI picks up the fix