### PR TITLE
feat(cli): mengram export obsidian — write the memory into a vault

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1668,6 +1668,71 @@ def cmd_try(args):
     print("→ Then feed it in:    mengram import claude-code")
 
 
+def cmd_export(args):
+    """Write the memory out as files the user owns.
+
+    The server does the serialising and hands back a zip, so the CLI, the API
+    and the plugin all produce identical trees — there is no second
+    implementation here to drift out of step.
+    """
+    import io
+    import zipfile
+    from pathlib import Path
+
+    export_type = getattr(args, "export_type", None)
+    if export_type not in ("obsidian", "markdown"):
+        print("Usage: mengram export obsidian <vault-path>")
+        print("       mengram export markdown <dir>")
+        sys.exit(1)
+
+    api_key = _load_cloud_api_key()
+    if not api_key:
+        print("❌ No API key found (checked MENGRAM_API_KEY env and ~/.mengram/config.json)")
+        print("   Run: mengram setup")
+        sys.exit(1)
+
+    destination = Path(args.path).expanduser()
+    if export_type == "obsidian" and not destination.is_dir():
+        print(f"❌ Not a directory: {destination}")
+        print("   Point this at your Obsidian vault — the folder holding .obsidian/")
+        sys.exit(1)
+
+    target = destination / "Mengram"
+    if target.exists() and not args.force:
+        print(f"❌ {target} already exists.")
+        print("   Re-run with --force to replace it. Anything you wrote inside will be lost.")
+        sys.exit(1)
+
+    from cloud.client import CloudMemory
+    mem = CloudMemory(api_key=api_key, base_url=_load_cloud_base_url())
+
+    print(f"📦 Exporting memory to {target} …")
+    try:
+        payload = mem.export(format="markdown", user_id=args.user_id)
+    except Exception as e:
+        print(f"❌ Export failed: {e}")
+        sys.exit(1)
+
+    written = 0
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        for name in archive.namelist():
+            # Every path comes from our own serialiser, but a zip is still
+            # untrusted input: refuse anything that would escape the target.
+            relative = Path(name)
+            if relative.is_absolute() or ".." in relative.parts:
+                print(f"   ⚠️  skipped suspicious path: {name}")
+                continue
+            out = destination / relative
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(archive.read(name))
+            written += 1
+
+    print(f"✅ {written} files written to {target}")
+    if export_type == "obsidian":
+        print("   Open the vault — relations are wikilinks, so the graph view just works.")
+    print("   These are yours. Plain Markdown, no account needed to read them.")
+
+
 def cmd_import(args):
     """Import existing data into memory"""
     import_type = args.import_type
@@ -1927,6 +1992,24 @@ def main():
     # try — zero-account local preview
     sub.add_parser("try", help="Preview what Mengram memory would know — local only, no account needed")
 
+    # export
+    p_export = sub.add_parser("export", help="Write your memory out as plain Markdown files")
+    export_sub = p_export.add_subparsers(dest="export_type")
+
+    p_exp_obs = export_sub.add_parser(
+        "obsidian", help="Write a Mengram/ folder into an Obsidian vault")
+    p_exp_obs.add_argument("path", help="Path to the vault directory")
+    p_exp_obs.add_argument("--user-id", default="default", dest="user_id",
+                           help="Export one sub-user's memory")
+    p_exp_obs.add_argument("--force", action="store_true",
+                           help="Overwrite an existing Mengram/ folder")
+
+    p_exp_md = export_sub.add_parser(
+        "markdown", help="Write the same tree into any directory")
+    p_exp_md.add_argument("path", help="Destination directory")
+    p_exp_md.add_argument("--user-id", default="default", dest="user_id")
+    p_exp_md.add_argument("--force", action="store_true")
+
     # import
     p_import = sub.add_parser("import", help="Import existing data into memory")
     import_sub = p_import.add_subparsers(dest="import_type")
@@ -2036,6 +2119,8 @@ def main():
         cmd_api(args)
     elif args.command == "try":
         cmd_try(args)
+    elif args.command == "export":
+        cmd_export(args)
     elif args.command == "import":
         cmd_import(args)
     elif args.command == "hook":

--- a/cloud/client.py
+++ b/cloud/client.py
@@ -427,6 +427,60 @@ class CloudMemory:
         result = self._request("GET", "/v1/memories", params=params)
         return result.get("memories", [])
 
+    def export(self, format: str = "markdown", user_id: str = "default"):
+        """Take the whole memory out.
+
+        `markdown` returns the bytes of a zip holding an Obsidian-native tree —
+        a file per entity, relations as wikilinks, procedures with their track
+        record. `json` returns the same content structured.
+
+        Read-only, and not charged against the add or search quota.
+        """
+        if format not in ("markdown", "json"):
+            raise ValueError("format must be 'markdown' or 'json'")
+
+        params = {"format": format}
+        if user_id and user_id != "default":
+            params["sub_user_id"] = user_id
+
+        if format == "json":
+            return self._request("GET", "/v1/export", params=params)
+
+        # A zip is not JSON, so this cannot go through _request. Same auth and
+        # the same 429/5xx retry, raising the same way the rest of the client
+        # does: QuotaExceededError on 402, plain Exception otherwise.
+        import time as _time
+
+        query = "&".join(f"{k}={urllib.parse.quote(str(v))}" for k, v in params.items())
+        url = f"{self.base_url}/v1/export?{query}"
+        last_err = None
+        for attempt in range(3):
+            req = urllib.request.Request(url, method="GET", headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "User-Agent": _USER_AGENT,
+            })
+            try:
+                # An export of a large memory takes longer than a normal call,
+                # and a hung socket with no timeout waits forever.
+                with urllib.request.urlopen(req, context=_SSL_CTX, timeout=120) as resp:
+                    return resp.read()
+            except urllib.error.HTTPError as e:
+                if e.code in (429, 502, 503, 504) and attempt < 2:
+                    _time.sleep(1 * (attempt + 1))
+                    last_err = e
+                    continue
+                detail = e.read().decode()[:300]
+                if e.code == 402:
+                    raise QuotaExceededError(detail)
+                raise Exception(f"API error {e.code}: {detail}")
+            except urllib.error.URLError as e:
+                if attempt < 2:
+                    last_err = e
+                    _time.sleep(1 * (attempt + 1))
+                    continue
+                raise Exception(f"Network error: {e}")
+        raise Exception(f"Export failed after 3 attempts: {last_err}")
+
     def get_all_full(self, user_id: str = "default") -> list[dict[str, Any]]:
         """Get all memories with full details in one request."""
         params = {}


### PR DESCRIPTION
Completes the v1 slice of `specs/markdown-export-obsidian-sync.md`. The server side landed in #79; this is the command people actually type.

```
mengram export obsidian ~/vault     # drops a Mengram/ folder into the vault
mengram export markdown ./out       # same tree, anywhere
```

## Shape

The server serialises and returns the zip, so the CLI, the API and the plugin all produce identical trees — there is no second implementation here to drift out of step with the first.

`CloudMemory.export()` carries it in the SDK too, rather than the CLI reaching past the client with its own request. A zip cannot go through `_request`, which parses JSON, so it makes its own call with the same auth and the same 429/5xx retry, and raises the way the rest of the client does: `QuotaExceededError` on 402, plain `Exception` otherwise. It sets a 120s timeout — an export of a large memory is slower than a normal call, and a hung socket with no timeout waits forever.

## Guards

**Refuses to overwrite an existing `Mengram/` folder without `--force`.** The whole point is files people keep.

**Archive paths are checked before writing.** The zip is ours, but a zip is still untrusted input, and one that escapes the target directory is a classic way to lose files.

**Rejects a path that isn't a directory** with a line explaining that the argument is the vault folder, not the `.obsidian` folder inside it.

## Verified

Exercised end-to-end against a real Postgres with the command's own handler: writes the expected tree, refuses a second run without `--force`, overwrites with it, and rejects a bad path. Suite unchanged at 219 passing; the three `test_parser.py` failures predate this branch.

## Still open from the spec

Plugin reverse-sync (pull memory into the vault and keep it current) — the remaining piece, and the one that makes it two-way.
