### PR TITLE
feat(export): get the whole memory out as plain Markdown

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -30,7 +30,7 @@ logger = logging.getLogger("mengram")
 
 from fastapi import FastAPI, HTTPException, Depends, Header, Form, Query, Request, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse, FileResponse, PlainTextResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, FileResponse, PlainTextResponse, RedirectResponse, Response
 from dataclasses import dataclass
 from pydantic import BaseModel, Field
 
@@ -8295,6 +8295,94 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
         entities, total = store.get_all_entities(user_id, sub_user_id=sub_user_id, limit=limit, offset=offset)
         store.log_usage(user_id, "get_all")
         return {"memories": entities, "total": total, "limit": limit, "offset": offset}
+
+    # How much a single export will serialise. Generous enough that almost
+    # nobody meets it, bounded so one request cannot pin a worker.
+    EXPORT_CAP = 5000
+
+    def _collect_export(user_id: str, sub_user_id: str) -> dict:
+        """Everything the export serialises, read once and reused by both formats."""
+        entities = store.get_all_entities_full(user_id, sub_user_id=sub_user_id)[:EXPORT_CAP]
+        episodes = store.get_episodes(user_id, limit=EXPORT_CAP, sub_user_id=sub_user_id)
+        procedures = store.get_procedures(user_id, limit=EXPORT_CAP, sub_user_id=sub_user_id)
+
+        # A procedure's evolution is the record that earned its trust, so it
+        # belongs in the export. One query per procedure, which is why it is
+        # skipped once the list gets long.
+        evolution = {}
+        if len(procedures) <= 200:
+            for proc in procedures:
+                try:
+                    log = store.get_procedure_evolution(user_id, str(proc["id"]),
+                                                        sub_user_id=sub_user_id)
+                    if log:
+                        evolution[str(proc["id"])] = log
+                except Exception as e:
+                    logger.warning(f"⚠️ Export: evolution for {proc.get('name')}: {e}")
+
+        return {"entities": entities, "episodes": episodes,
+                "procedures": procedures, "evolution": evolution}
+
+    @app.get("/v1/export", tags=["Memory"])
+    async def export_memory(format: str = Query("markdown", pattern="^(markdown|json)$"),
+                            sub_user_id: str = Query("default"),
+                            ctx: AuthContext = Depends(auth)):
+        """Export this memory as plain files you own.
+
+        `format=markdown` returns a zip of an Obsidian-native tree — one file per
+        entity, relations as `[[wikilinks]]`, procedures with their track record
+        and the failures that changed them. `format=json` returns the same
+        content structured, for the CLI and the plugin.
+
+        Read-only, and deliberately not charged against the add or search quota:
+        getting your data out should never cost you the ability to use the
+        product. The per-minute rate limit still applies.
+        """
+        from cloud import markdown_export
+
+        user_id = ctx.user_id
+        data = _collect_export(user_id, sub_user_id)
+        store.log_usage(user_id, "export")
+
+        if format == "json":
+            return {
+                "entities": data["entities"],
+                "episodes": data["episodes"],
+                "procedures": data["procedures"],
+                "evolution": data["evolution"],
+                "counts": {k: len(data[k]) for k in ("entities", "episodes", "procedures")},
+            }
+
+        profile = None
+        try:
+            # Cached; never generated on the export path, so an export cannot
+            # trigger a model call the caller did not ask for.
+            cached = store.cache.get(f"profile:{user_id}")
+            if isinstance(cached, dict):
+                profile = cached.get("profile")
+        except Exception:
+            pass
+
+        tree = markdown_export.build_tree(
+            entities=data["entities"], episodes=data["episodes"],
+            procedures=data["procedures"], profile=profile,
+            evolution_by_procedure=data["evolution"],
+        )
+
+        import io as _io
+        import zipfile as _zipfile
+        buffer = _io.BytesIO()
+        with _zipfile.ZipFile(buffer, "w", _zipfile.ZIP_DEFLATED) as archive:
+            for path, text in sorted(tree.items()):
+                archive.writestr(path, text)
+        buffer.seek(0)
+
+        stamp = datetime.date.today().isoformat()
+        return Response(
+            content=buffer.getvalue(),
+            media_type="application/zip",
+            headers={"Content-Disposition": f'attachment; filename="mengram-{stamp}.zip"'},
+        )
 
     @app.post("/v1/reindex", tags=["Memory"])
     async def reindex(sub_user_id: str = Query("default"), ctx: AuthContext = Depends(auth)):

--- a/cloud/markdown_export.py
+++ b/cloud/markdown_export.py
@@ -1,0 +1,321 @@
+"""Serialise a user's memory into an Obsidian-native Markdown tree.
+
+The promise this exists to keep: your memory is not locked in our database.
+Facts, events and the workflows it learned come out as plain files you can
+read, grep, edit and keep after we are gone.
+
+Obsidian-native means relations become `[[wikilinks]]`, so the graph view works
+with no configuration — the files are the graph. Every file carries its id in
+frontmatter so a future import updates rather than duplicates.
+
+Pure functions: dicts in, `{path: text}` out. No database, no model call, no
+filesystem. The API endpoint, the CLI and the plugin all serialise through here
+so the three can never drift apart.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime
+
+ROOT = "Mengram"
+
+# Characters a filename cannot carry on the platforms Obsidian runs on. Kept
+# deliberately small: entity names are the note titles users will see and link
+# by, so we preserve everything we safely can rather than lowercasing or
+# stripping punctuation the way a URL slug would.
+_UNSAFE = re.compile(r'[\\/:*?"<>|\x00-\x1f]')
+_SPACES = re.compile(r"\s+")
+MAX_STEM = 80
+
+
+def slugify(name: str) -> str:
+    """A filename that survives every filesystem while still reading as the name.
+
+    The original always goes in the `# H1` heading, so nothing is lost when a
+    name has to be trimmed here.
+    """
+    stem = _UNSAFE.sub("-", name or "")
+    stem = _SPACES.sub(" ", stem).strip(" .")
+    if len(stem) > MAX_STEM:
+        stem = stem[:MAX_STEM].rstrip(" .-")
+    return stem or "unnamed"
+
+
+def _unique(stem: str, taken: set) -> str:
+    """Two entities can legitimately share a name once punctuation is stripped.
+    Rather than let one silently overwrite the other, number the later ones."""
+    if stem not in taken:
+        taken.add(stem)
+        return stem
+    n = 2
+    while f"{stem} ({n})" in taken:
+        n += 1
+    stem = f"{stem} ({n})"
+    taken.add(stem)
+    return stem
+
+
+def _scalar(value) -> str:
+    """One YAML scalar. Quotes only when the value would otherwise be misread —
+    unquoted frontmatter is far easier for a human to skim."""
+    if value is None:
+        return '""'
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    text = str(value)
+    if text != text.strip() or _needs_quotes(text):
+        return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return text
+
+
+def _needs_quotes(text: str) -> bool:
+    if text == "":
+        return True
+    if text[0] in "-?:,[]{}#&*!|>'\"%@`":
+        return True
+    return ":" in text or "\n" in text
+
+
+def frontmatter(fields: dict) -> str:
+    """YAML block, skipping empty values so the header stays readable."""
+    lines = ["---"]
+    for key, value in fields.items():
+        if value is None or value == "" or value == []:
+            continue
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            lines.extend(f"  - {_scalar(v)}" for v in value)
+        else:
+            lines.append(f"{key}: {_scalar(value)}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _day(value) -> str:
+    """Just the date part, whatever shape the timestamp arrived in."""
+    if isinstance(value, (datetime, date)):
+        return value.date().isoformat() if isinstance(value, datetime) else value.isoformat()
+    text = str(value or "")
+    return text[:10] if len(text) >= 10 else ""
+
+
+def wikilink(name: str, targets: dict) -> str:
+    """A link Obsidian can follow.
+
+    When the file had to be renamed to be safe, the link carries an alias so it
+    still reads as the real name: `[[a-b|a/b]]`.
+    """
+    stem = targets.get(name)
+    if stem is None:
+        # Not exported (a relation can point outside the current sub-user's
+        # slice). Link anyway — Obsidian shows it as an unresolved node, which
+        # is honest about there being something there.
+        stem = slugify(name)
+    return f"[[{stem}]]" if stem == name else f"[[{stem}|{name}]]"
+
+
+# ---- files ----------------------------------------------------------------
+
+def entity_file(entity: dict, targets: dict) -> str:
+    name = entity.get("entity") or "unnamed"
+    body = [
+        frontmatter({
+            "mengram_type": "entity",
+            "entity_type": entity.get("type"),
+            "id": entity.get("id"),
+        }),
+        "",
+        f"# {name}",
+    ]
+
+    facts = [f for f in (entity.get("facts") or []) if f]
+    if facts:
+        body += ["", "## Facts", ""] + [f"- {f}" for f in facts]
+
+    relations = [r for r in (entity.get("relations") or []) if r.get("target")]
+    if relations:
+        body += ["", "## Relations", ""]
+        for r in relations:
+            verb = r.get("type") or "related to"
+            arrow = "→" if r.get("direction") != "incoming" else "←"
+            detail = f" — {r['detail']}" if r.get("detail") else ""
+            body.append(f"- {verb} {arrow} {wikilink(r['target'], targets)}{detail}")
+
+    knowledge = [k for k in (entity.get("knowledge") or []) if k.get("content") or k.get("title")]
+    if knowledge:
+        body += ["", "## Knowledge", ""]
+        for k in knowledge:
+            kind = k.get("type") or "note"
+            title = k.get("title") or ""
+            body.append(f"**[{kind}] {title}** — {k.get('content') or ''}".rstrip(" —"))
+            if k.get("artifact"):
+                body += ["", "```", str(k["artifact"]), "```"]
+
+    return "\n".join(body).rstrip() + "\n"
+
+
+def episode_file(episode: dict) -> str:
+    summary = episode.get("summary") or "untitled"
+    when = _day(episode.get("happened_at") or episode.get("created_at"))
+    body = [
+        frontmatter({
+            "mengram_type": "episode",
+            "id": episode.get("id"),
+            "happened": when,
+            "outcome": episode.get("outcome"),
+            "valence": episode.get("emotional_valence"),
+            "importance": episode.get("importance"),
+            "participants": episode.get("participants") or [],
+        }),
+        "",
+        f"# {summary}",
+    ]
+    if episode.get("context"):
+        body += ["", episode["context"]]
+    if episode.get("outcome"):
+        body += ["", f"**Outcome** — {episode['outcome']}"]
+    return "\n".join(body).rstrip() + "\n"
+
+
+def _reliability(success: int, fail: int) -> str:
+    total = success + fail
+    if total == 0:
+        return "untested"
+    return f"{round(100 * success / total)}% reliable"
+
+
+def procedure_file(procedure: dict, evolution: list = None) -> str:
+    """The differentiator, and the reason the export is worth having: a workflow
+    with its track record and the failures that changed it."""
+    name = procedure.get("name") or "unnamed"
+    success = int(procedure.get("success_count") or 0)
+    fail = int(procedure.get("fail_count") or 0)
+    version = procedure.get("version") or 1
+
+    body = [
+        frontmatter({
+            "mengram_type": "procedure",
+            "id": procedure.get("id"),
+            "version": version,
+            "success_count": success,
+            "fail_count": fail,
+        }),
+        "",
+        f"# {name} (v{version} · {_reliability(success, fail)})",
+    ]
+
+    if procedure.get("trigger_condition"):
+        body += ["", f"**When** — {procedure['trigger_condition']}"]
+
+    preconditions = [p for p in ((procedure.get("metadata") or {}).get("preconditions") or []) if p]
+    if preconditions:
+        body += ["", "**Preconditions**", ""] + [f"- {p}" for p in preconditions]
+
+    steps = procedure.get("steps") or []
+    if steps:
+        body += ["", "## Steps", ""]
+        for i, step in enumerate(steps, 1):
+            # steps are list[dict] with action/detail; older rows may hold plain
+            # strings, and a half-written export is worse than a plain one.
+            if isinstance(step, dict):
+                text = step.get("action") or ""
+                if step.get("detail"):
+                    text = f"{text} — {step['detail']}" if text else step["detail"]
+            else:
+                text = str(step)
+            body.append(f"{i}. {text}")
+
+    for entry in (evolution or []):
+        before, after = entry.get("version_before"), entry.get("version_after")
+        note = (entry.get("diff") or {}).get("reason") or entry.get("change_type") or "revised"
+        when = _day(entry.get("created_at"))
+        if "## Evolution" not in body:
+            body += ["", "## Evolution", ""]
+        stamp = f" ({when})" if when else ""
+        body.append(f"- v{before} → v{after}{stamp}: {note}")
+
+    return "\n".join(body).rstrip() + "\n"
+
+
+def index_file(counts: dict, entity_stems: list) -> str:
+    body = [
+        frontmatter({"mengram_type": "index", "generated": date.today().isoformat()}),
+        "",
+        "# Mengram",
+        "",
+    ]
+    if not any(counts.values()):
+        body += [
+            "This export is empty — nothing has been remembered yet.",
+            "",
+            "Notes you sync, conversations you add and workflows the agent learns",
+            "will appear here as files you own.",
+        ]
+        return "\n".join(body) + "\n"
+
+    body += [
+        f"- {counts.get('entities', 0)} entities",
+        f"- {counts.get('episodes', 0)} episodes",
+        f"- {counts.get('procedures', 0)} procedures",
+    ]
+    if entity_stems:
+        body += ["", "## Entities", ""] + [f"- [[{s}]]" for s in sorted(entity_stems)]
+    return "\n".join(body).rstrip() + "\n"
+
+
+def build_tree(entities: list = None, episodes: list = None, procedures: list = None,
+               profile: str = None, evolution_by_procedure: dict = None) -> dict:
+    """The whole export as `{relative path: file text}`.
+
+    Nothing is written here — the caller decides whether that becomes a zip, a
+    directory, or files in a vault.
+    """
+    entities = entities or []
+    episodes = episodes or []
+    procedures = procedures or []
+    evolution_by_procedure = evolution_by_procedure or {}
+
+    # Names resolve to stems first, so a relation written before its target is
+    # serialised still links to the right file.
+    taken: set = set()
+    targets = {}
+    for entity in entities:
+        name = entity.get("entity") or "unnamed"
+        targets[name] = _unique(slugify(name), taken)
+
+    tree = {}
+    for entity in entities:
+        stem = targets[entity.get("entity") or "unnamed"]
+        tree[f"{ROOT}/entities/{stem}.md"] = entity_file(entity, targets)
+
+    ep_taken: set = set()
+    for episode in episodes:
+        when = _day(episode.get("happened_at") or episode.get("created_at"))
+        stem = _unique(
+            f"{when}-{slugify(episode.get('summary') or 'episode')}" if when
+            else slugify(episode.get("summary") or "episode"),
+            ep_taken,
+        )
+        tree[f"{ROOT}/episodes/{stem}.md"] = episode_file(episode)
+
+    proc_taken: set = set()
+    for procedure in procedures:
+        stem = _unique(slugify(procedure.get("name") or "procedure"), proc_taken)
+        tree[f"{ROOT}/procedures/{stem}.md"] = procedure_file(
+            procedure, evolution_by_procedure.get(str(procedure.get("id"))))
+
+    if profile:
+        tree[f"{ROOT}/profile.md"] = "\n".join([
+            frontmatter({"mengram_type": "profile",
+                         "generated": date.today().isoformat()}),
+            "", "# Profile", "", profile.strip(),
+        ]) + "\n"
+
+    tree[f"{ROOT}/_index.md"] = index_file(
+        {"entities": len(entities), "episodes": len(episodes), "procedures": len(procedures)},
+        list(targets.values()),
+    )
+    return tree

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -2580,6 +2580,10 @@ class CloudStore:
                         "artifact": row["artifact"],
                     })
 
+            # The id rides along so callers can round-trip or re-query without
+            # a second lookup by name — the export needs it in frontmatter.
+            for eid, ent in entity_map.items():
+                ent["id"] = eid
             return [entity_map[str(e["id"])] for e in entities]
 
     def get_existing_context(self, user_id: str, max_entities: int = 40, max_facts_per: int = 10, sub_user_id: str = "default") -> str:

--- a/tests/test_markdown_export.py
+++ b/tests/test_markdown_export.py
@@ -1,0 +1,168 @@
+"""Tests for the Markdown export serialiser.
+
+The export exists to make one promise checkable: the memory is portable, and
+the files you get are the whole graph. These tests hold the parts that make
+that true — links that resolve, ids that survive, and filenames that do not
+collide or break a filesystem.
+
+Pure functions throughout: no database, no network, no filesystem.
+"""
+
+import pytest
+
+from cloud.markdown_export import (
+    build_tree, entity_file, episode_file, frontmatter, procedure_file,
+    slugify, wikilink,
+)
+
+
+def entity(name, **kw):
+    base = {"id": "id-" + name.lower(), "entity": name, "type": "technology",
+            "facts": [], "relations": [], "knowledge": []}
+    base.update(kw)
+    return base
+
+
+class TestFilenames:
+    def test_a_readable_name_is_kept_as_is(self):
+        """The filename is the note title users link by — don't mangle it."""
+        assert slugify("PostgreSQL") == "PostgreSQL"
+        assert slugify("Project Alpha") == "Project Alpha"
+
+    @pytest.mark.parametrize("raw", ["a/b", "a\\b", "a:b", "a*b", "a?b", 'a"b', "a<b", "a>b", "a|b"])
+    def test_characters_a_filesystem_rejects_are_replaced(self, raw):
+        assert not set(slugify(raw)) & set('\\/:*?"<>|')
+
+    def test_control_characters_are_replaced(self):
+        assert "\n" not in slugify("line\nbreak")
+
+    def test_overlong_names_are_trimmed(self):
+        assert len(slugify("x" * 300)) <= 80
+
+    def test_a_name_that_is_all_punctuation_still_yields_a_file(self):
+        assert slugify("///") not in ("", None)
+        assert slugify("") == "unnamed"
+
+    def test_colliding_names_do_not_overwrite_each_other(self):
+        tree = build_tree([entity("a/b"), entity("a:b")])
+        files = [p for p in tree if p.startswith("Mengram/entities/")]
+        assert len(files) == 2, "one entity silently replaced the other"
+
+
+class TestLinksResolve:
+    def test_relation_becomes_a_wikilink(self):
+        tree = build_tree([
+            entity("PostgreSQL", relations=[{"type": "caches", "target": "Redis"}]),
+            entity("Redis"),
+        ])
+        assert "[[Redis]]" in tree["Mengram/entities/PostgreSQL.md"]
+
+    def test_a_renamed_target_keeps_its_real_name_via_an_alias(self):
+        """The file had to be renamed to be safe; the link must still read right."""
+        targets = {"a/b": "a-b"}
+        assert wikilink("a/b", targets) == "[[a-b|a/b]]"
+
+    def test_a_target_outside_the_export_still_links(self):
+        """A relation can point at something not in this slice. An unresolved
+        node is honest; dropping the link would hide that it exists."""
+        tree = build_tree([entity("PostgreSQL", relations=[{"type": "caches", "target": "Redis"}])])
+        assert "[[Redis]]" in tree["Mengram/entities/PostgreSQL.md"]
+
+    def test_incoming_relations_point_the_other_way(self):
+        out = entity_file(entity("A", relations=[
+            {"type": "uses", "target": "B", "direction": "incoming"}]), {"B": "B"})
+        assert "←" in out
+
+
+class TestRoundTripIds:
+    def test_every_kind_carries_its_id(self):
+        tree = build_tree(
+            [entity("A")],
+            [{"id": "e1", "summary": "s", "created_at": "2026-04-29T00:00:00"}],
+            [{"id": "p1", "name": "P"}],
+        )
+        assert "id: id-a" in tree["Mengram/entities/A.md"]
+        assert "id: e1" in tree["Mengram/episodes/2026-04-29-s.md"]
+        assert "id: p1" in tree["Mengram/procedures/P.md"]
+
+
+class TestFrontmatter:
+    def test_empty_values_are_omitted(self):
+        assert "blank" not in frontmatter({"kept": "yes", "blank": None, "empty": ""})
+
+    def test_values_that_would_break_yaml_are_quoted(self):
+        assert frontmatter({"k": "a: b"}).count('"a: b"') == 1
+        assert frontmatter({"k": "- dash"}).count('"- dash"') == 1
+
+    def test_lists_render_as_yaml_sequences(self):
+        assert "  - Ali" in frontmatter({"participants": ["Ali"]})
+
+
+class TestProcedures:
+    """The differentiator — a workflow with the record that earned its trust."""
+
+    def test_title_carries_version_and_reliability(self):
+        out = procedure_file({"name": "Deploy", "version": 3,
+                              "success_count": 11, "fail_count": 1})
+        assert "# Deploy (v3 · 92% reliable)" in out
+
+    def test_an_untested_procedure_does_not_claim_a_rate(self):
+        out = procedure_file({"name": "Deploy", "version": 1})
+        assert "untested" in out and "%" not in out.split("\n")[7]
+
+    def test_steps_survive_both_shapes(self):
+        """steps is list[dict]; older rows hold plain strings. A half-written
+        export is worse than a plain one."""
+        out = procedure_file({"name": "P", "steps": [
+            {"action": "run tests"}, {"action": "migrate", "detail": "first"}, "push"]})
+        assert "1. run tests" in out and "2. migrate — first" in out and "3. push" in out
+
+    def test_evolution_records_what_changed_it(self):
+        out = procedure_file({"name": "P", "version": 3}, evolution=[
+            {"version_before": 2, "version_after": 3, "created_at": "2026-04-12",
+             "diff": {"reason": "added migrations after a prod failure"}}])
+        assert "v2 → v3 (2026-04-12): added migrations after a prod failure" in out
+
+    def test_preconditions_are_surfaced(self):
+        out = procedure_file({"name": "P", "metadata": {"preconditions": ["run migrations"]}})
+        assert "**Preconditions**" in out and "- run migrations" in out
+
+
+class TestEpisodes:
+    def test_filename_leads_with_the_date(self):
+        tree = build_tree([], [{"id": "e", "summary": "prod crash",
+                                "created_at": "2026-04-29T02:00:00"}])
+        assert "Mengram/episodes/2026-04-29-prod crash.md" in tree
+
+    def test_happened_at_wins_over_row_creation_time(self):
+        """When the event happened is what a timeline should order by."""
+        out = episode_file({"summary": "s", "created_at": "2026-08-01T00:00:00",
+                            "happened_at": "2026-04-29T00:00:00"})
+        assert "happened: 2026-04-29" in out
+
+    def test_outcome_is_stated_plainly(self):
+        assert "**Outcome** — failure" in episode_file({"summary": "s", "outcome": "failure"})
+
+
+class TestWholeTree:
+    def test_the_layout_matches_the_spec(self):
+        tree = build_tree([entity("A")], [{"id": "e", "summary": "s", "created_at": "2026-01-02"}],
+                          [{"id": "p", "name": "P"}], profile="A developer.")
+        assert set(tree) == {
+            "Mengram/entities/A.md", "Mengram/episodes/2026-01-02-s.md",
+            "Mengram/procedures/P.md", "Mengram/profile.md", "Mengram/_index.md",
+        }
+
+    def test_index_counts_and_links_what_was_exported(self):
+        tree = build_tree([entity("A"), entity("B")])
+        index = tree["Mengram/_index.md"]
+        assert "- 2 entities" in index and "[[A]]" in index and "[[B]]" in index
+
+    def test_an_empty_memory_explains_itself(self):
+        """An empty folder looks like a broken export."""
+        index = build_tree()["Mengram/_index.md"]
+        assert "empty" in index.lower()
+
+    def test_every_file_ends_with_exactly_one_newline(self):
+        for text in build_tree([entity("A")], [], [{"id": "p", "name": "P"}]).values():
+            assert text.endswith("\n") and not text.endswith("\n\n")


### PR DESCRIPTION
Answers the question a cloud memory product has to be able to answer: where does my data live, and can I take it with me. Implements v1 of `specs/markdown-export-obsidian-sync.md`.

## What comes out

An Obsidian-native tree — one file per entity, relations written as `[[wikilinks]]` so the graph view works with no configuration. The files *are* the graph.

```
Mengram/
  entities/PostgreSQL.md
  episodes/2026-04-29-prod-crash.md
  procedures/deploy-to-railway.md
  profile.md
  _index.md
```

Procedures are the reason this is worth having. They export with their track record and evolution log, so the file says not just what the workflow is but how well it has worked and which failure changed it:

```markdown
# Deploy to Railway (v3 · 92% reliable)

**Preconditions**
- run migrations before push

## Evolution
- v2 → v3 (2026-04-12): added migrations step after a prod failure
```

## Shape

`cloud/markdown_export.py` is a pure serialiser — dicts in, `{path: text}` out, no database, no model call, no filesystem — so the endpoint, the CLI and the plugin can share it without drifting apart.

`GET /v1/export?format=markdown` returns a zip; `format=json` returns the same content structured.

## Decisions worth flagging

**Not charged against the add or search quota.** Getting your data out must never cost you the ability to use the product. The per-minute rate limit still applies, and the cap is 5k entities so one request cannot pin a worker.

**The profile is read from cache only**, so an export can never trigger a model call the caller did not ask for.

**Every file carries its id** in frontmatter, so a later import can update rather than duplicate.

**Links to entities outside the export are still written.** A relation can point at something not in this slice; an unresolved node is honest, dropping the link would hide that it exists.

`get_all_entities_full` now returns each entity's id — it was already the map key and was being discarded, which forced callers to re-query by name.

## Verified

34 hermetic tests in `tests/test_markdown_export.py` — no database, no network. They pin the things that make the promise true: links that resolve, ids that survive, filenames that neither collide nor break a filesystem, and both step shapes (`list[dict]` and legacy strings) surviving serialisation.

End-to-end against a real Postgres: both formats return 200, the zip contains the expected tree, an empty account gets an `_index.md` that explains itself rather than an empty folder.

Suite goes from 185 to 219 passing. The three `test_parser.py` failures predate this branch — a gitignored fixture directory.
