### PR TITLE
fix: resolve hook credentials from ~/.mengram/config.json + add --verbose status markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 2026-06-14
+
+### Fixed
+- `auto-recall`, `auto-context`, and `auto-save` Claude Code hooks now resolve
+  the API key and base URL from `~/.mengram/config.json` as a fallback when
+  `MENGRAM_API_KEY`/`MENGRAM_URL` env vars are unset (fixes self-hosted setups
+  on Windows, where `setup --key` only persists to config.json).
+
+### Added
+- `--verbose` flag for `auto-recall`, `auto-context`, and `auto-save` hooks —
+  emits a one-line `[mengram:<hook>] <status>` marker via `systemMessage` so
+  hook activity is visible in Claude Code. Off by default.

--- a/cli.py
+++ b/cli.py
@@ -476,24 +476,26 @@ def cmd_auto_context(args):
 
 def cmd_auto_save(args):
     """Hook handler — called by Claude Code on Stop event. Reads stdin, saves to Mengram."""
+    HOOK = "auto-save"
+    EVENT = "Stop"
     try:
-        api_key = os.environ.get("MENGRAM_API_KEY", "")
+        api_key = _load_cloud_api_key()
         if not api_key:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "no API key")
 
         # Read hook input from stdin
         try:
             input_data = json.loads(sys.stdin.read())
         except Exception:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "no input")
 
         # Avoid infinite loops
         if input_data.get("stop_hook_active"):
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "skipped (stop_hook_active)")
 
         last_msg = input_data.get("last_assistant_message", "")
         if not last_msg or len(last_msg.strip()) < 10:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "skipped (short response)")
 
         # Throttle: only save every Nth response
         session_id = input_data.get("session_id", "unknown")
@@ -515,7 +517,7 @@ def cmd_auto_save(args):
             pass
 
         if count > 1 and count % every != 0:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, f"throttled ({count}/{every})")
 
         # Extract last user message from transcript
         user_message = ""
@@ -561,7 +563,7 @@ def cmd_auto_save(args):
 
         # Send to Mengram API
         from cloud.client import CloudMemory
-        base_url = os.environ.get("MENGRAM_URL", "https://mengram.io")
+        base_url = _load_cloud_base_url()
         user_id = getattr(args, "user_id", None) or os.environ.get("MENGRAM_USER_ID", "default")
 
         mem = CloudMemory(api_key=api_key, base_url=base_url)
@@ -573,24 +575,22 @@ def cmd_auto_save(args):
             run_id=session_id,
         )
 
-        output_hook_success()
+        _emit_hook_exit(EVENT, args, HOOK, "saved")
 
     except SystemExit:
         raise
     except Exception as e:
         if _is_quota_error(e):
-            # Surface quota error to user via stderr (Stop hooks don't support additionalContext)
+            # Always surface quota errors via stderr (Stop hooks don't support
+            # additionalContext), regardless of --verbose.
             print(
                 f"\n⚠️  [Mengram] Memory save failed — quota exceeded. {e}\n"
                 "   Your conversations are NOT being saved.\n"
                 "   Upgrade at https://mengram.io/dashboard\n",
                 file=sys.stderr,
             )
-            print(json.dumps({"continue": True}))
-            sys.exit(0)
-        # Never crash, never block Claude
-        print(json.dumps({"continue": True, "suppressOutput": True}))
-        sys.exit(0)
+            _emit_hook_exit(EVENT, args, HOOK, "quota exceeded")
+        _emit_hook_exit(EVENT, args, HOOK, "error")
 
 
 def cmd_hook(args):
@@ -1528,6 +1528,8 @@ def main():
     p_autosave = sub.add_parser("auto-save", help=argparse.SUPPRESS)
     p_autosave.add_argument("--every", type=int, default=3)
     p_autosave.add_argument("--user-id", default=None)
+    p_autosave.add_argument("--verbose", action="store_true",
+                             help="Emit a status marker for each hook invocation")
 
     # auto-recall (internal, called by Claude Code UserPromptSubmit hook)
     p_autorecall = sub.add_parser("auto-recall", help=argparse.SUPPRESS)

--- a/cli.py
+++ b/cli.py
@@ -439,13 +439,15 @@ def cmd_auto_recall(args):
 
 def cmd_auto_context(args):
     """Hook handler — called by Claude Code on SessionStart. Loads cognitive profile as context."""
+    HOOK = "auto-context"
+    EVENT = "SessionStart"
     try:
-        api_key = os.environ.get("MENGRAM_API_KEY", "")
+        api_key = _load_cloud_api_key()
         if not api_key:
-            sys.exit(0)
+            _emit_hook_exit(EVENT, args, HOOK, "no API key")
 
         from cloud.client import CloudMemory
-        base_url = os.environ.get("MENGRAM_URL", "https://mengram.io")
+        base_url = _load_cloud_base_url()
         user_id = getattr(args, "user_id", None) or os.environ.get("MENGRAM_USER_ID", "default")
 
         mem = CloudMemory(api_key=api_key, base_url=base_url)
@@ -453,21 +455,23 @@ def cmd_auto_context(args):
 
         system_prompt = profile.get("system_prompt", "")
         if not system_prompt:
-            sys.exit(0)
+            _emit_hook_exit(EVENT, args, HOOK, "no profile")
 
-        # For SessionStart, plain text stdout is added as context Claude sees
-        print(f"[Mengram Memory — user context loaded from past sessions]\n{system_prompt}")
-        sys.exit(0)
+        context = f"[Mengram Memory — user context loaded from past sessions]\n{system_prompt}"
+        _emit_hook_exit(EVENT, args, HOOK, f"context loaded ({len(system_prompt)} chars)", context=context)
 
     except SystemExit:
         raise
     except Exception as e:
         if _is_quota_error(e):
-            print(
-                f"[Mengram] Memory profile load failed — quota exceeded. {e} "
-                "Upgrade at https://mengram.io/dashboard"
+            _emit_hook_exit(
+                EVENT, args, HOOK, "quota exceeded",
+                context=(
+                    f"[Mengram] Memory profile load failed — quota exceeded. {e} "
+                    "Upgrade at https://mengram.io/dashboard"
+                ),
             )
-        sys.exit(0)
+        _emit_hook_exit(EVENT, args, HOOK, "error")
 
 
 def cmd_auto_save(args):
@@ -1534,6 +1538,8 @@ def main():
     # auto-context (internal, called by Claude Code SessionStart hook)
     p_autocontext = sub.add_parser("auto-context", help=argparse.SUPPRESS)
     p_autocontext.add_argument("--user-id", default=None)
+    p_autocontext.add_argument("--verbose", action="store_true",
+                                help="Emit a status marker for each hook invocation")
 
     # web
     p_web = sub.add_parser("web", help="Start Web UI (chat + knowledge graph)")

--- a/cli.py
+++ b/cli.py
@@ -376,36 +376,38 @@ def _is_quota_error(e: Exception) -> bool:
 
 def cmd_auto_recall(args):
     """Hook handler — called by Claude Code on UserPromptSubmit. Searches Mengram for relevant context."""
+    HOOK = "auto-recall"
+    EVENT = "UserPromptSubmit"
     try:
-        api_key = os.environ.get("MENGRAM_API_KEY", "")
+        api_key = _load_cloud_api_key()
         if not api_key:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "no API key")
 
         # Read hook input from stdin
         try:
             input_data = json.loads(sys.stdin.read())
         except Exception:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "no input")
 
         prompt = input_data.get("prompt", "")
         if not prompt or len(prompt) < 10:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "skipped (short/command prompt)")
 
         # Skip common non-question prompts
         skip_prefixes = ["/", "yes", "no", "ok", "y", "n", "da", "нет", "да"]
         prompt_lower = prompt.strip().lower()
         if any(prompt_lower == p or prompt_lower.startswith(p + " ") for p in skip_prefixes):
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "skipped (short/command prompt)")
 
         from cloud.client import CloudMemory
-        base_url = os.environ.get("MENGRAM_URL", "https://mengram.io")
+        base_url = _load_cloud_base_url()
         user_id = getattr(args, "user_id", None) or os.environ.get("MENGRAM_USER_ID", "default")
 
         mem = CloudMemory(api_key=api_key, base_url=base_url)
         results = mem.search(prompt, user_id=user_id, limit=3, graph_depth=1)
 
         if not results:
-            output_hook_success()
+            _emit_hook_exit(EVENT, args, HOOK, "no memories found")
 
         # Format context
         lines = ["[Mengram Memory — relevant context from past sessions]"]
@@ -418,32 +420,21 @@ def cmd_auto_recall(args):
                     lines.append(f"  - {fact}")
 
         context = "\n".join(lines)
-
-        # Return additionalContext for Claude to see
-        print(json.dumps({
-            "hookSpecificOutput": {
-                "hookEventName": "UserPromptSubmit",
-                "additionalContext": context,
-            }
-        }))
-        sys.exit(0)
+        _emit_hook_exit(EVENT, args, HOOK, f"found {len(results)} memories", context=context)
 
     except SystemExit:
         raise
     except Exception as e:
         if _is_quota_error(e):
-            print(json.dumps({
-                "hookSpecificOutput": {
-                    "hookEventName": "UserPromptSubmit",
-                    "additionalContext": (
-                        "[Mengram] Memory search quota exceeded — recall is disabled. "
-                        f"{e} "
-                        "Upgrade at https://mengram.io/dashboard"
-                    ),
-                }
-            }))
-            sys.exit(0)
-        output_hook_success()
+            _emit_hook_exit(
+                EVENT, args, HOOK, "quota exceeded",
+                context=(
+                    "[Mengram] Memory search quota exceeded — recall is disabled. "
+                    f"{e} "
+                    "Upgrade at https://mengram.io/dashboard"
+                ),
+            )
+        _emit_hook_exit(EVENT, args, HOOK, "error")
 
 
 def cmd_auto_context(args):
@@ -1537,6 +1528,8 @@ def main():
     # auto-recall (internal, called by Claude Code UserPromptSubmit hook)
     p_autorecall = sub.add_parser("auto-recall", help=argparse.SUPPRESS)
     p_autorecall.add_argument("--user-id", default=None)
+    p_autorecall.add_argument("--verbose", action="store_true",
+                               help="Emit a status marker for each hook invocation")
 
     # auto-context (internal, called by Claude Code SessionStart hook)
     p_autocontext = sub.add_parser("auto-context", help=argparse.SUPPRESS)

--- a/cli.py
+++ b/cli.py
@@ -783,6 +783,23 @@ def _load_cloud_api_key() -> str:
     return ""
 
 
+def _load_cloud_base_url() -> str:
+    """Resolve base URL in this order: env var, ~/.mengram/config.json, default."""
+    url = os.environ.get("MENGRAM_URL", "").strip()
+    if url:
+        return url.rstrip("/")
+    path = _cloud_config_path()
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+            cfg_url = (data.get("base_url") or "").strip()
+            if cfg_url:
+                return cfg_url.rstrip("/")
+        except Exception:
+            pass
+    return "https://mengram.io"
+
+
 def _save_and_report_key(api_key: str, label: str) -> None:
     """Persist API key to ~/.mengram/config.json + shell profile, print success.
     Shared by all CLI paths that successfully obtain a key."""

--- a/cli.py
+++ b/cli.py
@@ -933,7 +933,7 @@ def cmd_doctor(args):
         print("FAIL: no API key. Run `mengram signup --email <you>` first.", file=sys.stderr)
         sys.exit(1)
 
-    base = os.environ.get("MENGRAM_URL", "https://mengram.io").rstrip("/")
+    base = _load_cloud_base_url().rstrip("/")
     marker = f"mengram-doctor-{int(time.time())}"
     fact_text = f"Round-trip marker {marker}: this memory was written by mengram doctor."
 

--- a/cli.py
+++ b/cli.py
@@ -800,6 +800,48 @@ def _load_cloud_base_url() -> str:
     return "https://mengram.io"
 
 
+def _hook_marker(hook_name: str, status: str) -> str:
+    """Build a one-line status marker for verbose hook output."""
+    return f"[mengram:{hook_name}] {status}"
+
+
+def _emit_hook_exit(hook_event_name, args, hook_name, status, context=None):
+    """Emit a Claude Code hook JSON response and exit(0).
+
+    Non-verbose (default): preserves prior silent behavior — suppressOutput
+    when there's no context, or just the additionalContext when there is.
+
+    Verbose (--verbose): adds a one-line status marker via `systemMessage`
+    (shown to the user for any hook type), and for UserPromptSubmit /
+    SessionStart also prefixes it onto `additionalContext` so Claude sees it.
+    Stop hooks don't support additionalContext, so verbose Stop output is
+    systemMessage only.
+    """
+    verbose = getattr(args, "verbose", False)
+    payload = {"continue": True}
+
+    if context:
+        payload["hookSpecificOutput"] = {
+            "hookEventName": hook_event_name,
+            "additionalContext": context,
+        }
+
+    if verbose:
+        marker = _hook_marker(hook_name, status)
+        payload["systemMessage"] = marker
+        if hook_event_name in ("UserPromptSubmit", "SessionStart"):
+            existing = payload.get("hookSpecificOutput", {}).get("additionalContext", "")
+            payload["hookSpecificOutput"] = {
+                "hookEventName": hook_event_name,
+                "additionalContext": marker + (("\n\n" + existing) if existing else ""),
+            }
+    elif not context:
+        payload["suppressOutput"] = True
+
+    print(json.dumps(payload))
+    sys.exit(0)
+
+
 def _save_and_report_key(api_key: str, label: str) -> None:
     """Persist API key to ~/.mengram/config.json + shell profile, print success.
     Shared by all CLI paths that successfully obtain a key."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,32 @@
+"""Unit tests for cli.py helper functions used by Claude Code hooks."""
+
+import json
+import sys
+
+import pytest
+
+import cli
+
+
+def test_load_cloud_base_url_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("MENGRAM_URL", "http://192.168.2.99:8420/")
+    monkeypatch.setattr(cli, "DEFAULT_HOME", tmp_path / ".mengram")
+    assert cli._load_cloud_base_url() == "http://192.168.2.99:8420"
+
+
+def test_load_cloud_base_url_from_config(monkeypatch, tmp_path):
+    monkeypatch.delenv("MENGRAM_URL", raising=False)
+    home = tmp_path / ".mengram"
+    home.mkdir()
+    (home / "config.json").write_text(json.dumps({
+        "api_key": "om-test",
+        "base_url": "http://192.168.2.99:8420/",
+    }))
+    monkeypatch.setattr(cli, "DEFAULT_HOME", home)
+    assert cli._load_cloud_base_url() == "http://192.168.2.99:8420"
+
+
+def test_load_cloud_base_url_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("MENGRAM_URL", raising=False)
+    monkeypatch.setattr(cli, "DEFAULT_HOME", tmp_path / ".mengram")
+    assert cli._load_cloud_base_url() == "https://mengram.io"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,3 +30,60 @@ def test_load_cloud_base_url_default(monkeypatch, tmp_path):
     monkeypatch.delenv("MENGRAM_URL", raising=False)
     monkeypatch.setattr(cli, "DEFAULT_HOME", tmp_path / ".mengram")
     assert cli._load_cloud_base_url() == "https://mengram.io"
+
+
+def test_hook_marker_format():
+    assert cli._hook_marker("auto-recall", "no API key") == "[mengram:auto-recall] no API key"
+
+
+def _run_emit(monkeypatch, capsys, **kwargs):
+    """Helper: call _emit_hook_exit, capture stdout, return parsed JSON payload."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli._emit_hook_exit(**kwargs)
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out.strip()
+    return json.loads(out)
+
+
+class Args:
+    def __init__(self, verbose=False):
+        self.verbose = verbose
+
+
+def test_emit_hook_exit_silent_no_context(capsys):
+    payload = _run_emit(None, capsys, hook_event_name="Stop", args=Args(verbose=False),
+                         hook_name="auto-save", status="no API key")
+    assert payload == {"continue": True, "suppressOutput": True}
+
+
+def test_emit_hook_exit_verbose_no_context(capsys):
+    payload = _run_emit(None, capsys, hook_event_name="Stop", args=Args(verbose=True),
+                         hook_name="auto-save", status="saved")
+    assert payload["continue"] is True
+    assert payload["systemMessage"] == "[mengram:auto-save] saved"
+    assert "suppressOutput" not in payload
+
+
+def test_emit_hook_exit_with_context_silent(capsys):
+    payload = _run_emit(None, capsys, hook_event_name="UserPromptSubmit", args=Args(verbose=False),
+                         hook_name="auto-recall", status="found 1 memories", context="some context")
+    assert payload["hookSpecificOutput"] == {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": "some context",
+    }
+    assert "systemMessage" not in payload
+
+
+def test_emit_hook_exit_with_context_verbose(capsys):
+    payload = _run_emit(None, capsys, hook_event_name="UserPromptSubmit", args=Args(verbose=True),
+                         hook_name="auto-recall", status="found 1 memories", context="some context")
+    assert payload["systemMessage"] == "[mengram:auto-recall] found 1 memories"
+    assert payload["hookSpecificOutput"]["additionalContext"] == (
+        "[mengram:auto-recall] found 1 memories\n\nsome context"
+    )
+
+
+def test_emit_hook_exit_verbose_stop_has_no_additional_context(capsys):
+    payload = _run_emit(None, capsys, hook_event_name="Stop", args=Args(verbose=True),
+                         hook_name="auto-save", status="saved")
+    assert "hookSpecificOutput" not in payload


### PR DESCRIPTION
Fixes #41

Replaces #42 (that branch accidentally included unrelated commits from another in-progress branch).

## Summary
- Add `_load_cloud_base_url()` (mirrors `_load_cloud_api_key()`): resolves base URL from env var → `~/.mengram/config.json` → default `https://mengram.io`.
- `cmd_auto_recall`, `cmd_auto_context`, `cmd_auto_save` now use `_load_cloud_api_key()`/`_load_cloud_base_url()` instead of raw `os.environ.get(...)`, fixing self-hosted setups (e.g. Windows, where `setup --key` only persists to config.json, not shell profiles).
- Add opt-in `--verbose` flag to all three hooks. When set, every exit path emits a `[mengram:<hook>] <status>` marker via `systemMessage` (folded into `additionalContext` for UserPromptSubmit/SessionStart). Default behavior unchanged (silent).
- New `tests/test_cli.py` (9 tests) covering `_load_cloud_base_url` and the new `_hook_marker`/`_emit_hook_exit` helpers.
- CHANGELOG.md entry.

## Known limitation

The `--verbose` `systemMessage` output is only visible in the **Claude Code CLI** (terminal). The **VS Code extension** and **Claude Desktop app** do not currently render hook `systemMessage` output anywhere in their UI — see [anthropics/claude-code#63360](https://github.com/anthropics/claude-code/issues/63360). This is a Claude Code platform limitation, not something fixable from this CLI. Non-verbose (default) behavior is unaffected either way.

## Test plan
- [x] `uv run pytest -q` — 85 passed, 3 pre-existing unrelated failures in `tests/test_parser.py::TestParseVault` (Cyrillic vault fixtures, StopIteration — unrelated to this change)
- [x] Manual smoke test against live self-hosted instance: `auto-recall`/`auto-context`/`auto-save` with and without `--verbose`, confirmed markers present/absent and successful CloudMemory calls
- [x] `uv tool install --force --reinstall .` — confirmed reinstalled CLI picks up the fix

## Diff scope
Only `cli.py`, `tests/test_cli.py`, `CHANGELOG.md` — 216 insertions / 53 deletions, no unrelated changes.