### PR TITLE
fix: memory embedding rebuild, quota bounds, cron lock recovery, OAuth redirect validation

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -7559,8 +7559,11 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
         user_id = ctx.user_id
         sub_uid = req.user_id or "default"
 
-        # Dry run: extract and return preview without saving
+        # Dry run: extract and return preview without saving. Metered like a
+        # real add — it runs the same LLM extraction, so leaving it free made
+        # /v1/add an unlimited extraction API for anyone passing dry_run.
         if req.dry_run:
+            use_quota(ctx, "add")
             extractor = get_llm()
             existing_context = ""
             try:

--- a/cloud/api.py
+++ b/cloud/api.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 from pydantic import BaseModel, Field
 
 from cloud.store import CloudStore, _normalize_fact
+from cloud.oauth_policy import redirect_uri_error as _redirect_uri_error
 
 
 # ---- Auth Context ----
@@ -6691,7 +6692,36 @@ a{{color:#a855f7;text-decoration:none}}
     ):
         """OAuth authorize page — shows email login. Carries the PKCE challenge
         (RFC 7636) through the login step so the token exchange can verify it."""
-        from urllib.parse import quote
+        from urllib.parse import quote, urlparse
+        import html as _html
+
+        # Refuse before the user is asked for anything — a rejected target
+        # should never get as far as showing a Mengram-branded login form.
+        _redirect_error = _redirect_uri_error(redirect_uri)
+        if _redirect_error:
+            return HTMLResponse(
+                f"<!DOCTYPE html><meta charset='utf-8'>"
+                f"<div style=\"font-family:system-ui;max-width:32rem;margin:15vh auto;"
+                f"padding:0 1.5rem;line-height:1.6\">"
+                f"<h1 style='font-size:1.25rem'>Sign-in blocked</h1>"
+                f"<p>{_html.escape(_redirect_error)}. Mengram will not send an "
+                f"authorization code to this destination.</p>"
+                f"<p style='color:#666;font-size:.9rem'>If you started this from "
+                f"an AI assistant, open the connector settings and try again.</p>"
+                f"</div>",
+                status_code=400,
+            )
+
+        # Name the destination on the card: the one thing that lets someone
+        # spot a code being routed somewhere they didn't intend.
+        _dest_host = _html.escape((urlparse(redirect_uri).hostname or "") if redirect_uri else "")
+        destination_note = (
+            f"<p style='color:#888;margin-bottom:24px;font-size:14px'>Connecting your "
+            f"memory to <strong style='color:#e0e0e0'>{_dest_host}</strong></p>"
+            if _dest_host else
+            "<p style='color:#888;margin-bottom:24px;font-size:14px'>"
+            "Connect your memory to your AI assistant</p>"
+        )
         redirect_uri_encoded = quote(redirect_uri, safe="")
         state_encoded = quote(state, safe="")
         code_challenge_encoded = quote(code_challenge, safe="")
@@ -6723,7 +6753,7 @@ a{{color:#a855f7;text-decoration:none}}
 <div class="card">
   <div class="logo"><svg width='34' height='34' viewBox='0 0 100 100'><path d='M22 65 V44 C22 36 36 36 40 44 V65 M40 44 C44 36 58 36 58 44 V54 C58 63 70 64 73 54' fill='none' stroke='#7c3aed' stroke-width='10' stroke-linecap='round' stroke-linejoin='round'/><circle cx='75' cy='51' r='8' fill='#7c3aed'/><circle cx='75' cy='51' r='3' fill='#fff'/></svg></div>
   <h1>Sign in to Mengram</h1>
-  <p>Connect your memory to your AI assistant</p>
+  {destination_note}
 
   <div id="step1" class="step active">
     <input type="email" id="email" placeholder="your@email.com" autofocus>
@@ -6847,22 +6877,19 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
         if not _check_rate_limit(f"verify_ip:{client_ip}", 20):
             return {"error": "Too many attempts. Try again in 60 seconds."}
 
+        # Re-validated here because /oauth/authorize is only the UI and this
+        # endpoint is callable directly. Checked before the email code is
+        # consumed so a rejected target doesn't burn the user's one-shot code.
+        _redirect_error = _redirect_uri_error(redirect_uri)
+        if _redirect_error:
+            return {"error": _redirect_error}
+
         if not store.verify_email_code(email, code):
             return {"error": "Invalid or expired code"}
 
         user_id = store.get_user_by_email(email)
         if not user_id:
             return {"error": "User not found"}
-
-        # Validate redirect_uri — must be HTTPS or localhost
-        if redirect_uri:
-            from urllib.parse import urlparse
-            parsed = urlparse(redirect_uri)
-            if parsed.scheme not in ("https", "http"):
-                return {"error": "Invalid redirect_uri scheme"}
-            # Allow localhost for dev, require HTTPS for everything else
-            if parsed.scheme == "http" and parsed.hostname not in ("localhost", "127.0.0.1"):
-                return {"error": "redirect_uri must use HTTPS"}
 
         # Create OAuth authorization code (with PKCE challenge when provided)
         oauth_code = secrets.token_urlsafe(32)

--- a/cloud/api.py
+++ b/cloud/api.py
@@ -9729,6 +9729,24 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
         except Exception:
             return None
 
+    def _lock_still_held(conn) -> bool:
+        """Whether the lock connection is still usable. The Supabase pooler
+        drops idle connections, which silently releases the advisory lock — a
+        loop that never rechecks keeps running while another instance is free
+        to grab the same lock and double-fire."""
+        if conn is None or conn.closed:
+            return False
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+            return True
+        except Exception:
+            try:
+                conn.close()
+            except Exception:
+                pass
+            return False
+
     # Lock IDs (arbitrary unique ints)
     _LOCK_TRIGGER_CRON = 900001
     _LOCK_DRIP_CRON = 900002
@@ -9737,12 +9755,17 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
     def _trigger_cron_loop():
         """Background thread that processes triggers every 5 minutes."""
         _time.sleep(30)  # Initial delay to let server start
-        _lock_conn = _try_advisory_lock(_LOCK_TRIGGER_CRON)
-        if not _lock_conn:
-            logger.info("🧠 Trigger cron: another worker holds the lock, skipping")
-            return
-        logger.info("🧠 Smart trigger cron started (every 5 min)")
+        # The lock is retried every tick rather than once at startup: on a
+        # rolling deploy the incoming instance loses the race to the outgoing
+        # one, and giving up left this cron dead until the next restart.
+        _lock_conn = None
         while True:
+            if not _lock_still_held(_lock_conn):
+                _lock_conn = _try_advisory_lock(_LOCK_TRIGGER_CRON)
+                if not _lock_conn:
+                    _time.sleep(300)
+                    continue
+                logger.info("🧠 Smart trigger cron started (every 5 min)")
             try:
                 result = store.process_all_triggers()
                 if result["fired"] > 0:
@@ -9760,12 +9783,14 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
     def _drip_email_cron_loop():
         """Background thread that sends onboarding drip emails every 30 minutes."""
         _time.sleep(60)  # Initial delay
-        _lock_conn = _try_advisory_lock(_LOCK_DRIP_CRON)
-        if not _lock_conn:
-            logger.info("📧 Drip email cron: another worker holds the lock, skipping")
-            return
-        logger.info("📧 Onboarding drip email cron started (every 30 min)")
+        _lock_conn = None  # reacquired every tick — see _trigger_cron_loop
         while True:
+            if not _lock_still_held(_lock_conn):
+                _lock_conn = _try_advisory_lock(_LOCK_DRIP_CRON)
+                if not _lock_conn:
+                    _time.sleep(300)
+                    continue
+                logger.info("📧 Onboarding drip email cron started (every 30 min)")
             try:
                 import secrets as _secrets
 
@@ -9939,12 +9964,14 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
         import traceback
         logger.info("🩺 Memory Health cron: thread alive, sleeping 120s before first run")
         _time.sleep(120)  # Initial delay so this doesn't pile on with drip cron
-        _lock_conn = _try_advisory_lock(_LOCK_HEALTH_CRON)
-        if not _lock_conn:
-            logger.info("🩺 Memory Health cron: another worker holds the lock, skipping")
-            return
-        logger.info("🩺 Memory Health aggregation cron started (every 6h, 5min retry on error)")
+        _lock_conn = None  # reacquired every tick — see _trigger_cron_loop
         while True:
+            if not _lock_still_held(_lock_conn):
+                _lock_conn = _try_advisory_lock(_LOCK_HEALTH_CRON)
+                if not _lock_conn:
+                    _time.sleep(300)
+                    continue
+                logger.info("🩺 Memory Health aggregation cron started (every 6h, 5min retry on error)")
             iteration_failed = False
             try:
                 result = store.aggregate_memory_health(window_hours=24)
@@ -9990,14 +10017,16 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
         import traceback
         logger.info("🌙 Reflection cron: thread alive, sleeping 180s before first run")
         _time.sleep(180)
-        _lock_conn = _try_advisory_lock(_LOCK_REFLECTION_CRON)
-        if not _lock_conn:
-            logger.info("🌙 Reflection cron: another worker holds the lock, skipping")
-            return
-        logger.info(
-            f"🌙 Reflection cron started (every 24h, batch up to {_REFLECTION_BATCH_SIZE} users)"
-        )
+        _lock_conn = None  # reacquired every tick — see _trigger_cron_loop
         while True:
+            if not _lock_still_held(_lock_conn):
+                _lock_conn = _try_advisory_lock(_LOCK_REFLECTION_CRON)
+                if not _lock_conn:
+                    _time.sleep(300)
+                    continue
+                logger.info(
+                    f"🌙 Reflection cron started (every 24h, batch up to {_REFLECTION_BATCH_SIZE} users)"
+                )
             iteration_failed = False
             try:
                 users_due = store.get_users_due_for_reflection(

--- a/cloud/api.py
+++ b/cloud/api.py
@@ -7197,16 +7197,14 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
                         continue
                     created.append(name)
 
-                    chunks = [name] + [f"{name}: {fs}" for fs in fact_strings]
-                    for r in entity_relations:
-                        target = r.get("target", "")
-                        rel_type = r.get("type", "")
-                        if target and rel_type:
-                            chunks.append(f"{name} {rel_type} {target}")
-                    for k in entity_knowledge:
-                        kt = f"{k['title']} {k['content']}"
-                        chunks.append(_summarize_for_embedding(kt) if len(kt) > 2000 else kt)
-                    embedding_queue.append((entity_id, chunks))
+                    # Chunks cover the entity's full current state, not just
+                    # this conversation's facts — the embedding set is replaced
+                    # wholesale, so anything left out stops being searchable.
+                    try:
+                        embedding_queue.append((entity_id, store.build_entity_chunks(
+                            entity_id, name, summarize=_summarize_for_embedding)))
+                    except Exception as e:
+                        logger.warning(f"⚠️ Chunk build failed for '{name}': {e}")
 
                 # -- Refresh context for next window (includes just-saved entities) --
                 if win_start + WINDOW_SIZE < len(conversation):
@@ -7222,11 +7220,24 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
             embed_items = []  # [(save_fn, text)]
 
             # Entity embeddings
+            # Only chunks that aren't embedded yet go to the API; chunks that
+            # dropped out of the entity are retired after the batch succeeds.
+            stale_by_entity = {}
             if embedder and embedding_queue:
+                _dims = getattr(embedder, "dimensions", 1536)
                 for entity_id, chunks in embedding_queue:
-                    store.delete_embeddings(entity_id)
+                    try:
+                        existing = store.get_embedded_chunk_texts(entity_id, _dims)
+                    except Exception as e:
+                        logger.warning(f"⚠️ Embedding lookup failed for {entity_id}: {e}")
+                        existing = set()
+                    wanted = set(chunks)
+                    stale = [t for t in existing if t not in wanted]
+                    if stale:
+                        stale_by_entity[entity_id] = stale
                     for chunk in chunks:
-                        embed_items.append(("entity", entity_id, chunk))
+                        if chunk not in existing:
+                            embed_items.append(("entity", entity_id, chunk))
 
             # Raw conversation chunk
             conv_chunk_text = None
@@ -7307,7 +7318,6 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
                             (s.get("action", "") if isinstance(s, dict) else str(s)) for s in pr.steps[:10]
                         )
                         pr_text = f"{pr.name}. {pr.trigger or ''}. Steps: {steps_summary}"
-                        store.delete_procedure_embeddings(proc_id)
                         embed_items.append(("procedure", proc_id, pr_text))
                     procedures_created += 1
                 except Exception as e:
@@ -7318,6 +7328,22 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
             if embedder and embed_items:
                 all_texts = [item[2] for item in embed_items]
                 all_embeddings = embedder.embed_batch(all_texts)
+                if len(all_embeddings) != len(embed_items):
+                    # zip() would silently drop the tail and leave entities with
+                    # a partial embedding set; keep the existing one instead.
+                    logger.error(
+                        f"⚠️ Embedder returned {len(all_embeddings)} vectors for "
+                        f"{len(embed_items)} chunks — skipping embedding update")
+                    all_embeddings = []
+
+                # A procedure's text is rewritten wholesale, so its old vector
+                # goes only once the replacement is in hand — deleting up-front
+                # left it unsearchable whenever the embed call failed.
+                if all_embeddings:
+                    for item_type, item_id, _text in embed_items:
+                        if item_type == "procedure":
+                            store.delete_procedure_embeddings(item_id)
+
                 for (item_type, item_id, text), emb in zip(embed_items, all_embeddings):
                     if item_type == "entity":
                         store.save_embedding(item_id, text, emb)
@@ -7328,6 +7354,14 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
                         episode_embeddings[item_id] = emb
                     elif item_type == "procedure":
                         store.save_procedure_embedding(item_id, text, emb)
+
+            # Retire chunks the entity no longer has (archived facts, dropped
+            # relations). Runs even when nothing new needed embedding.
+            for entity_id, stale in stale_by_entity.items():
+                try:
+                    store.delete_embeddings_for_texts(entity_id, stale)
+                except Exception as e:
+                    logger.warning(f"⚠️ Stale embedding cleanup failed for {entity_id}: {e}")
 
             # ---- Episode auto-linking (uses pre-computed embeddings) ----
             for episode_id, (ep, ep_text) in episode_embed_map.items():
@@ -8253,17 +8287,14 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
             if not entity_id:
                 continue
 
-            chunks = [name] + entity.get("facts", [])
-            for r in entity.get("relations", []):
-                target = r.get("target", "")
-                rel_type = r.get("type", "")
-                if target and rel_type:
-                    chunks.append(f"{name} {rel_type} {target}")
-            for k in entity.get("knowledge", []):
-                chunks.append(f"{k.get('title', '')} {k.get('content', '')}")
-
-            store.delete_embeddings(entity_id)
+            chunks = store.build_entity_chunks(
+                entity_id, name, summarize=_summarize_for_embedding)
             embeddings = embedder.embed_batch(chunks)
+            if len(embeddings) != len(chunks):
+                logger.error(f"⚠️ Reindex skipped '{name}': embedder returned "
+                             f"{len(embeddings)} vectors for {len(chunks)} chunks")
+                continue
+            store.delete_embeddings(entity_id)
             for chunk, emb in zip(chunks, embeddings):
                 store.save_embedding(entity_id, chunk, emb)
             count += 1

--- a/cloud/oauth_policy.py
+++ b/cloud/oauth_policy.py
@@ -1,0 +1,58 @@
+"""Which redirect targets may receive an OAuth authorization code.
+
+Kept out of api.py so the rule is importable (and testable) without the web
+stack. The code exchanges for a full-access API key, so an unchecked
+redirect_uri turns the genuine sign-in page into a phishing endpoint: the
+victim logs in on mengram.io and the code lands on the attacker's host. PKCE
+does not help — a malicious client picks its own challenge.
+
+Client registration is open, so a per-client list would be attacker-controlled;
+the allowlist has to be ours.
+"""
+
+import logging
+import os
+import urllib.parse
+
+logger = logging.getLogger("mengram")
+
+_LOOPBACK = ("localhost", "127.0.0.1")
+
+
+def redirect_allowlist() -> list[str]:
+    """Hosts permitted to receive an authorization code. Read per call so the
+    env var can be changed without a redeploy."""
+    return [h.strip().lower()
+            for h in os.environ.get("OAUTH_REDIRECT_ALLOWLIST", "").split(",")
+            if h.strip()]
+
+
+def redirect_uri_error(redirect_uri: str) -> str | None:
+    """Reason this target must not receive a code, or None if it may.
+
+    With OAUTH_REDIRECT_ALLOWLIST unset the flow behaves as before and every
+    target is logged, so the live set of client callbacks can be read off the
+    logs before locking it down. Set it to a comma-separated host list;
+    subdomains of each entry are accepted, and loopback always is.
+    """
+    if not redirect_uri:
+        return None
+
+    parsed = urllib.parse.urlparse(redirect_uri)
+    host = (parsed.hostname or "").lower()
+    is_loopback = host in _LOOPBACK
+
+    if parsed.scheme not in ("https", "http"):
+        return "Invalid redirect_uri scheme"
+    if parsed.scheme == "http" and not is_loopback:
+        return "redirect_uri must use HTTPS"
+
+    allowlist = redirect_allowlist()
+    if not allowlist:
+        logger.info(f"🔓 OAuth redirect target (allowlist unset): {host}")
+        return None
+    if is_loopback or any(host == h or host.endswith("." + h) for h in allowlist):
+        return None
+
+    logger.warning(f"🔒 OAuth redirect target rejected: {host}")
+    return "redirect_uri is not allowed"

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -4713,6 +4713,19 @@ REFLECTIONS/PATTERNS:
 
         period_start = datetime.date.today().replace(day=1)
         with self._cursor() as cur:
+            # A call bigger than the whole allowance can never fit, and the
+            # INSERT arm below carries no bound — it fires on the period's
+            # first call, when no counter row exists yet — so an oversized
+            # request would otherwise sail through once a month.
+            if count > max_allowed:
+                cur.execute(
+                    f"SELECT {column} FROM usage_counters WHERE user_id = %s AND period_start = %s",
+                    (user_id, period_start)
+                )
+                r = cur.fetchone()
+                current = r[0] if r else 0
+                raise ValueError(f"quota_exceeded:{action}:{current}:{max_allowed}")
+
             # Atomic: increment only if current value < max_allowed
             cur.execute(
                 f"""INSERT INTO usage_counters (user_id, period_start, {column})

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -3895,6 +3895,79 @@ Return ONLY JSON (no markdown):
                 (entity_id, chunk_text, embedding_str, chunk_text)
             )
 
+    def build_entity_chunks(self, entity_id: str, name: str,
+                            summarize=None) -> list[str]:
+        """Every embeddable chunk for an entity: its name, each active fact,
+        each relation and each knowledge item.
+
+        Callers replace an entity's whole embedding set (delete + re-insert),
+        so the chunk list must cover the entity's *current* state, not just the
+        facts of the conversation being ingested. The `"{name}: {fact}"` fact
+        format is load-bearing: search_vector recovers fact text by splitting
+        the chunk on the first ": " to match it against facts rows.
+
+        summarize: optional (text) -> text, applied to knowledge over 2000
+        chars; falls back to truncation when not supplied.
+        """
+        chunks = [name]
+        with self._cursor(dict_cursor=True) as cur:
+            cur.execute(
+                """SELECT content FROM facts
+                   WHERE entity_id = %s AND archived = FALSE
+                     AND (expires_at IS NULL OR expires_at > NOW())""",
+                (entity_id,)
+            )
+            chunks.extend(f"{name}: {r['content']}" for r in cur.fetchall())
+
+            cur.execute(
+                """SELECT r.type, e.name AS target
+                   FROM relations r JOIN entities e ON e.id = r.target_id
+                   WHERE r.source_id = %s""",
+                (entity_id,)
+            )
+            chunks.extend(
+                f"{name} {r['type']} {r['target']}"
+                for r in cur.fetchall() if r["type"] and r["target"]
+            )
+
+            cur.execute(
+                "SELECT title, content FROM knowledge WHERE entity_id = %s",
+                (entity_id,)
+            )
+            for r in cur.fetchall():
+                kt = f"{r['title'] or ''} {r['content'] or ''}".strip()
+                if not kt:
+                    continue
+                if len(kt) > 2000:
+                    kt = summarize(kt) if summarize else kt[:2000]
+                chunks.append(kt)
+
+        return chunks
+
+    def get_embedded_chunk_texts(self, entity_id: str, dimensions: int) -> set[str]:
+        """chunk_text values that already have a vector in the column matching
+        `dimensions`. Lets callers embed only what changed instead of paying to
+        re-embed an entity's whole history on every write."""
+        col = "embedding_v2" if dimensions == 1024 else "embedding"
+        with self._cursor() as cur:
+            cur.execute(
+                f"SELECT chunk_text FROM embeddings "
+                f"WHERE entity_id = %s AND {col} IS NOT NULL",
+                (entity_id,)
+            )
+            return {r[0] for r in cur.fetchall()}
+
+    def delete_embeddings_for_texts(self, entity_id: str, texts: list[str]):
+        """Drop the chunks listed — used to retire text that is no longer part
+        of the entity (archived facts, removed relations)."""
+        if not texts:
+            return
+        with self._cursor() as cur:
+            cur.execute(
+                "DELETE FROM embeddings WHERE entity_id = %s AND chunk_text = ANY(%s)",
+                (entity_id, list(texts))
+            )
+
     def delete_embeddings(self, entity_id: str):
         """Remove all embeddings for entity (before reindex)."""
         with self._cursor() as cur:

--- a/tests/test_entity_chunks.py
+++ b/tests/test_entity_chunks.py
@@ -1,0 +1,132 @@
+"""Regression tests for CloudStore.build_entity_chunks.
+
+The chunk set an entity gets embedded under is what search can see. Two
+properties are load-bearing and were both broken in production:
+
+  * chunks must cover the entity's *whole* current state — the add path
+    replaces embeddings, so any active fact left out becomes unsearchable
+    even though its row still exists;
+  * fact chunks must stay in `"{name}: {fact}"` form — search_vector recovers
+    fact text by splitting the chunk on the first ": " and drops any fact it
+    can't match (relevance 0 < the 0.15 floor).
+
+Hermetic: CloudStore is constructed without __init__ and given a stub cursor,
+so no database is required.
+"""
+
+import contextlib
+
+from cloud.store import CloudStore
+
+
+class _FakeCursor:
+    """Returns a queued result set per execute(), recording the SQL it saw."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.sql = []
+
+    def execute(self, sql, params=None):
+        self.sql.append(" ".join(sql.split()))
+
+    def fetchall(self):
+        return self._results.pop(0) if self._results else []
+
+
+def _store(results):
+    store = CloudStore.__new__(CloudStore)
+    cursor = _FakeCursor(results)
+
+    @contextlib.contextmanager
+    def _cursor(dict_cursor=False):
+        yield cursor
+
+    store._cursor = _cursor
+    store._last_cursor = cursor
+    return store
+
+
+class TestBuildEntityChunks:
+    def test_name_and_every_active_fact_present(self):
+        store = _store([
+            [{"content": "uses Rust"}, {"content": "lives in Tokyo"}],
+            [],
+            [],
+        ])
+        chunks = store.build_entity_chunks("eid", "Frank")
+
+        assert chunks[0] == "Frank"
+        assert "Frank: uses Rust" in chunks
+        assert "Frank: lives in Tokyo" in chunks
+
+    def test_fact_chunk_round_trips_through_the_search_split(self):
+        """search_vector does chunk.split(": ", 1)[1] to key facts by content."""
+        facts = ["uses Rust", "note: ships on Friday", "café: 東京"]
+        store = _store([[{"content": f} for f in facts], [], []])
+
+        chunks = store.build_entity_chunks("eid", "Frank")
+
+        recovered = [c.split(": ", 1)[1] for c in chunks if ": " in c]
+        for fact in facts:
+            assert fact in recovered, f"search could not recover {fact!r}"
+
+    def test_archived_and_expired_facts_are_excluded_in_sql(self):
+        store = _store([[], [], []])
+        store.build_entity_chunks("eid", "Frank")
+
+        facts_sql = store._last_cursor.sql[0]
+        assert "archived = FALSE" in facts_sql
+        assert "expires_at IS NULL OR expires_at > NOW()" in facts_sql
+
+    def test_relations_become_triple_chunks(self):
+        store = _store([
+            [],
+            [{"type": "works_at", "target": "Anthropic"},
+             {"type": "", "target": "Ignored"}],
+            [],
+        ])
+        chunks = store.build_entity_chunks("eid", "Frank")
+
+        assert "Frank works_at Anthropic" in chunks
+        assert not any("Ignored" in c for c in chunks)
+
+    def test_long_knowledge_uses_the_summarizer(self):
+        long_text = "x" * 2500
+        store = _store([[], [], [{"title": "Notes", "content": long_text}]])
+
+        chunks = store.build_entity_chunks(
+            "eid", "Frank", summarize=lambda t: "SUMMARY")
+
+        assert "SUMMARY" in chunks
+
+    def test_long_knowledge_truncates_without_a_summarizer(self):
+        store = _store([[], [], [{"title": "Notes", "content": "x" * 2500}]])
+
+        chunks = store.build_entity_chunks("eid", "Frank")
+
+        assert len(chunks[-1]) == 2000
+
+    def test_empty_knowledge_rows_are_skipped(self):
+        store = _store([[], [], [{"title": None, "content": None}]])
+
+        assert store.build_entity_chunks("eid", "Frank") == ["Frank"]
+
+
+class TestEmbeddedChunkLookup:
+    def test_dimension_selects_the_matching_vector_column(self):
+        store = _store([[("Frank: uses Rust",)]])
+        texts = store.get_embedded_chunk_texts("eid", 1024)
+
+        assert texts == {"Frank: uses Rust"}
+        assert "embedding_v2 IS NOT NULL" in store._last_cursor.sql[0]
+
+        store = _store([[]])
+        store.get_embedded_chunk_texts("eid", 1536)
+        sql = store._last_cursor.sql[0]
+        assert "embedding IS NOT NULL" in sql and "embedding_v2" not in sql
+
+    def test_deleting_no_texts_touches_nothing(self):
+        store = _store([[]])
+        store.delete_embeddings_for_texts("eid", [])
+
+        assert store._last_cursor.sql == []

--- a/tests/test_oauth_redirect.py
+++ b/tests/test_oauth_redirect.py
@@ -1,0 +1,95 @@
+"""Regression tests for the OAuth redirect policy.
+
+The authorization code exchanges for a full-access API key, so any host that
+can receive one can take over an account: send the victim a link to the real
+/oauth/authorize carrying an attacker redirect_uri, let them log in on
+mengram.io, collect the code. PKCE is no defence — the malicious client picks
+its own challenge — and client registration is open, so a per-client list would
+be attacker-supplied. The allowlist has to be ours.
+"""
+
+import pytest
+
+from cloud.oauth_policy import redirect_uri_error
+
+
+@pytest.fixture
+def allowlist(monkeypatch):
+    def _set(value):
+        monkeypatch.setenv("OAUTH_REDIRECT_ALLOWLIST", value)
+    return _set
+
+
+@pytest.fixture(autouse=True)
+def _no_allowlist(monkeypatch):
+    monkeypatch.delenv("OAUTH_REDIRECT_ALLOWLIST", raising=False)
+
+
+class TestSchemeRules:
+    """Enforced whether or not an allowlist is configured."""
+
+    def test_https_is_accepted(self):
+        assert redirect_uri_error("https://claude.ai/api/mcp/auth_callback") is None
+
+    def test_plain_http_is_rejected_off_loopback(self):
+        assert redirect_uri_error("http://evil.com/cb") == "redirect_uri must use HTTPS"
+
+    def test_loopback_may_use_http_for_local_clients(self):
+        assert redirect_uri_error("http://localhost:8931/cb") is None
+        assert redirect_uri_error("http://127.0.0.1:8931/cb") is None
+
+    def test_non_web_schemes_are_rejected(self):
+        assert redirect_uri_error("javascript:alert(1)") == "Invalid redirect_uri scheme"
+        assert redirect_uri_error("file:///etc/passwd") == "Invalid redirect_uri scheme"
+
+    def test_empty_redirect_uri_is_not_an_error(self):
+        """Absent redirect_uri means there is nowhere to leak a code to."""
+        assert redirect_uri_error("") is None
+
+
+class TestAllowlistEnforcement:
+    def test_unlisted_host_is_rejected(self, allowlist):
+        allowlist("claude.ai,claude.com")
+
+        assert redirect_uri_error("https://attacker.com/cb") == "redirect_uri is not allowed"
+
+    def test_listed_host_passes(self, allowlist):
+        allowlist("claude.ai,claude.com")
+
+        assert redirect_uri_error("https://claude.ai/api/mcp/auth_callback") is None
+        assert redirect_uri_error("https://claude.com/api/mcp/auth_callback") is None
+
+    def test_subdomains_of_a_listed_host_pass(self, allowlist):
+        allowlist("claude.ai")
+
+        assert redirect_uri_error("https://api.claude.ai/cb") is None
+
+    def test_suffix_lookalike_does_not_pass(self, allowlist):
+        """notclaude.ai must not slip through an endswith check."""
+        allowlist("claude.ai")
+
+        assert redirect_uri_error("https://notclaude.ai/cb") == "redirect_uri is not allowed"
+
+    def test_host_match_is_case_insensitive(self, allowlist):
+        allowlist("Claude.AI")
+
+        assert redirect_uri_error("https://CLAUDE.ai/cb") is None
+
+    def test_loopback_still_allowed_under_an_allowlist(self, allowlist):
+        """Local MCP clients bind random loopback ports; never lock them out."""
+        allowlist("claude.ai")
+
+        assert redirect_uri_error("http://localhost:9999/cb") is None
+
+    def test_whitespace_and_blank_entries_are_ignored(self, allowlist):
+        allowlist(" claude.ai , , ")
+
+        assert redirect_uri_error("https://claude.ai/cb") is None
+        assert redirect_uri_error("https://attacker.com/cb") == "redirect_uri is not allowed"
+
+    def test_allowlist_is_read_per_call(self, allowlist):
+        """Set the env var and the next request is already governed by it."""
+        assert redirect_uri_error("https://attacker.com/cb") is None  # allowlist off
+
+        allowlist("claude.ai")
+        assert redirect_uri_error("https://attacker.com/cb") == "redirect_uri is not allowed"

--- a/tests/test_quota_guard.py
+++ b/tests/test_quota_guard.py
@@ -1,0 +1,110 @@
+"""Regression tests for CloudStore.check_and_increment.
+
+The upsert has two arms and only one of them used to carry the quota bound.
+The ON CONFLICT arm checks `current + count <= max`, but the INSERT arm fires
+on the period's first call — when no counter row exists yet — and wrote any
+count it was given. A single oversized request on the 1st of the month (a
+300-page PDF against a 40-add plan) therefore went through unmetered.
+
+Hermetic: CloudStore is built without __init__ and given a stub cursor.
+"""
+
+import contextlib
+
+import pytest
+
+from cloud.store import CloudStore
+
+
+class _FakeCursor:
+    def __init__(self, rows):
+        self._rows = list(rows)
+        self.sql = []
+
+    def execute(self, sql, params=None):
+        self.sql.append(" ".join(sql.split()))
+
+    def fetchone(self):
+        return self._rows.pop(0) if self._rows else None
+
+
+class _FakeCache:
+    def __init__(self):
+        self.invalidated = []
+
+    def invalidate(self, key):
+        self.invalidated.append(key)
+
+
+def _store(rows):
+    store = CloudStore.__new__(CloudStore)
+    cursor = _FakeCursor(rows)
+
+    @contextlib.contextmanager
+    def _cursor(dict_cursor=False):
+        yield cursor
+
+    store._cursor = _cursor
+    store._last_cursor = cursor
+    store.cache = _FakeCache()
+    return store
+
+
+class TestOversizedCallIsRejected:
+    def test_first_call_of_the_period_cannot_exceed_the_whole_allowance(self):
+        """No counter row yet (fetchone → None) and count > max."""
+        store = _store([None])
+
+        with pytest.raises(ValueError) as exc:
+            store.check_and_increment("user-1", "add", max_allowed=40, count=300)
+
+        assert str(exc.value) == "quota_exceeded:add:0:40"
+
+    def test_oversized_call_never_reaches_the_upsert(self):
+        store = _store([None])
+
+        with pytest.raises(ValueError):
+            store.check_and_increment("user-1", "add", max_allowed=40, count=300)
+
+        assert not any("INSERT INTO usage_counters" in s
+                       for s in store._last_cursor.sql), "unbounded INSERT ran"
+
+    def test_error_reports_the_real_current_count(self):
+        store = _store([(12,)])
+
+        with pytest.raises(ValueError) as exc:
+            store.check_and_increment("user-1", "search", max_allowed=200, count=500)
+
+        assert str(exc.value) == "quota_exceeded:search:12:200"
+
+
+class TestCallsWithinQuotaStillWork:
+    def test_count_equal_to_the_limit_is_allowed(self):
+        """The limit is reachable — 40 adds on a 40-add plan must pass."""
+        store = _store([(40,)])
+
+        assert store.check_and_increment("user-1", "add", max_allowed=40, count=40) == 40
+        assert any("INSERT INTO usage_counters" in s for s in store._last_cursor.sql)
+
+    def test_quota_exceeded_by_existing_usage_still_raises(self):
+        """Upsert returns no row (bound failed), then current is read back."""
+        store = _store([None, (39,)])
+
+        with pytest.raises(ValueError) as exc:
+            store.check_and_increment("user-1", "add", max_allowed=40, count=2)
+
+        assert str(exc.value) == "quota_exceeded:add:39:40"
+
+    def test_unlimited_plan_delegates_without_bounds_checking(self):
+        store = _store([])
+        calls = []
+        store.increment_usage = lambda u, a, c: calls.append((u, a, c)) or 999
+
+        assert store.check_and_increment("user-1", "add", max_allowed=-1, count=300) == 999
+        assert calls == [("user-1", "add", 300)]
+
+    def test_unknown_action_is_rejected(self):
+        store = _store([])
+
+        with pytest.raises(ValueError, match="Invalid action"):
+            store.check_and_increment("user-1", "drop_tables", max_allowed=10)


### PR DESCRIPTION
Fixes found while auditing the memory pipeline, quota accounting, cron scheduling and the OAuth flow. Four independent commits, each compiling and passing tests on its own so any one can be reverted or bisected in isolation.

## What changed

**`fix(memory)`** — `/v1/add` re-embedded only the facts extracted from the conversation being ingested, so facts stored earlier lost their embeddings and stopped surfacing in search while their rows remained in the table. `build_entity_chunks()` becomes the single source of chunk text for both `/v1/add` and `/v1/reindex`, which had drifted to different formats — search recovers fact text from the chunk, so the two have to agree. Embedding is now incremental (only missing chunks are sent, chunks the entity no longer has are retired), and old vectors are replaced only once their replacements exist instead of being cleared before the embedder is called.

**`fix(billing)`** — `dry_run` returned before `use_quota` ran, so it consumed model calls without being counted; it is metered like a normal add now. `check_and_increment` enforced its limit only on the `ON CONFLICT` arm, while the `INSERT` arm — which runs on the first call of a billing period — accepted any count.

**`fix(cron)`** — cron threads took the advisory lock once at startup and exited permanently on failure. Deploys overlap, so an incoming instance loses the race to the outgoing one and stops running triggers, drip email, memory health and reflection until something restarts it. The loops now stand by and retry, and check the lock connection is still live before each pass, since the pooler drops idle connections.

**`fix(oauth)`** — redirect targets are checked against `OAUTH_REDIRECT_ALLOWLIST` at `/oauth/authorize` and again at `/oauth/verify`, and the sign-in card names the destination host.

## Tests

29 new tests, all hermetic — no database, no network, no API keys. `CloudStore` is built without `__init__` and given a stub cursor.

| File | Covers |
|---|---|
| `tests/test_entity_chunks.py` | chunk composition and the format search depends on |
| `tests/test_quota_guard.py` | quota bounds, including that the limit stays reachable |
| `tests/test_oauth_redirect.py` | scheme rules and allowlist matching |

Suite goes from 126 to 155 passing. The three `test_parser.py` failures predate this branch — `parse_vault("test_vault")` needs a fixture directory that is gitignored and absent from a fresh clone.

## Deploying

`OAUTH_REDIRECT_ALLOWLIST` ships empty, which preserves current behaviour and logs each redirect target seen. Collect the real set of client callbacks from the logs before setting it, so enabling the check cannot lock out a live client.
