### PR TITLE
Answer HEAD on the landing page

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -1731,7 +1731,11 @@ m.add("I love hiking in the mountains")</code></pre>
 
     # ---- Public endpoints ----
 
-    @app.get("/", response_class=HTMLResponse)
+    # HEAD is declared alongside GET because FastAPI, unlike plain Starlette,
+    # does not derive it — so link checkers answered 405 and reported the site
+    # as unreachable. The Obsidian plugin review flagged authorUrl for exactly
+    # this while the page served 200 to every GET.
+    @app.api_route("/", methods=["GET", "HEAD"], response_class=HTMLResponse)
     async def landing():
         """Landing page."""
         landing_path = Path(__file__).parent / "landing.html"


### PR DESCRIPTION
`mengram.io` returns 200 to GET but **405 to HEAD**. FastAPI's `@app.get` does not add HEAD the way plain Starlette does, so every link checker that probes with HEAD concludes the site is down.

This surfaced as a warning on the Obsidian plugin listing — *"Manifest URL field is not reachable: authorUrl"* — while the page was serving fine to browsers.

```
curl -I https://mengram.io   -> 405
curl    https://mengram.io   -> 200
```

Verified against fastapi 0.141 that the combined route answers HEAD with 200, an empty body, and the same content-type and content-length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)