### PR TITLE
fix(dashboard): keep the Memory Feed and stats strip current

### DIFF
--- a/cloud/dashboard.html
+++ b/cloud/dashboard.html
@@ -1919,6 +1919,10 @@ window.addEventListener('focus', () => {
 // minutes. This watchdog compares against the wall clock instead of trusting
 // the interval, and fires the refresh the interval owed us.
 setInterval(() => {
+    // Also re-arms a timer that never started: the plan gate is only known
+    // once /v1/me answers, so a slow or failed response can leave the feature
+    // available but idle. _sync is a no-op when it is already running.
+    _syncFeedAutoRefresh();
     if (!_feedTimer) return;
     if (Date.now() - _feedLastRefresh < FEED_REFRESH_MS * 1.5) return;
     _feedLastRefresh = Date.now();
@@ -2357,6 +2361,11 @@ async function loadAccount() {
             _plan = d.plan || '';
             const arSection = document.getElementById('feed-autorefresh-section');
             if (arSection) arSection.style.display = _feedAutoRefreshAvailable() ? '' : 'none';
+            // The plan gates auto-refresh, and it only arrives here — after the
+            // initial switchTabDirect() has already run and found the feature
+            // unavailable. Without this the timer never starts on a fresh load,
+            // and only a later tab switch brings it to life.
+            _syncFeedAutoRefresh();
             document.getElementById('account-email').textContent = d.email;
             document.getElementById('account-email').title = d.email;
             const planEl = document.getElementById('account-plan');

--- a/cloud/dashboard.html
+++ b/cloud/dashboard.html
@@ -505,6 +505,63 @@
         .stagger > *:nth-child(8) { animation-delay: 0.16s; }
         @keyframes staggerIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 
+        /* Rows added by the background feed refresh slide down from the divider
+           instead of the whole list blanking to a skeleton. The row grows its
+           own height from 0 rather than appearing at full height, so the rows
+           below glide down instead of being shoved — that jump is what read as
+           a black flicker when several rows arrived at once. */
+        /* The row itself only fades and slides — opacity and transform are
+           composited, so its background is never repainted mid-flight. That
+           repaint was the flicker: animating max-height/padding on .feed-item
+           made its shade shift frame by frame, and its `transition: all` was
+           tweening the same properties in parallel.
+
+           The push-down is handled by a wrapper instead, which has no
+           background of its own, so growing its height moves the rows below
+           smoothly with nothing to repaint. */
+        /* The row opens its height; its *contents* fade. Fading the row itself
+           made it translucent, so the darker page behind showed through and
+           every row in a staggered batch sat at a different opacity — read as
+           rows having different brightness. The card must stay opaque. */
+        @keyframes feedItemIn {
+            from {
+                max-height: 0;
+                padding-top: 0;
+                padding-bottom: 0;
+                border-top-width: 0;
+                border-bottom-width: 0;
+            }
+            to {
+                max-height: 240px;
+                padding-top: 14px;
+                padding-bottom: 14px;
+                border-top-width: 1px;
+                border-bottom-width: 1px;
+            }
+        }
+        @keyframes feedItemContentIn {
+            from { opacity: 0; transform: translateY(-4px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+        /* Delay is set per row in JS (--feed-stagger): nth-child would count the
+           date dividers between rows, not just the newly inserted ones. */
+        .feed-item-new {
+            animation: feedItemIn 0.7s cubic-bezier(0.22, 0.7, 0.3, 1) backwards;
+            animation-delay: var(--feed-stagger, 0s);
+            overflow: hidden;
+            /* No opacity here — the card stays fully opaque so its shade never
+               differs from a settled row. `transition: all` on .feed-item would
+               tween these same properties in parallel, so it is off. */
+            transition: none;
+        }
+        .feed-item-new > * {
+            animation: feedItemContentIn 0.5s ease-out backwards;
+            animation-delay: calc(var(--feed-stagger, 0s) + 0.12s);
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .feed-item-new, .feed-item-new > * { animation: none; }
+        }
+
         @media (max-width: 768px) {
             .graph-search input { width: 140px; }
             .graph-search input:focus { width: 180px; }
@@ -1224,6 +1281,14 @@
                     <button onclick="createWebhook()" style="padding:8px 16px;background:var(--accent);color:#fff;border:none;border-radius:8px;cursor:pointer;font-size:13px;font-weight:500;">+ Add</button>
                 </div>
             </div>
+            <div class="set-section" id="feed-autorefresh-section" style="display:none;">
+                <h3>Feed Auto-Refresh</h3>
+                <p>Reload the Feed every 30 seconds while it is open, so new memories appear without a page reload.</p>
+                <label style="display:flex;align-items:center;gap:8px;margin-top:10px;font-size:13px;cursor:pointer;">
+                    <input type="checkbox" id="feed-autorefresh" onchange="setFeedAutoRefresh(this.checked)" style="cursor:pointer;">
+                    Enable auto-refresh
+                </label>
+            </div>
             <div class="set-section">
                 <h3>Teams — Shared Memory</h3>
                 <p>Share memories with your team. Everyone's AI sees the shared context.</p>
@@ -1798,6 +1863,68 @@ function _updateNavHighlighting(t) {
     document.querySelectorAll('.nav-sub').forEach(s => s.classList.toggle('active', s.dataset.tab === t));
 }
 
+// ---- Feed auto-refresh (opt-in, Settings) ----
+// Polling costs the server a request per open tab per interval, so the toggle
+// is exposed on self-hosted only. Flip to true to offer it on hosted plans too.
+const FEED_REFRESH_ALL_PLANS = false;
+const FEED_REFRESH_MS = 30000;
+let _feedTimer = null;
+let _feedLastRefresh = 0;
+let _plan = '';
+
+function _feedAutoRefreshAvailable() { return FEED_REFRESH_ALL_PLANS || _plan === 'selfhosted'; }
+function _feedAutoRefreshOn() { return _feedAutoRefreshAvailable() && localStorage.getItem('mengram_feed_autorefresh') === '1'; }
+
+// Timer runs only while the Feed tab is the visible one; re-evaluated on tab
+// switch, on toggle, and when the browser tab regains visibility.
+function _syncFeedAutoRefresh() {
+    const active = _feedAutoRefreshOn()
+        && document.getElementById('tab-feed')?.classList.contains('active')
+        && !document.hidden;
+    if (active && !_feedTimer) {
+        // Catch up immediately: the timer is stopped while the tab is hidden,
+        // so coming back would otherwise mean waiting a full interval before
+        // seeing anything that arrived in the meantime.
+        loadFeed(true);
+        _feedLastRefresh = Date.now();
+        _feedTimer = setInterval(() => {
+            _feedLastRefresh = Date.now();
+            loadFeed(true);
+        }, FEED_REFRESH_MS);
+    } else if (!active && _feedTimer) { clearInterval(_feedTimer); _feedTimer = null; }
+}
+
+function setFeedAutoRefresh(on) {
+    localStorage.setItem('mengram_feed_autorefresh', on ? '1' : '0');
+    _syncFeedAutoRefresh();
+}
+
+document.addEventListener('visibilitychange', _syncFeedAutoRefresh);
+// A window on a second monitor stays visible but unfocused, and browsers may
+// still throttle its timers. Refocusing it catches up rather than waiting out
+// whatever remains of the interval.
+// Re-evaluate rather than assuming a timer is already running: a window on a
+// second monitor stays visible but unfocused, and a browser that throttled or
+// dropped its timers there would otherwise never restart them. _sync starts the
+// timer and refreshes immediately when it does; refresh here too for the case
+// where it was already running but throttled.
+window.addEventListener('focus', () => {
+    const had = _feedTimer;
+    _syncFeedAutoRefresh();
+    if (had && _feedTimer) loadFeed(true);
+});
+
+// setInterval is not a dependable clock: an unfocused window (second monitor)
+// can have its timers throttled or coalesced, and the feed then sits still for
+// minutes. This watchdog compares against the wall clock instead of trusting
+// the interval, and fires the refresh the interval owed us.
+setInterval(() => {
+    if (!_feedTimer) return;
+    if (Date.now() - _feedLastRefresh < FEED_REFRESH_MS * 1.5) return;
+    _feedLastRefresh = Date.now();
+    loadFeed(true);
+}, 5000);
+
 function switchTabDirect(t) {
     _updateNavHighlighting(t);
     document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
@@ -1814,14 +1941,24 @@ function switchTabDirect(t) {
     const url = new URL(window.location);
     url.searchParams.set('tab', t);
     history.replaceState(null, '', url);
+    // The stats strip is only rendered on Memory tabs, and nothing refreshes it
+    // after login — memories added from outside the dashboard (MCP, API) left
+    // the counters stale until a page reload.
+    if (isMemory) loadStats();
     if (t === 'graph' && !_isCached('graph')) loadGraph();
     if (t === 'entities' && !_isCached('entities')) loadEntities();
+    if (t === 'feed') loadFeed();
     if (t === 'overview') loadIntelligence();
     if (t === 'insights') loadInsights();
     if (t === 'agents') loadAgentHistory();
     if (t === 'procedures') loadProcedures();
     if (t === 'billing') loadBilling();
-    if (t === 'settings') { loadWebhooks(); loadTeams(); loadKeys(); loadCapturePolicy(); }
+    if (t === 'settings') {
+        loadWebhooks(); loadTeams(); loadKeys(); loadCapturePolicy();
+        const cb = document.getElementById('feed-autorefresh');
+        if (cb) cb.checked = _feedAutoRefreshOn();
+    }
+    _syncFeedAutoRefresh();
 }
 
 function switchGroup(e, group) {
@@ -1875,6 +2012,7 @@ function logout() {
     document.getElementById('login-screen').style.display = '';
     document.getElementById('key-input').value = '';
     document.getElementById('login-error').style.display = 'none';
+    if (_feedTimer) { clearInterval(_feedTimer); _feedTimer = null; }
     showKeyLogin();
 }
 function showResetFlow() {
@@ -1975,32 +2113,9 @@ async function tryLogin(k) {
 }
 
 function switchTab(e, t) {
-    _updateNavHighlighting(t);
-    document.querySelectorAll('.tab-content').forEach(c=>c.classList.remove('active'));
-    document.getElementById('tab-'+t).classList.add('active');
-    // Show/hide Quick Add + Stats (search tab has its own UI)
-    const isMemory = TAB_GROUPS.memory.tabs.includes(t) && t !== 'search';
-    const qa = document.getElementById('quick-add');
-    const ss = document.querySelector('.stats-strip');
-    if (qa) qa.style.display = isMemory ? '' : 'none';
-    if (ss) ss.style.display = isMemory ? '' : 'none';
-    const ob = document.getElementById('onboarding-checklist');
-    if (ob && localStorage.getItem('mengram_ob_active') === '1') ob.style.display = isMemory ? '' : 'none';
-    // Update URL
-    const url = new URL(window.location);
-    url.searchParams.set('tab', t);
-    history.replaceState(null, '', url);
-    // Close mobile menu on tab switch
     const sidebar = document.querySelector('.sidebar');
-    if (sidebar.classList.contains('open')) toggleMobileMenu();
-    if(t==='graph' && !_isCached('graph')) loadGraph();
-    if(t==='entities' && !_isCached('entities')) loadEntities();
-    if(t==='overview') loadIntelligence();
-    if(t==='insights') loadInsights();
-    if(t==='agents') loadAgentHistory();
-    if(t==='procedures') loadProcedures();
-    if(t==='billing') loadBilling();
-    if(t==='settings') { loadWebhooks(); loadTeams(); loadKeys(); loadCapturePolicy(); }
+    if (sidebar && sidebar.classList.contains('open')) toggleMobileMenu();
+    switchTabDirect(t);
 }
 
 async function loadAll() { _updateNavHighlighting('graph'); loadStats(); loadGraph(); loadFeed(); loadAccount(); }
@@ -2239,6 +2354,9 @@ async function loadAccount() {
         const r = await fetch(`${API}/v1/me`, { headers: {'Authorization':`Bearer ${KEY}`} });
         if (r.ok) {
             const d = await r.json();
+            _plan = d.plan || '';
+            const arSection = document.getElementById('feed-autorefresh-section');
+            if (arSection) arSection.style.display = _feedAutoRefreshAvailable() ? '' : 'none';
             document.getElementById('account-email').textContent = d.email;
             document.getElementById('account-email').title = d.email;
             const planEl = document.getElementById('account-plan');
@@ -2903,7 +3021,81 @@ document.getElementById('quick-add-input')?.addEventListener('keydown', e => {
 
 // ---- Feed ----
 let _feedOffset = 0;
+let _feedTotal = null;
 const FEED_PAGE = 30;
+
+// Background refresh: diff against what's on screen by fact id and slide in
+// only the new rows. Silent on network errors — the visible list stays put
+// rather than collapsing into an error state under the user's cursor.
+async function _refreshFeedQuietly(box) {
+    const list = document.getElementById('feed-list');
+    if (!list) return;
+
+    // Cheap probe first: /v1/feed?limit=1 answers with the same `total` as a
+    // full page, so an unchanged feed costs one tiny request and touches
+    // nothing — no re-render, no DOM work, no scroll disturbance.
+    // A failed probe (server restarting, HTML error page instead of JSON) must
+    // not be treated as "nothing changed" — fall through to the full fetch so a
+    // blip cannot freeze the feed until a manual reload.
+    let head = null;
+    try {
+        head = await (await fetch(`${API}/v1/feed?limit=1&offset=0`, {headers:H()})).json();
+    } catch (e) { /* fall through */ }
+    if (head && typeof head.total === 'number' && head.total === _feedTotal) return;
+
+    // Fetch enough to cover what actually arrived. A single page is 30 rows,
+    // but extraction lands in bursts — two waves between probes can exceed
+    // that, and the overflow would be silently skipped: the rows never appear,
+    // and tabs that polled at different moments end up holding different
+    // subsets of the same feed.
+    const missing = (typeof head?.total === 'number' && typeof _feedTotal === 'number')
+        ? head.total - _feedTotal : 0;
+    const want = Math.min(Math.max(FEED_PAGE, missing + 5), 200);
+    let d;
+    try {
+        d = await (await fetch(`${API}/v1/feed?limit=${want}&offset=0`, {headers:H()})).json();
+    } catch (e) { return; }
+    if (!d.feed || !d.feed.length) return;
+    _feedOffset = Math.max(_feedOffset, d.feed.length);
+
+    const onScreen = new Set([...list.querySelectorAll('.feed-item')].map(el => el.dataset.factId));
+    const fresh = d.feed.filter(it => !onScreen.has(String(it.id)));
+    // Counters live above the feed and move with it, so refresh them whenever
+    // the feed itself changed — including when the change is a deletion.
+    loadStats();
+    // Only remember this total once the rows are actually on screen. Recording
+    // it earlier means any later bail-out leaves the probe thinking it is up to
+    // date, and the feed then stays frozen until a manual reload.
+    if (!fresh.length) { _feedTotal = d.total; return; }
+
+    // Rows belong under the first date divider, not above it: the divider
+    // labels the group ("Today"), so inserting before it strands new rows
+    // outside any group.
+    const anchor = list.querySelector('.feed-date-divider');
+    const after = anchor ? anchor.nextSibling : list.firstChild;
+    // The response is newest-first and must stay that way on screen. Walk it in
+    // order and advance the insertion point past each row: inserting every row
+    // before one fixed anchor would reverse the batch, since each new row lands
+    // between the anchor and the row inserted before it.
+    // Every row staggers, uncapped: a cap made the first few cascade and then
+    // dumped the remainder as one block, which hides how much arrived and how
+    // far there is to scroll. Steps shorten as the batch grows so a large burst
+    // still finishes in roughly the same time as a small one.
+    const step = fresh.length > 20 ? 0.05 : fresh.length > 10 ? 0.09 : 0.18;
+    fresh.forEach((it, i) => {
+        const tmp = document.createElement('div');
+        tmp.innerHTML = _renderFeedItem(it);
+        const el = tmp.firstElementChild;
+        el.classList.add('feed-item-new');
+        el.style.setProperty('--feed-stagger', `${(i * step).toFixed(2)}s`);
+        list.insertBefore(el, after);
+    });
+    _feedTotal = d.total;
+    // Drop the marker once the last row has finished, so re-renders don't replay it.
+    setTimeout(() => list.querySelectorAll('.feed-item-new')
+        .forEach(el => { el.classList.remove('feed-item-new'); el.style.removeProperty('--feed-stagger'); }),
+        1000 + Math.min(fresh.length, 6) * 180);
+}
 
 function _renderFeedItem(it) {
     const _bt = it.entity_type||'concept';
@@ -2913,24 +3105,29 @@ function _renderFeedItem(it) {
     const impPct = Math.round(imp * 100);
     const impColor = imp >= 0.8 ? 'var(--accent)' : imp >= 0.6 ? 'var(--blue)' : imp >= 0.4 ? 'var(--text-3)' : 'var(--border)';
     const accInfo = it.access_count > 0 ? ` · recalled ${it.access_count}×` : '';
-    return `<div class="feed-item">
+    return `<div class="feed-item" data-fact-id="${escA(String(it.id))}">
         <span class="feed-badge ${bc}" style="${_badgeStyle(_bt)}">${esc(it.entity)}</span>
         <div class="feed-content"><div class="feed-fact">${esc(it.fact)}</div><div class="feed-meta">${tm}<span class="feed-imp" title="Importance: ${impPct}%"><span class="feed-imp-bar"><span class="feed-imp-fill" style="width:${impPct}%;background:${impColor}"></span></span><span class="feed-imp-label">${impPct}%</span></span>${accInfo}</div></div>
         <button class="feed-del" onclick="archFact('${escA(it.id)}','${escA(it.entity)}','${escA(it.fact)}',this)" title="Delete">✕</button>
     </div>`;
 }
 
-async function loadFeed() {
+// `quiet` = background auto-refresh: keep the current list on screen and
+// slide in only what's new, instead of blanking the feed to a skeleton.
+async function loadFeed(quiet = false) {
     _feedOffset = 0;
     const box = document.getElementById('feed-box');
+    if (quiet && document.getElementById('feed-list')) return _refreshFeedQuietly(box);
     box.innerHTML = renderSkeleton('feed');
     try {
         const d = await (await fetch(`${API}/v1/feed?limit=${FEED_PAGE}&offset=0`,{headers:H()})).json();
         if(!d.feed||!d.feed.length) {
+            _feedTotal = 0;
             box.innerHTML = `<div class="empty"><div class="eicon">${I.list}</div><h3>Your memory is empty</h3><p>Use <a href="/">Claude Desktop MCP</a> or the <a href="https://pypi.org/project/mengram-ai/">Python API</a> to start building your AI memory.</p></div>`;
             return;
         }
         _feedOffset = d.feed.length;
+        _feedTotal = d.total;
         let h='<div class="feed-list" id="feed-list">',last='';
         for(const it of d.feed) {
             const dt = _relativeDate(it.created_at);

--- a/cloud/dashboard.html
+++ b/cloud/dashboard.html
@@ -2880,12 +2880,27 @@ async function triggerReflection() {
     }
 }
 
+// Counters animate, so a second call can arrive while the first is still
+// running — the feed refresh triggers one on every change. Two live loops on
+// one element interleave writes and the value settles wherever the last frame
+// happened to land, which is how a counter ends up showing a number the server
+// never reported. Each run therefore claims the element and stops as soon as a
+// newer run takes over: the most recent target always wins.
+let _countUpRun = 0;
 function countUp(el, target, duration=600) {
-    const start = parseInt(el.textContent) || 0;
-    if (start === target) return;
+    if (!el) return;
+    const run = ++_countUpRun;
+    el.dataset.countRun = String(run);
+    // Read the pending target, not the rendered text: mid-animation the text is
+    // a rounded in-between frame, and starting from it drops the remainder.
+    const start = Number(el.dataset.countTarget ?? el.textContent) || 0;
+    el.dataset.countTarget = String(target);
+    if (start === target) { el.textContent = target; return; }
     const step = (target - start) / (duration / 16);
     let current = start;
     const tick = () => {
+        // A newer countUp owns the element now; this loop must not write again.
+        if (el.dataset.countRun !== String(run)) return;
         current += step;
         if ((step > 0 && current >= target) || (step < 0 && current <= target)) {
             el.textContent = target;
@@ -3069,13 +3084,10 @@ async function _refreshFeedQuietly(box) {
 
     const onScreen = new Set([...list.querySelectorAll('.feed-item')].map(el => el.dataset.factId));
     const fresh = d.feed.filter(it => !onScreen.has(String(it.id)));
-    // Counters live above the feed and move with it, so refresh them whenever
-    // the feed itself changed — including when the change is a deletion.
-    loadStats();
     // Only remember this total once the rows are actually on screen. Recording
     // it earlier means any later bail-out leaves the probe thinking it is up to
     // date, and the feed then stays frozen until a manual reload.
-    if (!fresh.length) { _feedTotal = d.total; return; }
+    if (!fresh.length) { _feedTotal = d.total; _refreshStatsAfterFeed(); return; }
 
     // Rows belong under the first date divider, not above it: the divider
     // labels the group ("Today"), so inserting before it strands new rows
@@ -3100,10 +3112,28 @@ async function _refreshFeedQuietly(box) {
         list.insertBefore(el, after);
     });
     _feedTotal = d.total;
+    _refreshStatsAfterFeed();
     // Drop the marker once the last row has finished, so re-renders don't replay it.
     setTimeout(() => list.querySelectorAll('.feed-item-new')
         .forEach(el => { el.classList.remove('feed-item-new'); el.style.removeProperty('--feed-stagger'); }),
         1000 + Math.min(fresh.length, 6) * 180);
+}
+
+// The counters sit above the feed and have to move with it. Reading /v1/stats
+// only after the feed response is in keeps the two in order: anything that
+// landed in between shows up as a counter ahead of the rows, never behind them.
+// Firing both at once instead let the two responses cross, and the counter
+// settled on a value that matched neither the rows on screen nor the database.
+//
+// This bounds the gap to one request; it cannot close it. /v1/stats and
+// /v1/feed are separate queries, so with extraction running there is always
+// real movement between them. An exact counter needs both served from one
+// snapshot — the feed response carrying the counts — which is an API change.
+let _statsAfterFeed = null;
+function _refreshStatsAfterFeed() {
+    // Collapse bursts: several refreshes in flight should cost one stats read.
+    if (_statsAfterFeed) clearTimeout(_statsAfterFeed);
+    _statsAfterFeed = setTimeout(() => { _statsAfterFeed = null; loadStats(); }, 120);
 }
 
 function _renderFeedItem(it) {

--- a/tests/test_dashboard_tab_refresh.js
+++ b/tests/test_dashboard_tab_refresh.js
@@ -1,0 +1,239 @@
+// Regression: switching to the Feed tab must reload it. Before this test's fix,
+// loadFeed() ran only once at login, so the feed was stale until a page reload.
+// Runs the real switchTab/switchTabDirect source against a stub DOM — no deps.
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const html = fs.readFileSync(path.join(__dirname, '../cloud/dashboard.html'), 'utf8');
+const scripts = [...html.matchAll(/<script(?![^>]*src=)[^>]*>([\s\S]*?)<\/script>/g)]
+    .map(m => m[1]).join('\n');
+
+function clickTab(tab) {
+    const src = scripts.match(/function switchTabDirect\(t\)[\s\S]*?\n\}/)[0]
+        + '\n' + scripts.match(/function switchTab\(e, t\)[\s\S]*?\n\}/)[0];
+    const calls = [];
+    const stub = () => ({
+        classList: { remove() {}, add() {}, toggle() {}, contains: () => false },
+        style: {}, dataset: {}, querySelector: () => null, querySelectorAll: () => [],
+    });
+    const sandbox = {
+        document: {
+            getElementById: () => stub(),
+            querySelector: () => null, querySelectorAll: () => [], addEventListener() {},
+        },
+        history: { replaceState() {} },
+        window: { location: 'https://example/?tab=graph' },
+        URL: class { constructor() { this.searchParams = { set() {} }; } },
+        localStorage: { getItem: () => null, setItem() {} },
+        TAB_GROUPS: { memory: { tabs: ['graph', 'search', 'feed', 'entities'] } },
+        _updateNavHighlighting() {}, _isCached: () => true,
+        _syncFeedAutoRefresh() {}, toggleMobileMenu() {}, _feedAutoRefreshOn: () => false,
+    };
+    for (const fn of ['loadGraph', 'loadEntities', 'loadFeed', 'loadIntelligence', 'loadInsights',
+        'loadAgentHistory', 'loadProcedures', 'loadBilling', 'loadWebhooks', 'loadTeams',
+        'loadKeys', 'loadCapturePolicy', 'loadStats']) sandbox[fn] = () => { calls.push(fn); };
+    const keys = Object.keys(sandbox);
+    new Function(...keys, `${src}; switchTab(null, ${JSON.stringify(tab)});`)(...keys.map(k => sandbox[k]));
+    return calls;
+}
+
+assert(clickTab('feed').includes('loadFeed'), 'Feed tab must reload feed data on switch');
+// The stats strip sits above the Memory tabs and was stale for the same reason.
+assert(clickTab('feed').includes('loadStats'), 'Memory tabs must refresh the stats strip');
+assert(!clickTab('billing').includes('loadStats'), 'stats strip is hidden outside Memory, do not refetch');
+assert(clickTab('insights').includes('loadInsights'), 'Insights tab must still load');
+assert(!clickTab('graph').includes('loadGraph'), 'Graph stays cached within its TTL');
+
+// switchTab must stay a thin wrapper — a second dispatch block is how feed
+// silently fell out of sync in the first place.
+assert.strictEqual((scripts.match(/loadCapturePolicy\(\)/g) || []).length, 2,
+    'tab-load dispatch should exist in exactly one place (plus its definition)');
+
+// Auto-refresh is self-hosted-only by default; the maintainer can enable it
+// for hosted plans by flipping one constant.
+function autoRefreshGate(plan, stored, allPlans) {
+    const src = scripts.match(/const FEED_REFRESH_ALL_PLANS[\s\S]*?function _feedAutoRefreshOn\(\)[^\n]*\n/)[0]
+        .replace(/const FEED_REFRESH_ALL_PLANS = false;/, `const FEED_REFRESH_ALL_PLANS = ${allPlans};`)
+        .replace(/let _plan = '';/, `let _plan = ${JSON.stringify(plan)};`);
+    return new Function('localStorage',
+        `${src}; return _feedAutoRefreshOn();`)({ getItem: () => stored });
+}
+
+assert(autoRefreshGate('selfhosted', '1', false), 'self-hosted + enabled => on');
+assert(!autoRefreshGate('selfhosted', null, false), 'self-hosted + not enabled => off');
+assert(!autoRefreshGate('pro', '1', false), 'hosted plan must not poll even if localStorage says on');
+assert(autoRefreshGate('pro', '1', true), 'maintainer can opt hosted plans in');
+
+// A background refresh must not blank the list to a skeleton, must insert only
+// rows that aren't on screen, must place them under the date divider, and must
+// do nothing at all when the backend total is unchanged.
+const quietSrc = scripts.match(/async function _refreshFeedQuietly\(box\)[\s\S]*?\n\}/)[0];
+
+function runQuietRefresh({ total, feedTotal }) {
+    const divider = { __id: 'DIVIDER' };
+    const sibling = { __id: 'first-row' };
+    const inserted = [];
+    const requests = [];
+    const list = {
+        querySelectorAll: () => ['a', 'b'].map(id => ({ dataset: { factId: id }, classList: { remove() {} } })),
+        querySelector: sel => (sel === '.feed-date-divider' ? divider : null),
+        insertBefore: (el, ref) => inserted.push([el.__id, ref === sibling ? 'after-divider' : 'TOP', el.style.__delay]),
+        firstChild: divider,
+    };
+    divider.nextSibling = sibling;
+    let statsLoaded = false;
+    const sandbox = {
+        API: '', H: () => ({}), FEED_PAGE: 30,
+        _feedOffset: 0, _feedTotal: feedTotal,
+        fetch: async (url) => {
+            requests.push(url);
+            return { json: async () => ({ feed: [{ id: 'c' }, { id: 'b' }, { id: 'a' }], total }) };
+        },
+        document: {
+            getElementById: id => (id === 'feed-list' ? list : null),
+            createElement: () => ({
+                set innerHTML(v) {
+                    this.firstElementChild = {
+                        __id: v,
+                        classList: { add() {} },
+                        style: { setProperty(k, val) { this.__delay = val; }, removeProperty() {} },
+                    };
+                },
+            }),
+        },
+        _renderFeedItem: it => it.id,
+        loadStats: () => { statsLoaded = true; },
+        setTimeout: () => {},
+    };
+    const keys = Object.keys(sandbox);
+    new Function(...keys, `${quietSrc}; return _refreshFeedQuietly(null);`)(...keys.map(k => sandbox[k]));
+    return { inserted, requests, get statsLoaded() { return statsLoaded; } };
+}
+
+// Same harness, but nothing on screen matches — so all three rows are new.
+function runQuietRefreshBatch() {
+    const inserted = [];
+    const divider = { __id: 'DIVIDER' };
+    const sibling = { __id: 'first-row' };
+    divider.nextSibling = sibling;
+    const list = {
+        querySelectorAll: () => [],
+        querySelector: () => divider,
+        insertBefore: (el, ref) => inserted.push([el.__id, ref === sibling ? 'after-divider' : 'TOP', el.style.__delay]),
+        firstChild: divider,
+    };
+    const sandbox = {
+        API: '', H: () => ({}), FEED_PAGE: 30, _feedOffset: 0, _feedTotal: 0,
+        fetch: async () => ({ json: async () => ({ feed: [{ id: 'x' }, { id: 'y' }, { id: 'z' }], total: 3 }) }),
+        document: {
+            getElementById: id => (id === 'feed-list' ? list : null),
+            createElement: () => ({
+                set innerHTML(v) {
+                    this.firstElementChild = {
+                        __id: v,
+                        classList: { add() {} },
+                        style: { setProperty(k, val) { this.__delay = val; }, removeProperty() {} },
+                    };
+                },
+            }),
+        },
+        _renderFeedItem: it => it.id,
+        loadStats: () => {},
+        setTimeout: () => {},
+    };
+    const keys = Object.keys(sandbox);
+    new Function(...keys, `${quietSrc}; return _refreshFeedQuietly(null);`)(...keys.map(k => sandbox[k]));
+    return { inserted };
+}
+
+// Regression: the feed froze until a manual reload because _feedTotal was
+// recorded before the rows were on screen. Any bail-out after that point left
+// the probe believing it was up to date.
+{
+    const bodyAfterProbe = quietSrc.slice(quietSrc.indexOf('let d;'));
+    const insertLoop = bodyAfterProbe.indexOf('list.insertBefore');
+    // The only assignment before the insert loop is the no-new-rows early
+    // return, where recording the total is correct; the insert path must
+    // record it only afterwards.
+    assert(bodyAfterProbe.lastIndexOf('_feedTotal = d.total') > insertLoop,
+        '_feedTotal must only be recorded after the rows are inserted');
+    const beforeLoop = bodyAfterProbe.slice(0, insertLoop);
+    assert(!/_feedTotal = d\.total;\s*$/.test(beforeLoop.trimEnd()),
+        'no unconditional total update on the insert path before rows land');
+    // A probe that throws must fall through to the full fetch, not return.
+    assert(/catch \(e\) \{ \/\* fall through \*\/ \}/.test(quietSrc),
+        'a failed probe must not be treated as "nothing changed"');
+}
+
+// Regression: bursts larger than one page silently lost rows. The probe knows
+// how many facts appeared, so the refetch must ask for at least that many —
+// otherwise the overflow is never rendered and never seen as "new" again.
+{
+    const requested = [];
+    const list = {
+        querySelectorAll: () => [],
+        querySelector: () => null,
+        insertBefore: () => {},
+        firstChild: null,
+    };
+    const sandbox = {
+        API: '', H: () => ({}), FEED_PAGE: 30,
+        _feedOffset: 0, _feedTotal: 1000,
+        fetch: async (url) => {
+            requested.push(url);
+            // probe answers first, then the full page
+            return { json: async () => ({ feed: [{ id: 'n' }], total: 1042 }) };
+        },
+        document: {
+            getElementById: id => (id === 'feed-list' ? list : null),
+            createElement: () => ({
+                set innerHTML(v) {
+                    this.firstElementChild = {
+                        __id: v, classList: { add() {} },
+                        style: { setProperty() {}, removeProperty() {} },
+                    };
+                },
+            }),
+        },
+        _renderFeedItem: it => it.id,
+        loadStats: () => {},
+        setTimeout: () => {},
+    };
+    const keys = Object.keys(sandbox);
+    new Function(...keys, `${quietSrc}; return _refreshFeedQuietly(null);`)(...keys.map(k => sandbox[k]));
+    setImmediate(() => {
+        const full = requested.find(u => !u.includes('limit=1&'));
+        const limit = Number(/limit=(\d+)/.exec(full)[1]);
+        assert(limit >= 42, `42 new facts must be fetched in full, asked for ${limit}`);
+    });
+}
+
+assert(!/renderSkeleton/.test(quietSrc), 'quiet refresh must never blank the list to a skeleton');
+
+const changed = runQuietRefresh({ total: 3, feedTotal: 2 });
+const unchanged = runQuietRefresh({ total: 3, feedTotal: 3 });
+
+setImmediate(() => {
+    assert.deepStrictEqual(changed.inserted, [['c', 'after-divider', '0.00s']],
+        'only new facts, inserted below the date divider, top row animating first');
+    // A batch must cascade: each row further down starts later, so the list
+    // does not lurch all at once.
+    const batch = runQuietRefreshBatch();
+    setImmediate(() => {
+        // Response order is newest-first and must be preserved on screen: the
+        // batch is inserted front-to-back against a fixed anchor. Inserting a
+        // reversed list against that same anchor flipped the feed (observed
+        // live: an older row ended up above a newer one).
+        assert.deepStrictEqual(batch.inserted.map(r => r[0]), ['x', 'y', 'z'],
+            'rows keep the response order, newest first');
+        assert.deepStrictEqual(batch.inserted.map(r => r[2]), ['0.00s', '0.18s', '0.36s'],
+            'newest row animates first, each later row delayed further');
+    });
+    assert(changed.statsLoaded, 'stats strip refreshes when the feed changed');
+    // Unchanged feed: the cheap probe fires, the full page fetch must not.
+    assert.strictEqual(unchanged.requests.length, 1, 'unchanged total costs exactly one probe request');
+    assert(unchanged.requests[0].includes('limit=1'), 'probe asks for a single row, not a full page');
+    assert.deepStrictEqual(unchanged.inserted, [], 'unchanged feed touches no DOM');
+    console.log('dashboard tab refresh: all checks passed');
+});

--- a/tests/test_dashboard_tab_refresh.js
+++ b/tests/test_dashboard_tab_refresh.js
@@ -68,7 +68,12 @@ assert(autoRefreshGate('pro', '1', true), 'maintainer can opt hosted plans in');
 // A background refresh must not blank the list to a skeleton, must insert only
 // rows that aren't on screen, must place them under the date divider, and must
 // do nothing at all when the backend total is unchanged.
-const quietSrc = scripts.match(/async function _refreshFeedQuietly\(box\)[\s\S]*?\n\}/)[0];
+// Both functions run together: the refresh hands off to the stats debouncer,
+// so exercising the real one keeps the ordering guarantee under test rather
+// than stubbing the very thing that enforces it.
+const quietSrc = scripts.match(/async function _refreshFeedQuietly\(box\)[\s\S]*?\n\}/)[0]
+    + '\nlet _statsAfterFeed = null;\n'
+    + scripts.match(/function _refreshStatsAfterFeed\(\)[\s\S]*?\n\}/)[0];
 
 function runQuietRefresh({ total, feedTotal }) {
     const divider = { __id: 'DIVIDER' };
@@ -83,6 +88,7 @@ function runQuietRefresh({ total, feedTotal }) {
     };
     divider.nextSibling = sibling;
     let statsLoaded = false;
+    let statsAt = -1;
     const sandbox = {
         API: '', H: () => ({}), FEED_PAGE: 30,
         _feedOffset: 0, _feedTotal: feedTotal,
@@ -103,12 +109,19 @@ function runQuietRefresh({ total, feedTotal }) {
             }),
         },
         _renderFeedItem: it => it.id,
-        loadStats: () => { statsLoaded = true; },
-        setTimeout: () => {},
+        loadStats: () => { statsLoaded = true; statsAt = requests.length; },
+        // Run the debounced callback straight away so the assertion sees the
+        // real effect; the marker-cleanup timeout stays a no-op (no delay arg).
+        setTimeout: (fn, ms) => { if (ms === 120) fn(); },
+        clearTimeout: () => {},
     };
     const keys = Object.keys(sandbox);
     new Function(...keys, `${quietSrc}; return _refreshFeedQuietly(null);`)(...keys.map(k => sandbox[k]));
-    return { inserted, requests, get statsLoaded() { return statsLoaded; } };
+    return {
+        inserted, requests,
+        get statsLoaded() { return statsLoaded; },
+        get statsAt() { return statsAt; },
+    };
 }
 
 // Same harness, but nothing on screen matches — so all three rows are new.
@@ -141,6 +154,7 @@ function runQuietRefreshBatch() {
         _renderFeedItem: it => it.id,
         loadStats: () => {},
         setTimeout: () => {},
+        clearTimeout: () => {},
     };
     const keys = Object.keys(sandbox);
     new Function(...keys, `${quietSrc}; return _refreshFeedQuietly(null);`)(...keys.map(k => sandbox[k]));
@@ -199,6 +213,7 @@ function runQuietRefreshBatch() {
         _renderFeedItem: it => it.id,
         loadStats: () => {},
         setTimeout: () => {},
+        clearTimeout: () => {},
     };
     const keys = Object.keys(sandbox);
     new Function(...keys, `${quietSrc}; return _refreshFeedQuietly(null);`)(...keys.map(k => sandbox[k]));
@@ -210,6 +225,71 @@ function runQuietRefreshBatch() {
 }
 
 assert(!/renderSkeleton/.test(quietSrc), 'quiet refresh must never blank the list to a skeleton');
+
+// Regression: the header counters animate, and the feed refresh starts one on
+// every change. Two overlapping runs used to leave two requestAnimationFrame
+// loops writing to the same element, each with its own step and target, and
+// whichever frame landed last decided the value — so the counter could come to
+// rest on a number the server never reported.
+function countUpRace({ from, first, second, interrupt }) {
+    const src = scripts.match(/let _countUpRun = 0;[\s\S]*?\nfunction countUp\(el, target, duration=600\)[\s\S]*?\n\}/)[0];
+    // Record every write so an abandoned run that keeps painting is visible;
+    // the final value alone cannot show it, since both runs end on their target.
+    const writes = [];
+    let _text = String(from);
+    const el = {
+        dataset: {},
+        get textContent() { return _text; },
+        set textContent(v) { _text = String(v); writes.push(Number(v)); },
+    };
+    let queue = [];
+    const sandbox = {
+        requestAnimationFrame: fn => { queue.push(fn); },
+    };
+    const keys = Object.keys(sandbox);
+    const countUp = new Function(...keys, `${src}; return countUp;`)(...keys.map(k => sandbox[k]));
+
+    countUp(el, first);
+    // Let the first animation get partway, mid-flight.
+    for (let i = 0; i < interrupt; i++) {
+        const pending = queue; queue = [];
+        pending.forEach(fn => fn());
+    }
+    const writesBeforeRetarget = writes.length;
+    countUp(el, second);
+    // Drain everything still queued, both loops included.
+    for (let i = 0; i < 500 && queue.length; i++) {
+        const pending = queue; queue = [];
+        pending.forEach(fn => fn());
+    }
+    return { final: Number(el.textContent), after: writes.slice(writesBeforeRetarget) };
+}
+
+// Interrupted mid-animation, the newest target must win exactly.
+assert.strictEqual(countUpRace({ from: 3900, first: 3991, second: 3989, interrupt: 5 }).final, 3989,
+    'a counter interrupted mid-animation must settle on the newest value');
+// Same target twice must not drift.
+assert.strictEqual(countUpRace({ from: 3900, first: 3989, second: 3989, interrupt: 5 }).final, 3989,
+    'a repeated target must settle exactly, not overshoot');
+// Downward correction after an upward run: the case seen on screen.
+assert.strictEqual(countUpRace({ from: 3989, first: 4050, second: 3991, interrupt: 3 }).final, 3991,
+    'a counter must land on the last requested value even when direction flips');
+// Interrupted before the first frame ran at all.
+assert.strictEqual(countUpRace({ from: 100, first: 900, second: 105, interrupt: 0 }).final, 105,
+    'an immediate re-target must not leave the first run animating');
+
+// The final value alone proves nothing: an abandoned run also ends by writing
+// its own target, so both implementations land on the same last number. What
+// the generation counter actually buys is that the abandoned run stops
+// painting — otherwise two tickers alternate on one element and the counter
+// visibly jitters between two unrelated values before settling.
+//
+// After a downward re-target every write must descend. A surviving upward
+// ticker interleaves rising values among them, which is exactly the jitter
+// seen on screen.
+const flip = countUpRace({ from: 3989, first: 4050, second: 3991, interrupt: 3 });
+assert(flip.after.every((v, i) => i === 0 || v <= flip.after[i - 1]),
+    `writes after a downward re-target must descend monotonically, got ${flip.after}`);
 
 const changed = runQuietRefresh({ total: 3, feedTotal: 2 });
 const unchanged = runQuietRefresh({ total: 3, feedTotal: 3 });
@@ -231,6 +311,13 @@ setImmediate(() => {
             'newest row animates first, each later row delayed further');
     });
     assert(changed.statsLoaded, 'stats strip refreshes when the feed changed');
+    // Regression: /v1/stats used to be fired alongside the feed fetch, so the
+    // two responses could cross and the counter settled on a number matching
+    // neither the rows on screen nor the database (observed live: 3991 shown,
+    // 3989 after a reload). Reading stats only after both feed requests are in
+    // keeps the counter at or ahead of the rows, never behind them.
+    assert.strictEqual(changed.statsAt, changed.requests.length,
+        'stats must be read after the feed responses, not raced against them');
     // Unchanged feed: the cheap probe fires, the full page fetch must not.
     assert.strictEqual(unchanged.requests.length, 1, 'unchanged total costs exactly one probe request');
     assert(unchanged.requests[0].includes('limit=1'), 'probe asks for a single row, not a full page');


### PR DESCRIPTION
## The bug

Switching between the Memory tabs (Search / Feed / Entities) changes the view but not the data. The Feed keeps showing whatever was there at login until you press F5.

`loadFeed()` runs once from `loadAll()` at login and is never called again. The tab-load dispatch exists in **two** near-identical copies — `switchTab()` and `switchTabDirect()` — and `feed` is missing from both. Graph and Entities are gated behind a 60s cache, which is why the Feed is where it shows most.

The stats strip above it has the same problem for the same reason: `loadStats()` runs at login and after local mutations, never on a tab switch. Memories added from outside the dashboard (MCP, API) leave ENTITIES/FACTS/RELATIONS/KNOWLEDGE frozen — visibly wrong next to a Feed that has moved on.

## The fix

`switchTab()` becomes a thin wrapper over `switchTabDirect()`, so the dispatch lives in one place, and both the feed and the stats strip load from it. No cache gate on the feed: a TTL there would reproduce the very staleness being reported.

## The auto-refresh (opt-in)

A 30s refresh for the Feed, off by default and offered on self-hosted only — polling costs a request per open tab per interval, so the toggle is exposed where the operator owns the server. `FEED_REFRESH_ALL_PLANS` opts hosted plans in with a one-line change. The gate is enforced in `_feedAutoRefreshOn()`, not just by hiding the settings section, so a preference carried over from a self-hosted instance cannot start a poll loop on a hosted plan.

It is built to be quiet and to not lose anything:

- **Probes before fetching.** `/v1/feed?limit=1` returns the same `total` as a full page; unchanged means one tiny request and zero DOM work.
- **Fetches the whole delta.** Extraction lands in bursts — 26 facts in one wave, 16 in the next were common in testing, and 58 at once happened. A fixed 30-row page silently dropped the overflow, and since each tab polls at a different moment, tabs ended up holding *different* subsets of the same feed.
- **Never blanks the list.** `loadFeed()` replaced the feed with a skeleton before the request even went out. Background refreshes diff by fact id and insert only new rows, under the first date divider rather than above it.
- **Stops when it should.** No timer while the tab is hidden, none after logout — that one polled `/v1/feed` every 30s with a cleared bearer token.

Rows animate their height open so the list glides rather than jumps, while only their *contents* fade. Fading the row itself made the card translucent, and a staggered batch then had every row at a different opacity — which reads as rows having different brightness. `.feed-item`'s `transition: all` is disabled for the duration so it cannot tween the same properties in parallel.

## Notes for review

- `document.hidden`, not `visibilityState === 'visible'`: Firefox split view renders two tabs side by side but reports only one as visible, so the timer stayed off in the tab the user was looking at.
- A watchdog compares against the wall clock every 5s. `setInterval` is not a dependable clock in an unfocused window on a second monitor — throttled timers left the feed still for minutes.
- A failed probe (server restarting, HTML error page instead of JSON) falls through to the full fetch rather than counting as "nothing changed"; `_feedTotal` is recorded only once rows are on screen. Getting that wrong froze the feed until a manual reload.

## Test plan

`tests/test_dashboard_tab_refresh.js` — no dependencies, runs the real source against a stub DOM:

```
$ node tests/test_dashboard_tab_refresh.js
dashboard tab refresh: all checks passed
```

Covers: feed reloads on tab switch; stats strip refreshes on Memory tabs only; graph stays cached; the dispatch exists in exactly one place; the self-hosted gate in all four states; quiet refresh never renders a skeleton; only genuinely new rows insert, under the divider, in response order; unchanged total costs exactly one probe; a burst larger than a page is fetched in full.

Verified live on a self-hosted instance (`plan=selfhosted`) across bursts of 9, 26, 34, 42 and 58 facts, and across four browser tabs — including one in Firefox split view and one on an unfocused second monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)