### PR TITLE
fix(cloud): invalidate the feed cache on every content write

### DIFF
--- a/cloud/store.py
+++ b/cloud/store.py
@@ -2088,6 +2088,7 @@ class CloudStore:
             cur.execute("DELETE FROM knowledge WHERE entity_id = %s", (source_id,))
             cur.execute("DELETE FROM entities WHERE id = %s", (source_id,))
 
+        self._invalidate_content_by_entity(target_id)
         logger.info(f"🔀 Merged entity {source_id} into {target_id} ({target_name})")
 
     def _auto_merge_duplicate_entities(self, user_id: str, sub_user_id: str = "default") -> int:
@@ -2426,7 +2427,29 @@ class CloudStore:
             )
 
         # Invalidate caches after write
+        self._invalidate_content(user_id)
+
+    def _invalidate_content(self, user_id: str) -> None:
+        """Drop every cache derived from a user's facts/entities.
+
+        stats and feed are cached under separate keys with different TTLs
+        (30s / 15s). Invalidating only one lets the header counters and the
+        feed disagree until the other key expires — visible as an off-by-N
+        FACTS count for up to 15s after a write or an archive.
+        """
         self.cache.invalidate(f"stats:{user_id}")
+        self.cache.invalidate(f"feed:{user_id}")
+
+    def _invalidate_content_by_entity(self, entity_id: str) -> None:
+        """_invalidate_content for the archive paths, which only carry entity_id."""
+        try:
+            with self._cursor() as cur:
+                cur.execute("SELECT user_id FROM entities WHERE id = %s", (entity_id,))
+                row = cur.fetchone()
+            if row:
+                self._invalidate_content(str(row[0]))
+        except Exception as e:
+            logger.warning(f"⚠️ Cache invalidation skipped for entity {entity_id}: {e}")
 
     def get_entity_id(self, user_id: str, name: str, sub_user_id: str = "default") -> Optional[str]:
         """Get entity ID by name."""
@@ -2707,7 +2730,7 @@ class CloudStore:
                 cur.execute(f"DELETE FROM {child} WHERE entity_id = %s", (eid,))
             cur.execute("DELETE FROM relations WHERE source_id = %s OR target_id = %s", (eid, eid))
             cur.execute("DELETE FROM entities WHERE id = %s", (eid,))
-        self.cache.invalidate(f"stats:{user_id}")
+        self._invalidate_content(user_id)
         self._schedule_matview_refresh()
         return True
 
@@ -2797,7 +2820,7 @@ class CloudStore:
                 wipe("conversation_chunks", "id = ANY(%s::uuid[])", (chunk_ids,))
             wipe("memory_triggers", "user_id::text = %s AND sub_user_id = %s", scope)
 
-        self.cache.invalidate(f"stats:{user_id}")
+        self._invalidate_content(user_id)
         self.cache.invalidate(f"graph:{user_id}:{sub_user_id}:150")
         self.cache.invalidate(f"profile:{user_id}")
         self._schedule_matview_refresh()
@@ -2879,7 +2902,7 @@ class CloudStore:
                     counts["drip_emails"] = counts.get("drip_emails", 0) + cur.rowcount
             cur.execute("DELETE FROM users WHERE id = %s", (user_id,))
             counts["users"] = cur.rowcount
-        for prefix in ("stats:", "profile:", "rules:", "graph:", "value_mirror:", "sub:"):
+        for prefix in ("stats:", "feed:", "profile:", "rules:", "graph:", "value_mirror:", "sub:"):
             self.cache.invalidate(f"{prefix}{user_id}")
         for kh in key_hashes:
             self.cache.invalidate(f"auth:{kh[:16]}")
@@ -3490,6 +3513,8 @@ No markdown, no explanation."""
             archived.append(old_fact)
             logger.info(f"📦 Archived: '{old_fact}' → superseded by '{new_fact}'")
 
+        if archived:
+            self._invalidate_content_by_entity(entity_id)
         return archived
 
     def dedup_entity_facts(self, entity_id: str, entity_name: str, llm_client) -> dict:
@@ -3557,6 +3582,9 @@ Return ONLY this JSON (no markdown):
                     )
                     if cur.rowcount > 0:
                         archived.append(fact)
+
+        if archived:
+            self._invalidate_content_by_entity(entity_id)
 
         kept = result.get("keep", [])
         logger.info(f"🧹 Dedup '{entity_name}': {len(facts)} → {len(facts)-len(archived)} facts ({len(archived)} archived)")
@@ -6166,6 +6194,9 @@ Be specific and personal, not generic. No markdown, just JSON."""
                             )
                             if cur.rowcount > 0:
                                 actions_taken += 1
+
+            if actions_taken:
+                self._invalidate_content(user_id)
 
             # Auto-fix: merge case-insensitive duplicate entities
             try:

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -2088,6 +2088,7 @@ class CloudStore:
             cur.execute("DELETE FROM knowledge WHERE entity_id = %s", (source_id,))
             cur.execute("DELETE FROM entities WHERE id = %s", (source_id,))
 
+        self._invalidate_content_by_entity(target_id)
         logger.info(f"🔀 Merged entity {source_id} into {target_id} ({target_name})")
 
     def _auto_merge_duplicate_entities(self, user_id: str, sub_user_id: str = "default") -> int:
@@ -2426,7 +2427,29 @@ class CloudStore:
             )
 
         # Invalidate caches after write
+        self._invalidate_content(user_id)
+
+    def _invalidate_content(self, user_id: str) -> None:
+        """Drop every cache derived from a user's facts/entities.
+
+        stats and feed are cached under separate keys with different TTLs
+        (30s / 15s). Invalidating only one lets the header counters and the
+        feed disagree until the other key expires — visible as an off-by-N
+        FACTS count for up to 15s after a write or an archive.
+        """
         self.cache.invalidate(f"stats:{user_id}")
+        self.cache.invalidate(f"feed:{user_id}")
+
+    def _invalidate_content_by_entity(self, entity_id: str) -> None:
+        """_invalidate_content for the archive paths, which only carry entity_id."""
+        try:
+            with self._cursor() as cur:
+                cur.execute("SELECT user_id FROM entities WHERE id = %s", (entity_id,))
+                row = cur.fetchone()
+            if row:
+                self._invalidate_content(str(row[0]))
+        except Exception as e:
+            logger.warning(f"⚠️ Cache invalidation skipped for entity {entity_id}: {e}")
 
     def get_entity_id(self, user_id: str, name: str, sub_user_id: str = "default") -> Optional[str]:
         """Get entity ID by name."""
@@ -2703,7 +2726,7 @@ class CloudStore:
                 cur.execute(f"DELETE FROM {child} WHERE entity_id = %s", (eid,))
             cur.execute("DELETE FROM relations WHERE source_id = %s OR target_id = %s", (eid, eid))
             cur.execute("DELETE FROM entities WHERE id = %s", (eid,))
-        self.cache.invalidate(f"stats:{user_id}")
+        self._invalidate_content(user_id)
         self._schedule_matview_refresh()
         return True
 
@@ -2724,7 +2747,7 @@ class CloudStore:
                     "DELETE FROM relations WHERE source_id = ANY(%s::uuid[]) OR target_id = ANY(%s::uuid[])",
                     (entity_ids, entity_ids))
                 cur.execute("DELETE FROM entities WHERE id = ANY(%s::uuid[])", (entity_ids,))
-        self.cache.invalidate(f"stats:{user_id}")
+        self._invalidate_content(user_id)
         self.cache.invalidate(f"graph:{user_id}:{sub_user_id}:150")
         self._schedule_matview_refresh()
         return count
@@ -3406,6 +3429,8 @@ No markdown, no explanation."""
             archived.append(old_fact)
             logger.info(f"📦 Archived: '{old_fact}' → superseded by '{new_fact}'")
 
+        if archived:
+            self._invalidate_content_by_entity(entity_id)
         return archived
 
     def dedup_entity_facts(self, entity_id: str, entity_name: str, llm_client) -> dict:
@@ -3473,6 +3498,9 @@ Return ONLY this JSON (no markdown):
                     )
                     if cur.rowcount > 0:
                         archived.append(fact)
+
+        if archived:
+            self._invalidate_content_by_entity(entity_id)
 
         kept = result.get("keep", [])
         logger.info(f"🧹 Dedup '{entity_name}': {len(facts)} → {len(facts)-len(archived)} facts ({len(archived)} archived)")
@@ -5996,6 +6024,9 @@ Be specific and personal, not generic. No markdown, just JSON."""
                             )
                             if cur.rowcount > 0:
                                 actions_taken += 1
+
+            if actions_taken:
+                self._invalidate_content(user_id)
 
             # Auto-fix: merge case-insensitive duplicate entities
             try:

--- a/tests/test_cache_invalidation.py
+++ b/tests/test_cache_invalidation.py
@@ -1,0 +1,128 @@
+"""Feed and stats are cached under separate keys; a write must drop both.
+
+Regression test for header counters (FACTS) disagreeing with the memory feed
+for up to 15s after a write or an archive: `stats:` was invalidated on the
+write paths, `feed:` was never invalidated anywhere and expired only by TTL.
+
+Runs without a database: TTLCache is exercised directly against the real
+cache-key shapes used by get_stats/get_feed, and the store source is scanned
+to prove every content-mutating path routes through _invalidate_content.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+STORE_PATH = pathlib.Path(__file__).resolve().parents[1] / "cloud" / "store.py"
+STORE_SRC = STORE_PATH.read_text(encoding="utf-8")
+
+USER = "user-1"
+SUB = "default"
+STATS_KEY = f"stats:{USER}:{SUB}"
+FEED_KEY = f"feed:{USER}:{SUB}:0:20"
+
+
+def load_ttl_cache():
+    """Exec just the TTLCache class — importing cloud.store needs psycopg2."""
+    start = STORE_SRC.index("class TTLCache:")
+    # Next top-level statement, decorator or class alike.
+    end = min(
+        pos
+        for pos in (STORE_SRC.find(m, start + 1) for m in ("\nclass ", "\n@dataclass"))
+        if pos != -1
+    )
+    namespace: dict = {}
+    exec(
+        "import threading, time\nfrom typing import Any, Optional\n"
+        + STORE_SRC[start:end],
+        namespace,
+    )
+    return namespace["TTLCache"]
+
+
+TTLCache = load_ttl_cache()
+
+
+class TestPrefixInvalidation(unittest.TestCase):
+    """The keys carry sub_user_id/offset/limit — a prefix must still catch them."""
+
+    def setUp(self):
+        self.cache = TTLCache(default_ttl=60)
+        self.cache.set(STATS_KEY, {"facts": 4030}, ttl=30)
+        self.cache.set(FEED_KEY, {"items": []}, ttl=15)
+
+    def test_stats_prefix_catches_sub_user_variant(self):
+        self.cache.invalidate(f"stats:{USER}")
+        self.assertIsNone(self.cache.get(STATS_KEY))
+
+    def test_feed_prefix_catches_offset_limit_variants(self):
+        for offset in (0, 20, 40):
+            self.cache.set(f"feed:{USER}:{SUB}:{offset}:20", {"items": []}, ttl=15)
+        self.cache.invalidate(f"feed:{USER}")
+        for offset in (0, 20, 40):
+            self.assertIsNone(self.cache.get(f"feed:{USER}:{SUB}:{offset}:20"))
+
+    def test_invalidating_stats_alone_leaves_feed_stale(self):
+        """The bug: this is what the old code did, and it is why counts drifted."""
+        self.cache.invalidate(f"stats:{USER}")
+        self.assertIsNone(self.cache.get(STATS_KEY))
+        self.assertIsNotNone(self.cache.get(FEED_KEY))
+
+    def test_other_users_unaffected(self):
+        self.cache.set("stats:user-2:default", {"facts": 7}, ttl=30)
+        self.cache.set("feed:user-2:default:0:20", {"items": []}, ttl=15)
+        self.cache.invalidate(f"stats:{USER}")
+        self.cache.invalidate(f"feed:{USER}")
+        self.assertIsNotNone(self.cache.get("stats:user-2:default"))
+        self.assertIsNotNone(self.cache.get("feed:user-2:default:0:20"))
+
+
+class TestHelperDropsBoth(unittest.TestCase):
+    def test_invalidate_content_drops_stats_and_feed(self):
+        cache = TTLCache(default_ttl=60)
+        cache.set(STATS_KEY, {"facts": 4030}, ttl=30)
+        cache.set(FEED_KEY, {"items": []}, ttl=15)
+
+        # The helper's body, applied to a bare cache holder.
+        class Store:
+            def __init__(self, c):
+                self.cache = c
+
+            def _invalidate_content(self, user_id):
+                self.cache.invalidate(f"stats:{user_id}")
+                self.cache.invalidate(f"feed:{user_id}")
+
+        Store(cache)._invalidate_content(USER)
+        self.assertIsNone(cache.get(STATS_KEY))
+        self.assertIsNone(cache.get(FEED_KEY))
+
+
+class TestNoUninvalidatedWritePaths(unittest.TestCase):
+    """Guards against a new write path reintroducing the drift."""
+
+    def test_no_bare_stats_invalidation_outside_the_helper(self):
+        helper_start = STORE_SRC.index("def _invalidate_content(")
+        helper_end = STORE_SRC.index("def _invalidate_content_by_entity(")
+        outside = STORE_SRC[:helper_start] + STORE_SRC[helper_end:]
+        self.assertNotIn(
+            'self.cache.invalidate(f"stats:{user_id}")',
+            outside,
+            "invalidate stats via _invalidate_content so feed is dropped too",
+        )
+
+    def test_every_fact_archiving_path_invalidates(self):
+        """Each `SET archived = TRUE` site must have an invalidation downstream."""
+        sites = [m.start() for m in re.finditer(r"SET archived = TRUE", STORE_SRC)]
+        self.assertGreaterEqual(len(sites), 4, "archiving sites disappeared?")
+        for start in sites:
+            window = STORE_SRC[start:start + 2500]
+            self.assertRegex(
+                window,
+                r"self\._invalidate_content(_by_entity)?\(",
+                f"archiving site at offset {start} never invalidates caches",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`get_stats` and `get_feed` are cached under separate keys with different TTLs
(`stats:{user_id}:{sub_user_id}`, 30s — `feed:{user_id}:{sub_user_id}:{offset}:{limit}`, 15s).
Only `stats:` was ever invalidated, and only on 3 of the content-changing paths.
`feed:` was invalidated **nowhere** and expired by TTL alone.

The visible symptom: the header FACTS counter and the memory feed disagree by
a few entries after a write or an archive, for up to 15s. Measured live before
the fix — stats 4030 vs feed 4028, feed caught up 1.5s later.

Four fact-archiving paths invalidated nothing at all:

| path | before | after |
|---|---|---|
| `archive_contradicted_facts` | — | `_invalidate_content_by_entity` |
| `dedup_entity_facts` | — | `_invalidate_content_by_entity` |
| curator auto-fix (low_quality, stale) | — | `_invalidate_content` |
| `merge_entities` | — | `_invalidate_content_by_entity` |
| write path, `delete_entity`, `delete_all_entities` | `stats:` only | `_invalidate_content` (both) |

Two helpers replace the bare `stats:` calls:

```python
def _invalidate_content(self, user_id: str) -> None:
    self.cache.invalidate(f"stats:{user_id}")
    self.cache.invalidate(f"feed:{user_id}")

def _invalidate_content_by_entity(self, entity_id: str) -> None:
    """_invalidate_content for the archive paths, which only carry entity_id."""
```

The archive paths only carry `entity_id`, so the by-entity variant looks up the
owning `user_id` first. Its exception is logged and swallowed: a failed
invalidation degrades to the pre-existing TTL behaviour rather than breaking the
archive itself. Every invalidation call sits outside any open cursor scope, so
no nested cursor or transaction is introduced.

### Verification

`tests/test_cache_invalidation.py` — 7 tests, no database needed. `TTLCache` is
exec'd out of `cloud/store.py` directly and exercised against the real key
shapes, plus a source scan asserting every `SET archived = TRUE` site has an
invalidation downstream and no bare `stats:` invalidation survives outside the
helper.

Proven to catch the bug rather than merely pass: reverting `cloud/store.py`
gives `AssertionError: ... archiving site at offset 155896 never invalidates caches`.

Measured live after the fix: 26 samples at 0.4s intervals across a counter rise
from 4061 to 4066 — **max stats/feed divergence 0**.

### Scope

`stats:` and `feed:` only. `graph:` (30s) is sourced from the `entity_overview`
materialized view and can still lag on archive; that staleness predates this
change and is left alone deliberately.
