### PR TITLE
Point the VS Code manifest at the repository that exists

### DIFF
--- a/vscode-mengram/package.json
+++ b/vscode-mengram/package.json
@@ -29,7 +29,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/alibaizhanov/vscode-mengram"
+    "url": "https://github.com/alibaizhanov/mengram",
+        "directory": "vscode-mengram"
   },
   "homepage": "https://mengram.io",
   "main": "./dist/extension.js",


### PR DESCRIPTION
The extension manifest advertised `github.com/alibaizhanov/vscode-mengram`, which 404s — the extension has always lived in this repo under `vscode-mengram/`. The marketplace renders that field as the source link on the listing page, so publishing as-is would ship a dead link.

Now points at this repository with the subdirectory named, the same shape npm uses for packages inside a monorepo.

Found while preparing the extension for its first marketplace publish. Packaging verified: `mengram-0.2.0.vsix`, 12 files, 21 KB, icon 128×128.