### PR TITLE
fix(privacy): delete everything the user asked to delete

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -8853,11 +8853,17 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
 
     @app.delete("/v1/memories/all", tags=["Memory"])
     async def delete_all_memories(sub_user_id: str = Query("default"), ctx: AuthContext = Depends(auth)):
-        """Delete ALL memories (entities, facts, relations, knowledge). Irreversible."""
+        """Delete ALL memories for this sub-user — entities and their facts,
+        plus episodes, procedures, raw conversation text and triggers.
+        Irreversible."""
         user_id = ctx.user_id
-        count = store.delete_all_entities(user_id, sub_user_id=sub_user_id)
-        logger.warning(f"🗑️ DELETE ALL | user={user_id[:8]} | deleted={count} entities")
-        return {"status": "deleted", "count": count}
+        counts = store.delete_all_memories(user_id, sub_user_id=sub_user_id)
+        total = sum(counts.values())
+        logger.warning(
+            f"🗑️ DELETE ALL | user={user_id[:8]} | sub={sub_user_id} | rows={total} | {counts}")
+        # `count` stays the entity count the dashboard has always shown.
+        return {"status": "deleted", "count": counts.get("entities", 0),
+                "deleted": counts, "rows": total}
 
     @app.get("/v1/capture-policy", tags=["System"])
     async def get_capture_policy(ctx: AuthContext = Depends(auth)):

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -2707,27 +2707,97 @@ class CloudStore:
         self._schedule_matview_refresh()
         return True
 
-    def delete_all_entities(self, user_id: str, sub_user_id: str = "default") -> int:
-        """Delete ALL entities with their facts, relations, knowledge, embeddings.
-        Children deleted explicitly — no cascade reliance (see delete_entity)."""
+    def _existing_tables(self, cur, names: tuple) -> set:
+        """The subset of `names` that exists in this database.
+
+        Several tables are created lazily on first use, so an install that has
+        never sent a drip email or run an agent genuinely does not have them.
+        Deleting from a missing one raises — and because connections run in
+        autocommit, every delete before that point has already landed, leaving
+        the data half-erased while the caller sees a 500.
+        """
+        cur.execute(
+            "SELECT n FROM unnest(%s::text[]) AS t(n) "
+            "WHERE to_regclass('public.' || t.n) IS NOT NULL",
+            (list(names),)
+        )
+        return {r[0] for r in cur.fetchall()}
+
+    def delete_all_memories(self, user_id: str, sub_user_id: str = "default") -> dict:
+        """Erase everything remembered for one sub_user. Returns per-table counts.
+
+        Everything the user can read back has to go. Deleting only entities
+        left /v1/episodes and /v1/procedures still answering, and the verbatim
+        conversation text still sitting in conversation_chunks, after the
+        account had been told its memories were deleted.
+
+        Children before parents throughout: production tables predate the
+        ON DELETE CASCADE that schema.sql declares, so nothing is cascaded for
+        us. `entities.user_id` is a uuid while the other roots store it as
+        text, hence the two forms of the scope predicate.
+        """
+        counts = {}
+        scope = (user_id, sub_user_id)
+
         with self._cursor() as cur:
-            cur.execute(
-                "SELECT id FROM entities WHERE user_id = %s AND sub_user_id = %s",
-                (user_id, sub_user_id)
-            )
-            entity_ids = [str(r[0]) for r in cur.fetchall()]
-            count = len(entity_ids)
+            present = self._existing_tables(cur, (
+                "facts", "knowledge", "embeddings", "relations", "entities",
+                "episodes", "episode_embeddings",
+                "procedures", "procedure_embeddings", "procedure_evolution",
+                "conversation_chunks", "chunk_embeddings", "memory_triggers",
+            ))
+
+            def roots(table, uuid_owner=False):
+                if table not in present:
+                    return []
+                owner = "user_id" if uuid_owner else "user_id::text"
+                cur.execute(
+                    f"SELECT id FROM {table} WHERE {owner} = %s AND sub_user_id = %s", scope)
+                return [str(r[0]) for r in cur.fetchall()]
+
+            def wipe(table, predicate, params):
+                if table not in present:
+                    return
+                cur.execute(f"DELETE FROM {table} WHERE {predicate}", params)
+                counts[table] = counts.get(table, 0) + cur.rowcount
+
+            entity_ids = roots("entities", uuid_owner=True)
+            episode_ids = roots("episodes")
+            procedure_ids = roots("procedures")
+            chunk_ids = roots("conversation_chunks")
+
+            # Grandchildren: vectors and evolution history keyed off the roots.
+            if episode_ids:
+                wipe("episode_embeddings", "episode_id = ANY(%s::uuid[])", (episode_ids,))
+                wipe("procedure_evolution", "episode_id = ANY(%s::uuid[])", (episode_ids,))
+            if procedure_ids:
+                wipe("procedure_embeddings", "procedure_id = ANY(%s::uuid[])", (procedure_ids,))
+                wipe("procedure_evolution", "procedure_id = ANY(%s::uuid[])", (procedure_ids,))
+            if chunk_ids:
+                wipe("chunk_embeddings", "chunk_id = ANY(%s::uuid[])", (chunk_ids,))
             if entity_ids:
                 for child in ("facts", "knowledge", "embeddings"):
-                    cur.execute(f"DELETE FROM {child} WHERE entity_id = ANY(%s::uuid[])", (entity_ids,))
-                cur.execute(
-                    "DELETE FROM relations WHERE source_id = ANY(%s::uuid[]) OR target_id = ANY(%s::uuid[])",
-                    (entity_ids, entity_ids))
-                cur.execute("DELETE FROM entities WHERE id = ANY(%s::uuid[])", (entity_ids,))
+                    wipe(child, "entity_id = ANY(%s::uuid[])", (entity_ids,))
+                wipe("relations",
+                     "source_id = ANY(%s::uuid[]) OR target_id = ANY(%s::uuid[])",
+                     (entity_ids, entity_ids))
+
+            # Roots.
+            if entity_ids:
+                wipe("entities", "id = ANY(%s::uuid[])", (entity_ids,))
+            if episode_ids:
+                wipe("episodes", "id = ANY(%s::uuid[])", (episode_ids,))
+            if procedure_ids:
+                wipe("procedures", "id = ANY(%s::uuid[])", (procedure_ids,))
+            if chunk_ids:
+                wipe("conversation_chunks", "id = ANY(%s::uuid[])", (chunk_ids,))
+            wipe("memory_triggers", "user_id::text = %s AND sub_user_id = %s", scope)
+
         self.cache.invalidate(f"stats:{user_id}")
         self.cache.invalidate(f"graph:{user_id}:{sub_user_id}:150")
+        self.cache.invalidate(f"profile:{user_id}")
         self._schedule_matview_refresh()
-        return count
+        return counts
 
     def delete_account(self, user_id: str) -> dict:
         """Permanently delete a user account and ALL associated data across
@@ -2782,17 +2852,27 @@ class CloudStore:
                 "team_members", "api_keys", "usage_log", "subscriptions",
                 "usage_counters",
             ]
+            # Four of these are created lazily on first use, so an install
+            # where nobody ever opened a checkout or ran an agent does not have
+            # them. Skipping the absent ones keeps deletion from aborting
+            # part-way and leaving a half-erased account behind.
+            present = self._existing_tables(cur, tuple(user_tables) + ("teams", "email_codes"))
             for table in user_tables:
+                if table not in present:
+                    continue
                 cur.execute(f"DELETE FROM {table} WHERE user_id::text = %s", (user_id,))  # noqa: S608 — fixed list above
                 counts[table] = cur.rowcount
-            cur.execute("DELETE FROM teams WHERE created_by = %s", (user_id,))
-            counts["teams"] = cur.rowcount
+            if "teams" in present:
+                cur.execute("DELETE FROM teams WHERE created_by = %s", (user_id,))
+                counts["teams"] = cur.rowcount
             if email:
-                cur.execute("DELETE FROM email_codes WHERE email = %s", (email,))
-                counts["email_codes"] = cur.rowcount
+                if "email_codes" in present:
+                    cur.execute("DELETE FROM email_codes WHERE email = %s", (email,))
+                    counts["email_codes"] = cur.rowcount
                 # drip_emails rows can predate signup (user_id NULL) — clear by email too
-                cur.execute("DELETE FROM drip_emails WHERE email = %s", (email,))
-                counts["drip_emails"] += cur.rowcount
+                if "drip_emails" in present:
+                    cur.execute("DELETE FROM drip_emails WHERE email = %s", (email,))
+                    counts["drip_emails"] = counts.get("drip_emails", 0) + cur.rowcount
             cur.execute("DELETE FROM users WHERE id = %s", (user_id,))
             counts["users"] = cur.rowcount
         for prefix in ("stats:", "profile:", "rules:", "graph:", "value_mirror:", "sub:"):

--- a/tests/test_delete_completeness.py
+++ b/tests/test_delete_completeness.py
@@ -1,0 +1,177 @@
+"""Regression tests for deletion completeness.
+
+`DELETE /v1/memories/all` used to remove entities and nothing else, so after a
+user was told their memories were deleted, /v1/episodes and /v1/procedures kept
+answering and the verbatim conversation text stayed in the database. These
+tests pin down what the wipe has to reach, and in what order.
+
+Production tables lack the ON DELETE CASCADE that schema.sql declares, so
+child-before-parent ordering is load-bearing rather than cosmetic.
+
+Hermetic: CloudStore is built without __init__ and given a stub cursor.
+"""
+
+import contextlib
+import re
+
+import pytest
+
+from cloud.store import CloudStore
+
+ROOTS = ("entities", "episodes", "procedures", "conversation_chunks")
+ALL_TABLES = ROOTS + (
+    "facts", "knowledge", "embeddings", "relations", "memory_triggers",
+    "episode_embeddings", "procedure_embeddings", "procedure_evolution",
+    "chunk_embeddings",
+)
+
+
+class _FakeCursor:
+    """Answers the three query shapes delete_all_memories issues."""
+
+    def __init__(self, present, row_ids):
+        self.present = set(present)
+        self.row_ids = row_ids          # table -> list of ids it should report
+        self.sql = []
+        self.rowcount = 1
+        self._last = []
+
+    def execute(self, sql, params=None):
+        flat = " ".join(sql.split())
+        self.sql.append(flat)
+        if "to_regclass" in flat:
+            self._last = [(n,) for n in (params[0] if params else []) if n in self.present]
+        elif flat.startswith("SELECT id FROM"):
+            table = flat.split()[3]
+            self._last = [(i,) for i in self.row_ids.get(table, [])]
+        else:
+            self._last = []
+
+    def fetchall(self):
+        return self._last
+
+    def deletes(self):
+        """Tables targeted by DELETE, in the order they were issued."""
+        return [m.group(1) for s in self.sql
+                if (m := re.match(r"DELETE FROM (\w+)", s))]
+
+
+class _Cache:
+    def invalidate(self, key):
+        pass
+
+
+def _store(present=ALL_TABLES, row_ids=None):
+    store = CloudStore.__new__(CloudStore)
+    cur = _FakeCursor(present, row_ids if row_ids is not None
+                      else {t: ["11111111-1111-1111-1111-111111111111"] for t in ROOTS})
+
+    @contextlib.contextmanager
+    def _cursor(dict_cursor=False):
+        yield cur
+
+    store._cursor = _cursor
+    store.cache = _Cache()
+    store._schedule_matview_refresh = lambda: None
+    store._cur = cur
+    return store
+
+
+class TestEverythingUserFacingIsRemoved:
+    def test_wipe_reaches_beyond_entities(self):
+        """The original bug: only entities were deleted."""
+        s = _store()
+        s.delete_all_memories("user-1")
+
+        hit = set(s._cur.deletes())
+        for table in ("episodes", "procedures", "conversation_chunks", "memory_triggers"):
+            assert table in hit, f"{table} survived the wipe"
+
+    def test_verbatim_conversation_text_is_removed(self):
+        s = _store()
+        s.delete_all_memories("user-1")
+
+        assert "conversation_chunks" in s._cur.deletes()
+
+    def test_every_child_table_is_reached(self):
+        s = _store()
+        s.delete_all_memories("user-1")
+
+        hit = set(s._cur.deletes())
+        for table in ("facts", "knowledge", "embeddings", "relations",
+                      "episode_embeddings", "procedure_embeddings", "chunk_embeddings"):
+            assert table in hit, f"{table} would be orphaned"
+
+    def test_counts_are_reported_per_table(self):
+        s = _store()
+        counts = s.delete_all_memories("user-1")
+
+        assert counts["entities"] > 0 and counts["episodes"] > 0
+
+
+class TestChildBeforeParent:
+    """No CASCADE in production — order is what keeps rows from orphaning."""
+
+    @pytest.mark.parametrize("child,parent", [
+        ("episode_embeddings", "episodes"),
+        ("procedure_embeddings", "procedures"),
+        ("procedure_evolution", "procedures"),
+        ("chunk_embeddings", "conversation_chunks"),
+        ("facts", "entities"),
+        ("knowledge", "entities"),
+        ("embeddings", "entities"),
+        ("relations", "entities"),
+    ])
+    def test_child_deleted_first(self, child, parent):
+        s = _store()
+        s.delete_all_memories("user-1")
+        order = s._cur.deletes()
+
+        assert order.index(child) < order.index(parent), \
+            f"{child} must be deleted before {parent}"
+
+
+class TestScoping:
+    def test_roots_are_scoped_by_user_and_sub_user(self):
+        s = _store()
+        s.delete_all_memories("user-1", sub_user_id="alice")
+
+        selects = [q for q in s._cur.sql if q.startswith("SELECT id FROM")]
+        assert selects, "no root lookup ran"
+        for q in selects:
+            assert "sub_user_id = %s" in q, f"unscoped root lookup: {q}"
+
+    def test_entities_use_the_uuid_owner_column(self):
+        """entities.user_id is uuid; the other roots store it as text."""
+        s = _store()
+        s.delete_all_memories("user-1")
+
+        ent = next(q for q in s._cur.sql if q.startswith("SELECT id FROM entities"))
+        eps = next(q for q in s._cur.sql if q.startswith("SELECT id FROM episodes"))
+        assert "WHERE user_id = %s" in ent
+        assert "WHERE user_id::text = %s" in eps
+
+
+class TestMissingTablesDoNotAbortTheWipe:
+    """Lazily-created tables are absent on installs that never used them.
+    Connections are autocommit, so aborting half-way leaves data destroyed
+    and the account intact — the worst of both."""
+
+    def test_absent_table_is_skipped_not_queried(self):
+        s = _store(present=[t for t in ALL_TABLES if t != "memory_triggers"])
+        s.delete_all_memories("user-1")
+
+        assert "memory_triggers" not in s._cur.deletes()
+
+    def test_the_rest_still_gets_deleted(self):
+        s = _store(present=[t for t in ALL_TABLES if t != "chunk_embeddings"])
+        counts = s.delete_all_memories("user-1")
+
+        assert "entities" in counts and "episodes" in counts
+
+    def test_nothing_to_delete_is_not_an_error(self):
+        s = _store(row_ids={t: [] for t in ROOTS})
+        counts = s.delete_all_memories("user-1")
+
+        assert counts.get("entities", 0) == 0
+        assert "entities" not in s._cur.deletes()


### PR DESCRIPTION
`DELETE /v1/memories/all` removed entities and their facts and stopped there. Episodes, procedures, the raw conversation text in `conversation_chunks` and the derived triggers stayed behind — and stayed readable, because `/v1/episodes` and `/v1/procedures` answer from those tables directly. Pressing "delete all memories" returned 200 while the conversations could still be read back.

`delete_all_memories()` now clears every table the wipe is meant to reach, children before parents, and reports per-table counts instead of a bare entity number. Nothing cascades for us: production predates the `ON DELETE CASCADE` that `schema.sql` declares. `entities.user_id` is a uuid while the other roots store it as text, so the scope predicate comes in two forms.

Account deletion had the same root cause in a different shape. It walks a fixed list of seventeen tables, four of which are created lazily and are absent on an install that never sent a drip email or ran an agent. Deleting from a missing table raised, and with autocommit connections everything already deleted had landed — memories destroyed, account and API keys intact, caller handed a 500. Both paths now skip tables the database does not have.

## Verified against a real Postgres

- a wipe leaves zero rows for the target sub-user, and zero orphans across all five child tables
- a second sub-user's data is untouched
- account deletion completes on a schema built from `schema.sql` alone, where the lazy tables do not exist

17 new hermetic tests in `tests/test_delete_completeness.py` — no database, no network — pin the table coverage, the child-before-parent ordering, the two forms of the scope predicate, and the missing-table guard.

Suite goes from 168 to 185 passing. The three `test_parser.py` failures predate this branch: they need a fixture directory that is gitignored and absent from a fresh clone.
