### PR TITLE
Export the published format, not a private dialect of it

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1697,7 +1697,11 @@ def cmd_export(args):
         print("   Point this at your Obsidian vault — the folder holding .obsidian/")
         sys.exit(1)
 
-    target = destination / "Mengram"
+    # The folder name comes from the format, not from a literal here: the
+    # guard below must protect the same directory the archive actually writes
+    # into, and those two silently disagreeing is how you overwrite a vault.
+    from cloud.markdown_export import ROOT as EXPORT_ROOT
+    target = destination / EXPORT_ROOT
     if target.exists() and not args.force:
         print(f"❌ {target} already exists.")
         print("   Re-run with --force to replace it. Anything you wrote inside will be lost.")
@@ -1997,12 +2001,12 @@ def main():
     export_sub = p_export.add_subparsers(dest="export_type")
 
     p_exp_obs = export_sub.add_parser(
-        "obsidian", help="Write a Mengram/ folder into an Obsidian vault")
+        "obsidian", help="Write a memory/ folder into an Obsidian vault")
     p_exp_obs.add_argument("path", help="Path to the vault directory")
     p_exp_obs.add_argument("--user-id", default="default", dest="user_id",
                            help="Export one sub-user's memory")
     p_exp_obs.add_argument("--force", action="store_true",
-                           help="Overwrite an existing Mengram/ folder")
+                           help="Overwrite an existing memory/ folder")
 
     p_exp_md = export_sub.add_parser(
         "markdown", help="Write the same tree into any directory")

--- a/cloud/markdown_export.py
+++ b/cloud/markdown_export.py
@@ -18,7 +18,14 @@ from __future__ import annotations
 import re
 from datetime import date, datetime
 
-ROOT = "Mengram"
+#: The format is published as a spec and a library of its own:
+#: https://github.com/alibaizhanov/memfmt. These three constants are the whole
+#: of what makes a tree readable by it, so they live together and are named
+#: after the spec rather than after us — a standard with our product's name in
+#: its field keys is not a standard anyone else adopts.
+TYPE_KEY = "memfmt_type"
+ROOT = "memory"
+INDEX = "MEMORY.md"
 
 # Characters a filename cannot carry on the platforms Obsidian runs on. Kept
 # deliberately small: entity names are the note titles users will see and link
@@ -123,7 +130,7 @@ def entity_file(entity: dict, targets: dict) -> str:
     name = entity.get("entity") or "unnamed"
     body = [
         frontmatter({
-            "mengram_type": "entity",
+            TYPE_KEY: "entity",
             "entity_type": entity.get("type"),
             "id": entity.get("id"),
         }),
@@ -162,7 +169,7 @@ def episode_file(episode: dict) -> str:
     when = _day(episode.get("happened_at") or episode.get("created_at"))
     body = [
         frontmatter({
-            "mengram_type": "episode",
+            TYPE_KEY: "episode",
             "id": episode.get("id"),
             "happened": when,
             "outcome": episode.get("outcome"),
@@ -197,7 +204,7 @@ def procedure_file(procedure: dict, evolution: list = None) -> str:
 
     body = [
         frontmatter({
-            "mengram_type": "procedure",
+            TYPE_KEY: "procedure",
             "id": procedure.get("id"),
             "version": version,
             "success_count": success,
@@ -242,9 +249,9 @@ def procedure_file(procedure: dict, evolution: list = None) -> str:
 
 def index_file(counts: dict, entity_stems: list) -> str:
     body = [
-        frontmatter({"mengram_type": "index", "generated": date.today().isoformat()}),
+        frontmatter({TYPE_KEY: "index", "generated": date.today().isoformat()}),
         "",
-        "# Mengram",
+        "# Memory",
         "",
     ]
     if not any(counts.values()):
@@ -309,12 +316,12 @@ def build_tree(entities: list = None, episodes: list = None, procedures: list = 
 
     if profile:
         tree[f"{ROOT}/profile.md"] = "\n".join([
-            frontmatter({"mengram_type": "profile",
+            frontmatter({TYPE_KEY: "profile",
                          "generated": date.today().isoformat()}),
             "", "# Profile", "", profile.strip(),
         ]) + "\n"
 
-    tree[f"{ROOT}/_index.md"] = index_file(
+    tree[f"{ROOT}/{INDEX}"] = index_file(
         {"entities": len(entities), "episodes": len(episodes), "procedures": len(procedures)},
         list(targets.values()),
     )

--- a/tests/test_markdown_export.py
+++ b/tests/test_markdown_export.py
@@ -45,7 +45,7 @@ class TestFilenames:
 
     def test_colliding_names_do_not_overwrite_each_other(self):
         tree = build_tree([entity("a/b"), entity("a:b")])
-        files = [p for p in tree if p.startswith("Mengram/entities/")]
+        files = [p for p in tree if p.startswith("memory/entities/")]
         assert len(files) == 2, "one entity silently replaced the other"
 
 
@@ -55,7 +55,7 @@ class TestLinksResolve:
             entity("PostgreSQL", relations=[{"type": "caches", "target": "Redis"}]),
             entity("Redis"),
         ])
-        assert "[[Redis]]" in tree["Mengram/entities/PostgreSQL.md"]
+        assert "[[Redis]]" in tree["memory/entities/PostgreSQL.md"]
 
     def test_a_renamed_target_keeps_its_real_name_via_an_alias(self):
         """The file had to be renamed to be safe; the link must still read right."""
@@ -66,7 +66,7 @@ class TestLinksResolve:
         """A relation can point at something not in this slice. An unresolved
         node is honest; dropping the link would hide that it exists."""
         tree = build_tree([entity("PostgreSQL", relations=[{"type": "caches", "target": "Redis"}])])
-        assert "[[Redis]]" in tree["Mengram/entities/PostgreSQL.md"]
+        assert "[[Redis]]" in tree["memory/entities/PostgreSQL.md"]
 
     def test_incoming_relations_point_the_other_way(self):
         out = entity_file(entity("A", relations=[
@@ -81,9 +81,9 @@ class TestRoundTripIds:
             [{"id": "e1", "summary": "s", "created_at": "2026-04-29T00:00:00"}],
             [{"id": "p1", "name": "P"}],
         )
-        assert "id: id-a" in tree["Mengram/entities/A.md"]
-        assert "id: e1" in tree["Mengram/episodes/2026-04-29-s.md"]
-        assert "id: p1" in tree["Mengram/procedures/P.md"]
+        assert "id: id-a" in tree["memory/entities/A.md"]
+        assert "id: e1" in tree["memory/episodes/2026-04-29-s.md"]
+        assert "id: p1" in tree["memory/procedures/P.md"]
 
 
 class TestFrontmatter:
@@ -132,7 +132,7 @@ class TestEpisodes:
     def test_filename_leads_with_the_date(self):
         tree = build_tree([], [{"id": "e", "summary": "prod crash",
                                 "created_at": "2026-04-29T02:00:00"}])
-        assert "Mengram/episodes/2026-04-29-prod crash.md" in tree
+        assert "memory/episodes/2026-04-29-prod crash.md" in tree
 
     def test_happened_at_wins_over_row_creation_time(self):
         """When the event happened is what a timeline should order by."""
@@ -149,18 +149,18 @@ class TestWholeTree:
         tree = build_tree([entity("A")], [{"id": "e", "summary": "s", "created_at": "2026-01-02"}],
                           [{"id": "p", "name": "P"}], profile="A developer.")
         assert set(tree) == {
-            "Mengram/entities/A.md", "Mengram/episodes/2026-01-02-s.md",
-            "Mengram/procedures/P.md", "Mengram/profile.md", "Mengram/_index.md",
+            "memory/entities/A.md", "memory/episodes/2026-01-02-s.md",
+            "memory/procedures/P.md", "memory/profile.md", "memory/MEMORY.md",
         }
 
     def test_index_counts_and_links_what_was_exported(self):
         tree = build_tree([entity("A"), entity("B")])
-        index = tree["Mengram/_index.md"]
+        index = tree["memory/MEMORY.md"]
         assert "- 2 entities" in index and "[[A]]" in index and "[[B]]" in index
 
     def test_an_empty_memory_explains_itself(self):
         """An empty folder looks like a broken export."""
-        index = build_tree()["Mengram/_index.md"]
+        index = build_tree()["memory/MEMORY.md"]
         assert "empty" in index.lower()
 
     def test_every_file_ends_with_exactly_one_newline(self):


### PR DESCRIPTION
The Markdown export predates the format being published, so it used our own names throughout. The spec released as [memfmt](https://github.com/alibaizhanov/memfmt) uses different ones.

| | before | after |
|---|---|---|
| frontmatter key | `mengram_type` | `memfmt_type` |
| root folder | `Mengram/` | `memory/` |
| index file | `_index.md` | `MEMORY.md` |

Nothing else about the files changes — same sections, same wikilinks, same frontmatter fields.

### Verified, not assumed

The tree this serialiser builds is parsed by the released `memfmt` package, and re-serialising the parsed result is byte-identical to what the server produced. A cross-check, not a matching pair of assertions I wrote twice.

```
расхождений между сервером и библиотекой: нет
```

34 export tests pass. The 3 failures in `test_parser.py` are pre-existing on `main` (a missing `test_vault` fixture) and unrelated.

### Merge order matters

**The Obsidian plugin at 1.1.3 strips a hardcoded `Mengram/` prefix.** If this merges first, those users get their memory one level deeper — `<folder>/memory/entities/…` instead of `<folder>/entities/…`. Nothing is lost and nothing outside the pull folder is touched, but the layout shuffles.

Plugin 1.1.4, which accepts either root, should ship before this is merged. I have it ready.

### Follow-up, not in here

The server still carries its own copy of the serialiser rather than depending on `memfmt`. That is deliberate for now — a fresh PyPI package is not something to put in the deploy path a day after publishing it — but the copy is what will drift, and depending on the package is the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)