### PR TITLE
fix(rerank): route LLM-rerank fallback through shared free-model-fallback client

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -481,7 +481,6 @@ profile = m.get_profile()             # instant system prompt
 
     # ---- Re-ranking (Cohere Rerank → LLM fallback) ----
     _cohere_client = None
-    _openai_rerank_client = None
 
     def _summarize_for_embedding(text: str, max_chars: int = 1500) -> str:
         """Summarize long text for embedding. Preserves key facts for search."""
@@ -578,17 +577,13 @@ profile = m.get_profile()             # instant system prompt
             except Exception as e:
                 logger.warning(f"⚠️ Cohere rerank failed, falling back: {e}")
 
-        # Fallback: LLM rerank
+        # Fallback: LLM rerank — uses the shared free-model-fallback LLM client
         openai_key = os.environ.get("OPENAI_API_KEY", "")
         if not openai_key:
             return results
 
         try:
-            nonlocal _openai_rerank_client
-            if _openai_rerank_client is None:
-                import openai
-                _openai_rerank_client = openai.OpenAI(api_key=openai_key)
-            client = _openai_rerank_client
+            llm = get_llm().llm
 
             candidates = []
             for i, r in enumerate(results):
@@ -613,14 +608,7 @@ Return ONLY a JSON array of indices of relevant entities, e.g. [0, 2, 4].
 If none are relevant, return [].
 Be strict — only include entities that directly answer or relate to the query."""
 
-            resp = client.chat.completions.create(
-                model="gpt-4o-mini",
-                messages=[{"role": "user", "content": prompt}],
-                max_completion_tokens=100,
-                temperature=0,
-            )
-
-            text = (resp.choices[0].message.content or "").strip()
+            text = llm.complete(prompt).strip()
             if not text:
                 return results
 

--- a/cloud/api.py
+++ b/cloud/api.py
@@ -453,12 +453,14 @@ profile = m.get_profile()             # instant system prompt
         if _llm_client is None:
             from engine.extractor.llm_client import create_llm_client
             llm_model = os.environ.get("LLM_MODEL", "")
+            model_list_url = os.environ.get("MODEL_LIST_URL", "")
             llm_config = {
                 "provider": os.environ.get("LLM_PROVIDER", "anthropic"),
                 "anthropic": {"api_key": os.environ.get("ANTHROPIC_API_KEY", ""),
                               **({"model": llm_model} if llm_model else {})},
                 "openai": {"api_key": os.environ.get("OPENAI_API_KEY", ""),
-                            **({"model": llm_model} if llm_model else {})},
+                            **({"model": llm_model} if llm_model else {}),
+                            **({"model_list_url": model_list_url} if model_list_url else {})},
             }
             _llm_client = create_llm_client(llm_config)
             from engine.extractor.conversation_extractor import ConversationExtractor

--- a/cloud/api.py
+++ b/cloud/api.py
@@ -454,13 +454,15 @@ profile = m.get_profile()             # instant system prompt
             from engine.extractor.llm_client import create_llm_client
             llm_model = os.environ.get("LLM_MODEL", "")
             model_list_url = os.environ.get("MODEL_LIST_URL", "")
+            provider_sort = os.environ.get("PROVIDER_SORT", "")
             llm_config = {
                 "provider": os.environ.get("LLM_PROVIDER", "anthropic"),
                 "anthropic": {"api_key": os.environ.get("ANTHROPIC_API_KEY", ""),
                               **({"model": llm_model} if llm_model else {})},
                 "openai": {"api_key": os.environ.get("OPENAI_API_KEY", ""),
                             **({"model": llm_model} if llm_model else {}),
-                            **({"model_list_url": model_list_url} if model_list_url else {})},
+                            **({"model_list_url": model_list_url} if model_list_url else {}),
+                            **({"provider_sort": provider_sort} if provider_sort else {})},
             }
             _llm_client = create_llm_client(llm_config)
             from engine.extractor.conversation_extractor import ConversationExtractor

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,12 @@ llm:
   openai:
     api_key: "sk-..."
     model: "gpt-4o-mini"
+    # Optional: URL to a models.json produced by
+    # https://github.com/<user>/mengram-model-list. When set, mengram tries
+    # each listed model in score order before falling back to `model`.
+    # If unset, empty, or unreachable with no cache, `model` is used directly
+    # as before — fully backward compatible.
+    # model_list_url: "https://raw.githubusercontent.com/<user>/mengram-model-list/main/models.json"
 
   # Ollama (fully local, free)
   ollama:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -24,6 +24,10 @@ llm:
     # If unset, empty, or unreachable with no cache, `model` is used directly
     # as before — fully backward compatible.
     # model_list_url: "https://raw.githubusercontent.com/<user>/mengram-model-list/main/models.json"
+    # Optional: route each request to a specific class of OpenRouter provider
+    # via `provider.sort`. One of: latency, throughput, price. Unset/empty =
+    # no extra_body sent, OpenRouter's default load-balancing applies.
+    # provider_sort: "latency"
 
   # Ollama (fully local, free)
   ollama:

--- a/engine/brain.py
+++ b/engine/brain.py
@@ -19,8 +19,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from engine.extractor.llm_client import LLMClient, create_llm_client
-from engine.extractor.conversation_extractor import ConversationExtractor, MockLLMClient
+from engine.extractor.llm_client import LLMClient, create_llm_client, AllModelsFailedError
+from engine.extractor.conversation_extractor import ConversationExtractor, ExtractionResult, MockLLMClient
 from engine.vault_manager.vault_manager import VaultManager
 from engine.graph.knowledge_graph import build_graph_from_vault, KnowledgeGraph
 from engine.parser.markdown_parser import parse_vault
@@ -120,7 +120,11 @@ class MengramBrain:
         print("🧠 Extracting knowledge from conversation...", file=sys.stderr)
 
         # 1. Extract via LLM
-        extraction = self.extractor.extract(conversation)
+        try:
+            extraction = self.extractor.extract(conversation)
+        except AllModelsFailedError as e:
+            print(f"⚠️  Extraction skipped — all fallback models failed: {e}", file=sys.stderr)
+            extraction = ExtractionResult()
         print(f"   📊 Found: {len(extraction.entities)} entities, {len(extraction.relations)} relations, "
               f"{len(extraction.knowledge)} knowledge, {len(extraction.episodes)} episodes, "
               f"{len(extraction.procedures)} procedures", file=sys.stderr)

--- a/engine/extractor/llm_client.py
+++ b/engine/extractor/llm_client.py
@@ -71,18 +71,32 @@ class AnthropicClient(LLMClient):
 class OpenAIClient(LLMClient):
     """GPT via OpenAI API"""
 
-    def __init__(self, api_key: str, model: str = "gpt-4o-mini"):
+    def __init__(self, api_key: str, model: str = "gpt-4o-mini", provider_sort: str = ""):
         try:
             from openai import OpenAI
         except ImportError:
             raise ImportError("pip install openai")
         self.client = OpenAI(api_key=api_key)
         self.model = model
+        self.provider_sort = provider_sort
 
     def _is_reasoning_model(self) -> bool:
         """gpt-5.x and o1/o3 models accept reasoning_effort and ignore temperature."""
         m = (self.model or "").lower()
         return m.startswith("gpt-5") or m.startswith("o1") or m.startswith("o3")
+
+    def _finish(self, response):
+        if not response.choices:
+            raise RuntimeError(f"model {self.model} returned no choices: {response}")
+        content = response.choices[0].message.content
+        if content is None:
+            raise RuntimeError(f"model {self.model} returned empty content: {response}")
+        _logger.info(
+            "model %s served by %s",
+            getattr(response, "model", self.model),
+            getattr(response, "provider", "?"),
+        )
+        return content
 
     def complete(self, prompt: str, system: str = "", response_format=None) -> str:
         kwargs = dict(
@@ -98,8 +112,10 @@ class OpenAIClient(LLMClient):
             kwargs["temperature"] = 0.2
         if response_format:
             kwargs["response_format"] = response_format
+        if self.provider_sort:
+            kwargs["extra_body"] = {"provider": {"sort": self.provider_sort}}
         response = self.client.chat.completions.create(**kwargs)
-        return response.choices[0].message.content
+        return self._finish(response)
 
     def chat(self, messages: list[dict], system: str = "") -> str:
         msgs = [{"role": "system", "content": system or "You are a helpful assistant."}]
@@ -107,8 +123,10 @@ class OpenAIClient(LLMClient):
         kwargs = dict(model=self.model, messages=msgs)
         if self._is_reasoning_model():
             kwargs["reasoning_effort"] = "low"
+        if self.provider_sort:
+            kwargs["extra_body"] = {"provider": {"sort": self.provider_sort}}
         response = self.client.chat.completions.create(**kwargs)
-        return response.choices[0].message.content
+        return self._finish(response)
 
 
 class OllamaClient(LLMClient):

--- a/engine/extractor/llm_client.py
+++ b/engine/extractor/llm_client.py
@@ -8,8 +8,11 @@ Supported providers:
 """
 
 import json
+import logging
 from abc import ABC, abstractmethod
 from typing import Optional
+
+_logger = logging.getLogger("mengram")
 
 
 class LLMClient(ABC):
@@ -154,6 +157,47 @@ class OllamaClient(LLMClient):
         with urllib.request.urlopen(req) as resp:
             result = json.loads(resp.read())
             return result["message"]["content"]
+
+
+class AllModelsFailedError(Exception):
+    """Raised by FallbackOpenAIClient when every candidate model fails."""
+
+
+class FallbackOpenAIClient(LLMClient):
+    """OpenAI-compatible client that tries a list of models in order.
+
+    Used when ~/.mengram/config.yaml sets `model_list_url`: `models` is the
+    ordered candidate list from get_model_candidates (curated list, scored
+    highest-first, with the configured `model` appended as final fallback).
+    """
+
+    def __init__(self, api_key: str, models: list[str]):
+        if not models:
+            raise ValueError("FallbackOpenAIClient requires at least one model")
+        self.models = models
+        self._clients = [OpenAIClient(api_key=api_key, model=m) for m in models]
+
+    def complete(self, prompt: str, system: str = "", response_format=None) -> str:
+        errors = []
+        for model, client in zip(self.models, self._clients):
+            try:
+                return client.complete(prompt, system=system, response_format=response_format)
+            except Exception as e:
+                _logger.warning("model %s failed: %s", model, e)
+                errors.append((model, e))
+        _logger.error("all models failed: %s", ", ".join(f"{m}: {e}" for m, e in errors))
+        raise AllModelsFailedError(f"all models failed: {[m for m, _ in errors]}")
+
+    def chat(self, messages: list[dict], system: str = "") -> str:
+        errors = []
+        for model, client in zip(self.models, self._clients):
+            try:
+                return client.chat(messages, system=system)
+            except Exception as e:
+                _logger.warning("model %s failed: %s", model, e)
+                errors.append((model, e))
+        _logger.error("all models failed: %s", ", ".join(f"{m}: {e}" for m, e in errors))
+        raise AllModelsFailedError(f"all models failed: {[m for m, _ in errors]}")
 
 
 def create_llm_client(config: dict) -> LLMClient:

--- a/engine/extractor/llm_client.py
+++ b/engine/extractor/llm_client.py
@@ -193,11 +193,13 @@ class FallbackOpenAIClient(LLMClient):
     highest-first, with the configured `model` appended as final fallback).
     """
 
-    def __init__(self, api_key: str, models: list[str]):
+    def __init__(self, api_key: str, models: list[str], provider_sort: str = ""):
         if not models:
             raise ValueError("FallbackOpenAIClient requires at least one model")
         self.models = models
-        self._clients = [OpenAIClient(api_key=api_key, model=m) for m in models]
+        self._clients = [
+            OpenAIClient(api_key=api_key, model=m, provider_sort=provider_sort) for m in models
+        ]
 
     def complete(self, prompt: str, system: str = "", response_format=None) -> str:
         errors = []
@@ -236,10 +238,11 @@ def create_llm_client(config: dict) -> LLMClient:
         settings = config.get("openai", {})
         api_key = settings["api_key"]
         model = settings.get("model", "gpt-4o-mini")
+        provider_sort = (settings.get("provider_sort") or "").strip()
         if (settings.get("model_list_url") or "").strip():
             candidates = get_model_candidates(settings, fetch_fn=_default_fetch_fn)
-            return FallbackOpenAIClient(api_key=api_key, models=candidates)
-        return OpenAIClient(api_key=api_key, model=model)
+            return FallbackOpenAIClient(api_key=api_key, models=candidates, provider_sort=provider_sort)
+        return OpenAIClient(api_key=api_key, model=model, provider_sort=provider_sort)
     elif provider == "ollama":
         settings = config.get("ollama", {})
         return OllamaClient(

--- a/engine/extractor/llm_client.py
+++ b/engine/extractor/llm_client.py
@@ -12,6 +12,10 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Optional
 
+from engine.extractor.model_source import get_model_candidates
+
+_default_fetch_fn = None
+
 _logger = logging.getLogger("mengram")
 
 
@@ -212,10 +216,12 @@ def create_llm_client(config: dict) -> LLMClient:
         )
     elif provider == "openai":
         settings = config.get("openai", {})
-        return OpenAIClient(
-            api_key=settings["api_key"],
-            model=settings.get("model", "gpt-4o-mini"),
-        )
+        api_key = settings["api_key"]
+        model = settings.get("model", "gpt-4o-mini")
+        if (settings.get("model_list_url") or "").strip():
+            candidates = get_model_candidates(settings, fetch_fn=_default_fetch_fn)
+            return FallbackOpenAIClient(api_key=api_key, models=candidates)
+        return OpenAIClient(api_key=api_key, model=model)
     elif provider == "ollama":
         settings = config.get("ollama", {})
         return OllamaClient(

--- a/engine/extractor/model_source.py
+++ b/engine/extractor/model_source.py
@@ -65,3 +65,46 @@ def _refresh(
         "models": models,
     })
     return models
+
+
+def _http_get(url: str) -> bytes:
+    import urllib.request
+
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        return resp.read()
+
+
+def get_model_candidates(
+    config: dict,
+    cache_path: Path | None = None,
+    now: float | None = None,
+    fetch_fn=None,
+) -> list[str]:
+    import time
+
+    url = (config.get("model_list_url") or "").strip()
+    static_model = config.get("model")
+
+    if not url:
+        return [static_model] if static_model else []
+
+    if cache_path is None:
+        cache_path = DEFAULT_CACHE_PATH
+    if now is None:
+        now = time.time()
+    if fetch_fn is None:
+        fetch_fn = _http_get
+
+    cache = _read_cache(cache_path)
+
+    if cache and cache.get("url") == url and now - cache.get("fetched_at", 0) < CACHE_TTL_SECONDS:
+        models = cache["models"]
+    else:
+        models = _refresh(url, cache, now, cache_path, fetch_fn)
+        if models is None:
+            return [static_model] if static_model else []
+
+    candidates = list(models)
+    if static_model and static_model not in candidates:
+        candidates.append(static_model)
+    return candidates

--- a/engine/extractor/model_source.py
+++ b/engine/extractor/model_source.py
@@ -1,0 +1,29 @@
+"""Fetch and cache the curated free-model fallback list for self-hosted LLM config.
+
+See https://github.com/<user>/mengram-model-list for the models.json schema.
+"""
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+
+_logger = logging.getLogger("mengram")
+
+DEFAULT_CACHE_PATH = Path.home() / ".mengram" / "model-cache.json"
+CACHE_TTL_SECONDS = 6 * 60 * 60  # 6 hours
+
+
+def _read_cache(cache_path: Path) -> dict | None:
+    try:
+        return json.loads(cache_path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _write_cache(cache_path: Path, data: dict) -> None:
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(data))
+    except OSError as e:
+        _logger.warning("failed to write model cache to %s: %s", cache_path, e)

--- a/engine/extractor/model_source.py
+++ b/engine/extractor/model_source.py
@@ -27,3 +27,41 @@ def _write_cache(cache_path: Path, data: dict) -> None:
         cache_path.write_text(json.dumps(data))
     except OSError as e:
         _logger.warning("failed to write model cache to %s: %s", cache_path, e)
+
+
+def _refresh(
+    url: str,
+    cache: dict | None,
+    now: float,
+    cache_path: Path,
+    fetch_fn,
+) -> list[str] | None:
+    try:
+        raw = fetch_fn(url)
+    except Exception as e:
+        _logger.warning("failed to fetch model list from %s: %s", url, e)
+        if cache and cache.get("url") == url:
+            return cache["models"]
+        return None
+
+    content_hash = hashlib.sha256(raw).hexdigest()
+
+    if cache and cache.get("url") == url and cache.get("content_hash") == content_hash:
+        models = cache["models"]
+    else:
+        try:
+            data = json.loads(raw)
+            models = [m["id"] for m in data["models"]]
+        except (ValueError, KeyError, TypeError) as e:
+            _logger.warning("failed to parse model list from %s: %s", url, e)
+            if cache and cache.get("url") == url:
+                return cache["models"]
+            return None
+
+    _write_cache(cache_path, {
+        "url": url,
+        "fetched_at": now,
+        "content_hash": content_hash,
+        "models": models,
+    })
+    return models

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -1,0 +1,28 @@
+"""Tests for MengramBrain graceful handling of AllModelsFailedError."""
+
+import pytest
+
+from engine.brain import MengramBrain
+from engine.extractor.conversation_extractor import ExtractionResult
+from engine.extractor.llm_client import AllModelsFailedError, LLMClient
+
+
+class AlwaysFailsExtractor:
+    """Stand-in for ConversationExtractor whose .extract() always raises."""
+
+    def extract(self, conversation, existing_context="", prompt_version=None):
+        raise AllModelsFailedError("all models failed: ['a/model', 'b/model']")
+
+
+class _NullLLMClient(LLMClient):
+    def complete(self, prompt, system="", response_format=None):
+        return "{}"
+
+
+def test_remember_skips_extraction_when_all_models_fail(tmp_path):
+    brain = MengramBrain(vault_path=str(tmp_path), llm_client=_NullLLMClient(), use_vectors=False)
+    brain.extractor = AlwaysFailsExtractor()
+
+    result = brain.remember([{"role": "user", "content": "hello"}])
+
+    assert result is not None

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import logging
 import pytest
 
 from engine.extractor.llm_client import (
@@ -125,3 +126,95 @@ def test_create_llm_client_openai_with_model_list_url_returns_fallback_client(tm
 
     assert isinstance(client, FallbackOpenAIClient)
     assert client.models == ["list/model-a", "list/model-b", "fallback/model"]
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = _FakeMessage(content)
+
+
+class _FakeResponse:
+    def __init__(self, content="ok", choices=None, model=None, provider=None):
+        self.choices = [_FakeChoice(content)] if choices is None else choices
+        if model is not None:
+            self.model = model
+        if provider is not None:
+            self.provider = provider
+
+
+class _FakeCompletions:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.response
+
+
+class _FakeChatAPI:
+    def __init__(self, completions):
+        self.completions = completions
+
+
+class _FakeOpenAISDK:
+    def __init__(self, completions):
+        self.chat = _FakeChatAPI(completions)
+
+
+def _make_openai_client_with_fake_sdk(response=None, provider_sort=""):
+    client = OpenAIClient(api_key="key", model="test/model", provider_sort=provider_sort)
+    completions = _FakeCompletions(response or _FakeResponse())
+    client.client = _FakeOpenAISDK(completions)
+    return client, completions
+
+
+def test_openai_client_complete_without_provider_sort_omits_extra_body():
+    client, completions = _make_openai_client_with_fake_sdk()
+    assert client.complete("prompt") == "ok"
+    assert "extra_body" not in completions.calls[0]
+
+
+def test_openai_client_complete_with_provider_sort_adds_extra_body():
+    client, completions = _make_openai_client_with_fake_sdk(provider_sort="latency")
+    client.complete("prompt")
+    assert completions.calls[0]["extra_body"] == {"provider": {"sort": "latency"}}
+
+
+def test_openai_client_chat_with_provider_sort_adds_extra_body():
+    client, completions = _make_openai_client_with_fake_sdk(provider_sort="throughput")
+    client.chat([{"role": "user", "content": "hi"}])
+    assert completions.calls[0]["extra_body"] == {"provider": {"sort": "throughput"}}
+
+
+def test_openai_client_complete_raises_runtime_error_on_empty_choices():
+    client, _ = _make_openai_client_with_fake_sdk(response=_FakeResponse(choices=[]))
+    with pytest.raises(RuntimeError, match="returned no choices"):
+        client.complete("prompt")
+
+
+def test_openai_client_complete_raises_runtime_error_on_none_content():
+    client, _ = _make_openai_client_with_fake_sdk(response=_FakeResponse(content=None))
+    with pytest.raises(RuntimeError, match="returned empty content"):
+        client.complete("prompt")
+
+
+def test_openai_client_complete_logs_model_and_provider(caplog):
+    response = _FakeResponse(content="ok", model="google/gemma-4-31b-it-20260402:free", provider="OpenInference")
+    client, _ = _make_openai_client_with_fake_sdk(response=response)
+    with caplog.at_level(logging.INFO, logger="mengram"):
+        client.complete("prompt")
+    assert "google/gemma-4-31b-it-20260402:free" in caplog.text
+    assert "OpenInference" in caplog.text
+
+
+def test_openai_client_complete_logs_fallback_provider_when_missing(caplog):
+    client, _ = _make_openai_client_with_fake_sdk(response=_FakeResponse(content="ok"))
+    with caplog.at_level(logging.INFO, logger="mengram"):
+        client.complete("prompt")
+    assert "test/model served by ?" in caplog.text

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,80 @@
+"""Tests for FallbackOpenAIClient and AllModelsFailedError."""
+
+from unittest.mock import patch
+
+import pytest
+
+from engine.extractor.llm_client import (
+    AllModelsFailedError,
+    FallbackOpenAIClient,
+    OpenAIClient,
+)
+
+
+def _make_openai_client(responses_by_model):
+    """Return a fake OpenAIClient constructor: responses_by_model maps model -> str or Exception."""
+
+    class FakeClient:
+        def __init__(self, api_key, model):
+            self.model = model
+
+        def complete(self, prompt, system="", response_format=None):
+            result = responses_by_model[self.model]
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        def chat(self, messages, system=""):
+            result = responses_by_model[self.model]
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+    return FakeClient
+
+
+def test_fallback_client_requires_at_least_one_model():
+    with pytest.raises(ValueError):
+        FallbackOpenAIClient(api_key="key", models=[])
+
+
+def test_fallback_client_uses_first_model_on_success():
+    fake_cls = _make_openai_client({"model-a": "ok from a"})
+    with patch("engine.extractor.llm_client.OpenAIClient", fake_cls):
+        client = FallbackOpenAIClient(api_key="key", models=["model-a"])
+
+    assert client.complete("prompt") == "ok from a"
+
+
+def test_fallback_client_falls_back_to_second_model_on_first_failure():
+    fake_cls = _make_openai_client({
+        "model-a": RuntimeError("model-a down"),
+        "model-b": "ok from b",
+    })
+    with patch("engine.extractor.llm_client.OpenAIClient", fake_cls):
+        client = FallbackOpenAIClient(api_key="key", models=["model-a", "model-b"])
+
+    assert client.complete("prompt") == "ok from b"
+
+
+def test_fallback_client_raises_all_models_failed_when_all_fail():
+    fake_cls = _make_openai_client({
+        "model-a": RuntimeError("model-a down"),
+        "model-b": RuntimeError("model-b down"),
+    })
+    with patch("engine.extractor.llm_client.OpenAIClient", fake_cls):
+        client = FallbackOpenAIClient(api_key="key", models=["model-a", "model-b"])
+
+    with pytest.raises(AllModelsFailedError):
+        client.complete("prompt")
+
+
+def test_fallback_client_chat_falls_back_too():
+    fake_cls = _make_openai_client({
+        "model-a": RuntimeError("model-a down"),
+        "model-b": "chat ok from b",
+    })
+    with patch("engine.extractor.llm_client.OpenAIClient", fake_cls):
+        client = FallbackOpenAIClient(api_key="key", models=["model-a", "model-b"])
+
+    assert client.chat([{"role": "user", "content": "hi"}]) == "chat ok from b"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -16,8 +16,9 @@ def _make_openai_client(responses_by_model):
     """Return a fake OpenAIClient constructor: responses_by_model maps model -> str or Exception."""
 
     class FakeClient:
-        def __init__(self, api_key, model):
+        def __init__(self, api_key, model, provider_sort=""):
             self.model = model
+            self.provider_sort = provider_sort
 
         def complete(self, prompt, system="", response_format=None):
             result = responses_by_model[self.model]
@@ -218,3 +219,48 @@ def test_openai_client_complete_logs_fallback_provider_when_missing(caplog):
     with caplog.at_level(logging.INFO, logger="mengram"):
         client.complete("prompt")
     assert "test/model served by ?" in caplog.text
+
+
+def test_fallback_client_passes_provider_sort_to_each_model():
+    fake_cls = _make_openai_client({"model-a": "ok", "model-b": "ok"})
+    with patch("engine.extractor.llm_client.OpenAIClient", fake_cls):
+        client = FallbackOpenAIClient(api_key="key", models=["model-a", "model-b"], provider_sort="latency")
+
+    assert client._clients[0].provider_sort == "latency"
+    assert client._clients[1].provider_sort == "latency"
+
+
+def test_create_llm_client_openai_passes_provider_sort_to_openai_client():
+    client = create_llm_client({
+        "provider": "openai",
+        "openai": {"api_key": "key", "model": "gpt-4o-mini", "provider_sort": "latency"},
+    })
+
+    assert isinstance(client, OpenAIClient)
+    assert client.provider_sort == "latency"
+
+
+def test_create_llm_client_fallback_passes_provider_sort(tmp_path, monkeypatch):
+    cache_path = tmp_path / "model-cache.json"
+    monkeypatch.setattr(
+        "engine.extractor.model_source.DEFAULT_CACHE_PATH", cache_path
+    )
+
+    def fetch_fn(url):
+        import json as _json
+        return _json.dumps({"models": [{"id": "list/model-a"}]}).encode()
+
+    monkeypatch.setattr("engine.extractor.llm_client._default_fetch_fn", fetch_fn)
+
+    client = create_llm_client({
+        "provider": "openai",
+        "openai": {
+            "api_key": "key",
+            "model": "fallback/model",
+            "model_list_url": "https://example.com/models.json",
+            "provider_sort": "throughput",
+        },
+    })
+
+    assert isinstance(client, FallbackOpenAIClient)
+    assert all(c.provider_sort == "throughput" for c in client._clients)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -78,3 +78,50 @@ def test_fallback_client_chat_falls_back_too():
         client = FallbackOpenAIClient(api_key="key", models=["model-a", "model-b"])
 
     assert client.chat([{"role": "user", "content": "hi"}]) == "chat ok from b"
+
+
+from engine.extractor.llm_client import create_llm_client
+
+
+def test_create_llm_client_openai_without_model_list_url_returns_openai_client():
+    client = create_llm_client({
+        "provider": "openai",
+        "openai": {"api_key": "key", "model": "gpt-4o-mini"},
+    })
+
+    assert isinstance(client, OpenAIClient)
+    assert client.model == "gpt-4o-mini"
+
+
+def test_create_llm_client_openai_with_empty_model_list_url_returns_openai_client():
+    client = create_llm_client({
+        "provider": "openai",
+        "openai": {"api_key": "key", "model": "gpt-4o-mini", "model_list_url": ""},
+    })
+
+    assert isinstance(client, OpenAIClient)
+
+
+def test_create_llm_client_openai_with_model_list_url_returns_fallback_client(tmp_path, monkeypatch):
+    cache_path = tmp_path / "model-cache.json"
+    monkeypatch.setattr(
+        "engine.extractor.model_source.DEFAULT_CACHE_PATH", cache_path
+    )
+
+    def fetch_fn(url):
+        import json as _json
+        return _json.dumps({"models": [{"id": "list/model-a"}, {"id": "list/model-b"}]}).encode()
+
+    monkeypatch.setattr("engine.extractor.llm_client._default_fetch_fn", fetch_fn)
+
+    client = create_llm_client({
+        "provider": "openai",
+        "openai": {
+            "api_key": "key",
+            "model": "fallback/model",
+            "model_list_url": "https://example.com/models.json",
+        },
+    })
+
+    assert isinstance(client, FallbackOpenAIClient)
+    assert client.models == ["list/model-a", "list/model-b", "fallback/model"]

--- a/tests/test_model_source.py
+++ b/tests/test_model_source.py
@@ -1,0 +1,43 @@
+"""Tests for engine.extractor.model_source cache helpers."""
+
+import json
+
+from engine.extractor.model_source import _read_cache, _write_cache
+
+
+def test_read_cache_missing_file_returns_none(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+
+    assert _read_cache(cache_path) is None
+
+
+def test_read_cache_invalid_json_returns_none(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    cache_path.write_text("not json")
+
+    assert _read_cache(cache_path) is None
+
+
+def test_write_cache_then_read_round_trips(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    data = {
+        "url": "https://example.com/models.json",
+        "fetched_at": 1000.0,
+        "content_hash": "abc123",
+        "models": ["a/model", "b/model"],
+    }
+
+    _write_cache(cache_path, data)
+
+    assert _read_cache(cache_path) == data
+    assert json.loads(cache_path.read_text()) == data
+
+
+def test_write_cache_creates_parent_directory(tmp_path):
+    cache_path = tmp_path / "nested" / "dir" / "model-cache.json"
+    data = {"url": "x", "fetched_at": 0.0, "content_hash": "h", "models": []}
+
+    _write_cache(cache_path, data)
+
+    assert cache_path.exists()
+    assert _read_cache(cache_path) == data

--- a/tests/test_model_source.py
+++ b/tests/test_model_source.py
@@ -3,7 +3,13 @@
 import hashlib
 import json
 
-from engine.extractor.model_source import _read_cache, _refresh, _write_cache
+from engine.extractor.model_source import (
+    CACHE_TTL_SECONDS,
+    _read_cache,
+    _refresh,
+    _write_cache,
+    get_model_candidates,
+)
 
 
 def test_read_cache_missing_file_returns_none(tmp_path):
@@ -155,3 +161,119 @@ def test_refresh_malformed_json_with_no_cache_returns_none(tmp_path):
     )
 
     assert models is None
+
+
+def test_get_model_candidates_no_url_returns_only_configured_model(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    config = {"model": "openrouter/owl-alpha"}
+
+    candidates = get_model_candidates(config, cache_path=cache_path, now=1000.0)
+
+    assert candidates == ["openrouter/owl-alpha"]
+
+
+def test_get_model_candidates_empty_url_returns_only_configured_model(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    config = {"model": "openrouter/owl-alpha", "model_list_url": ""}
+
+    candidates = get_model_candidates(config, cache_path=cache_path, now=1000.0)
+
+    assert candidates == ["openrouter/owl-alpha"]
+
+
+def test_get_model_candidates_no_url_and_no_model_returns_empty(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    config = {}
+
+    candidates = get_model_candidates(config, cache_path=cache_path, now=1000.0)
+
+    assert candidates == []
+
+
+def test_get_model_candidates_fresh_cache_skips_fetch(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    url = "https://example.com/models.json"
+    _write_cache(cache_path, {
+        "url": url,
+        "fetched_at": 1000.0,
+        "content_hash": "h",
+        "models": ["a/model", "b/model"],
+    })
+
+    def fetch_should_not_be_called(url):
+        raise AssertionError("fetch_fn should not be called when cache is fresh")
+
+    candidates = get_model_candidates(
+        {"model": "fallback/model", "model_list_url": url},
+        cache_path=cache_path,
+        now=1000.0 + 60,  # well within CACHE_TTL_SECONDS
+        fetch_fn=fetch_should_not_be_called,
+    )
+
+    assert candidates == ["a/model", "b/model", "fallback/model"]
+
+
+def test_get_model_candidates_stale_cache_refetches(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    url = "https://example.com/models.json"
+    _write_cache(cache_path, {
+        "url": url,
+        "fetched_at": 1000.0,
+        "content_hash": "old-hash",
+        "models": ["a/model"],
+    })
+
+    candidates = get_model_candidates(
+        {"model": "fallback/model", "model_list_url": url},
+        cache_path=cache_path,
+        now=1000.0 + CACHE_TTL_SECONDS + 1,
+        fetch_fn=_fetch_ok(MODELS_JSON),
+    )
+
+    assert candidates == [
+        "openrouter/owl-alpha",
+        "qwen/qwen3-next-80b-a3b-instruct:free",
+        "fallback/model",
+    ]
+
+
+def test_get_model_candidates_dedupes_configured_model_already_in_list(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    url = "https://example.com/models.json"
+
+    candidates = get_model_candidates(
+        {"model": "openrouter/owl-alpha", "model_list_url": url},
+        cache_path=cache_path,
+        now=1000.0,
+        fetch_fn=_fetch_ok(MODELS_JSON),
+    )
+
+    assert candidates == ["openrouter/owl-alpha", "qwen/qwen3-next-80b-a3b-instruct:free"]
+
+
+def test_get_model_candidates_fetch_fails_no_cache_falls_back_to_configured_model(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    url = "https://example.com/models.json"
+
+    candidates = get_model_candidates(
+        {"model": "openrouter/owl-alpha", "model_list_url": url},
+        cache_path=cache_path,
+        now=1000.0,
+        fetch_fn=_fetch_raises(OSError("network down")),
+    )
+
+    assert candidates == ["openrouter/owl-alpha"]
+
+
+def test_get_model_candidates_fetch_fails_no_cache_no_configured_model_returns_empty(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    url = "https://example.com/models.json"
+
+    candidates = get_model_candidates(
+        {"model_list_url": url},
+        cache_path=cache_path,
+        now=1000.0,
+        fetch_fn=_fetch_raises(OSError("network down")),
+    )
+
+    assert candidates == []

--- a/tests/test_model_source.py
+++ b/tests/test_model_source.py
@@ -1,8 +1,9 @@
 """Tests for engine.extractor.model_source cache helpers."""
 
+import hashlib
 import json
 
-from engine.extractor.model_source import _read_cache, _write_cache
+from engine.extractor.model_source import _read_cache, _refresh, _write_cache
 
 
 def test_read_cache_missing_file_returns_none(tmp_path):
@@ -41,3 +42,116 @@ def test_write_cache_creates_parent_directory(tmp_path):
 
     assert cache_path.exists()
     assert _read_cache(cache_path) == data
+
+
+def _fetch_ok(body: bytes):
+    def fetch(url: str) -> bytes:
+        return body
+    return fetch
+
+
+def _fetch_raises(exc: Exception):
+    def fetch(url: str):
+        raise exc
+    return fetch
+
+
+MODELS_JSON = json.dumps({
+    "generated_at": "2026-06-14T00:00:00Z",
+    "schema_version": 2,
+    "models": [
+        {"id": "openrouter/owl-alpha", "score": 0.94},
+        {"id": "qwen/qwen3-next-80b-a3b-instruct:free", "score": 0.81},
+    ],
+}).encode()
+
+
+def test_refresh_parses_models_and_writes_cache(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+
+    models = _refresh(
+        url="https://example.com/models.json",
+        cache=None,
+        now=1000.0,
+        cache_path=cache_path,
+        fetch_fn=_fetch_ok(MODELS_JSON),
+    )
+
+    assert models == ["openrouter/owl-alpha", "qwen/qwen3-next-80b-a3b-instruct:free"]
+
+    cached = _read_cache(cache_path)
+    assert cached["url"] == "https://example.com/models.json"
+    assert cached["fetched_at"] == 1000.0
+    assert cached["models"] == models
+
+
+def test_refresh_unchanged_content_reuses_cached_models_and_bumps_fetched_at(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    content_hash = hashlib.sha256(MODELS_JSON).hexdigest()
+    old_cache = {
+        "url": "https://example.com/models.json",
+        "fetched_at": 1000.0,
+        "content_hash": content_hash,
+        "models": ["openrouter/owl-alpha", "qwen/qwen3-next-80b-a3b-instruct:free"],
+    }
+    _write_cache(cache_path, old_cache)
+
+    models = _refresh(
+        url="https://example.com/models.json",
+        cache=old_cache,
+        now=2000.0,
+        cache_path=cache_path,
+        fetch_fn=_fetch_ok(MODELS_JSON),
+    )
+
+    assert models == old_cache["models"]
+    assert _read_cache(cache_path)["fetched_at"] == 2000.0
+
+
+def test_refresh_fetch_error_with_matching_cache_returns_stale_models(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+    old_cache = {
+        "url": "https://example.com/models.json",
+        "fetched_at": 1000.0,
+        "content_hash": "irrelevant",
+        "models": ["openrouter/owl-alpha"],
+    }
+    _write_cache(cache_path, old_cache)
+
+    models = _refresh(
+        url="https://example.com/models.json",
+        cache=old_cache,
+        now=2000.0,
+        cache_path=cache_path,
+        fetch_fn=_fetch_raises(OSError("network down")),
+    )
+
+    assert models == ["openrouter/owl-alpha"]
+
+
+def test_refresh_fetch_error_with_no_cache_returns_none(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+
+    models = _refresh(
+        url="https://example.com/models.json",
+        cache=None,
+        now=2000.0,
+        cache_path=cache_path,
+        fetch_fn=_fetch_raises(OSError("network down")),
+    )
+
+    assert models is None
+
+
+def test_refresh_malformed_json_with_no_cache_returns_none(tmp_path):
+    cache_path = tmp_path / "model-cache.json"
+
+    models = _refresh(
+        url="https://example.com/models.json",
+        cache=None,
+        now=2000.0,
+        cache_path=cache_path,
+        fetch_fn=_fetch_ok(b"not json"),
+    )
+
+    assert models is None


### PR DESCRIPTION
Closes #49.

## Summary

`cloud/api.py`'s `rerank_results()` "Fallback: LLM rerank" path previously built its own `openai.OpenAI(api_key=openai_key)` client and called `chat.completions.create(model="gpt-4o-mini", ...)` — hardcoded, independent of `LLM_PROVIDER`/`MODEL_LIST_URL`/`LLM_MODEL` config.

This PR replaces that with `get_llm().llm.complete(prompt)` — the same `LLMClient` (`OpenAIClient`/`FallbackOpenAIClient`/`AnthropicClient`) the extraction pipeline already builds from config. Parsing of the response stays the same (fence-stripping + `json.loads()` of the index array); `.complete()` already returns the content string directly, so the `.choices[0].message.content` indexing is dropped. The `_openai_rerank_client` cache variable is removed as unused.

On self-hosted instances with `OPENAI_BASE_URL` pointed at OpenRouter and a `$0`-balance account, the old code returned `402 Payment Required` asking for `gpt-4o-mini`. The shared client now resolves dynamically via `MODEL_LIST_URL`'s `FallbackOpenAIClient` candidate chain when configured (falling back to `LLM_MODEL`/`model` only if no list is set), and never requests a model the account can't afford.

## ⚠️ Dependency on #44 / PR #45 and #46 / PR #48

**This PR's branch is based on PR #48's branch** (`claude/free-model-fallback-part1-clean`), which itself is based on PR #45's branch (`claude/free-model-fallback-clean`). The diff therefore includes:

- PR #45's commits (`model_list_url` free-model-fallback support)
- PR #48's commits (observability/none-guard/`provider_sort`)
- **This PR's one commit** (last in the list): `fix(rerank): route LLM-rerank fallback through shared free-model-fallback client`

This is **not** independent of the other two PRs — it's a direct stack on top of both. Reasoning: the rerank fallback's whole point is to inherit `get_llm()`'s `MODEL_LIST_URL`-driven `FallbackOpenAIClient` candidate chain (so it never hardcodes a single model), and that wiring in `get_llm()` only exists once PR #45/#48 land. An earlier version of this PR was based directly on `main` and only swapped `gpt-4o-mini` for a different *static* model (`LLM_MODEL`) — that didn't actually fix the underlying problem, so this PR was rebuilt on the dependency chain instead.

**Suggested merge order:** #45 → #48 → this PR. If you'd prefer this PR's single commit be reviewed/merged independently once #45/#48 land, it cherry-picks cleanly onto `main` + #45 + #48 (no overlapping lines — confirmed: #45/#48 touch `get_llm()` ~lines 451-470, this commit touches `rerank_results()` ~lines 576-625).

## Test plan

- [x] `pytest tests/test_llm_client.py tests/test_model_source.py tests/test_brain.py` — 36 passed
- [x] `python -c "import ast; ast.parse(open('cloud/api.py').read())"` — parses cleanly
- [x] Verified end-to-end on a self-hosted deployment: with `COHERE_API_KEY` set but `plan=selfhosted` (Cohere rerank currently skipped for this plan — separate follow-up planned), `/v1/search` with multiple results now returns `200` (previously `402`), with logs showing:
  ```
  HTTP Request: POST https://openrouter.ai/api/v1/chat/completions "HTTP/1.1 200 OK"
  model nvidia/nemotron-3-super-120b-a12b-20260311:free served by Nvidia
  ```
  confirming the rerank fallback resolved dynamically via `MODEL_LIST_URL`'s fallback chain (not a static hardcoded model).