### PR TITLE
Record where a signup came from

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 from pydantic import BaseModel, Field
 
 from cloud.store import CloudStore, _normalize_fact
+from cloud.attribution import clean_source
 from cloud.oauth_policy import redirect_uri_error as _redirect_uri_error
 from cloud.sub_user import SubUserScoped, resolve_sub_user as _resolve_sub_user
 
@@ -327,6 +328,7 @@ def _require_full_uuid(value: str, field_name: str = "id") -> None:
 class SignupRequest(BaseModel):
     email: str
     website: str = ""  # Honeypot — hidden form field, real users leave empty, bots fill
+    source: str = ""   # Where they came from, if the landing page knew
 
     @property
     def validated_email(self) -> str:
@@ -342,6 +344,7 @@ class SignupResponse(BaseModel):
 class VerifyRequest(BaseModel):
     email: str
     code: str
+    source: str = ""   # Carried through the two-step flow from the first request
 
     @property
     def validated_email(self) -> str:
@@ -6282,7 +6285,7 @@ m.delete_webhook(webhook_id=1)</code></pre>
 
         # Self-hosted: skip email verification, create account immediately
         if DISABLE_EMAIL_VERIFICATION:
-            user_id = store.create_user(email)
+            user_id = store.create_user(email, clean_source(req.source))
             api_key = store.create_api_key(user_id)
             _seed_initial_memory(user_id, email)
             logger.info(f"✅ Account created (email verification disabled) for {email}")
@@ -6319,7 +6322,7 @@ m.delete_webhook(webhook_id=1)</code></pre>
         if existing:
             raise HTTPException(status_code=409, detail="Email already registered")
 
-        user_id = store.create_user(email)
+        user_id = store.create_user(email, clean_source(req.source))
         api_key = store.create_api_key(user_id)
         # Eagerly create free subscription so user isn't stuck in no_sub state
         # (lazy creation in get_subscription only happens on first API call)
@@ -6409,7 +6412,14 @@ m.delete_webhook(webhook_id=1)</code></pre>
             raise HTTPException(status_code=500, detail="GitHub OAuth not configured")
         # Generate state token to prevent CSRF
         state = secrets.token_urlsafe(32)
-        store.cache.set(f"github_state:{state}", "1", ttl=600)
+        # The state entry doubles as the carrier for attribution. It is already
+        # per-attempt, already short-lived and already verified on the way
+        # back, so the tag survives the round trip to GitHub without a cookie
+        # or a second store. "1" stands in for "no tag" so the truthiness check
+        # below keeps working.
+        source = clean_source(request.query_params.get("ref")
+                               or request.query_params.get("utm_source"))
+        store.cache.set(f"github_state:{state}", source or "1", ttl=600)
         github_url = (
             f"https://github.com/login/oauth/authorize"
             f"?client_id={GITHUB_CLIENT_ID}"
@@ -6431,10 +6441,13 @@ m.delete_webhook(webhook_id=1)</code></pre>
             return _github_error_page("GitHub OAuth not configured on server.")
 
         # Verify CSRF state
-        if not store.cache.get(f"github_state:{state}"):
+        state_value = store.cache.get(f"github_state:{state}")
+        if not state_value:
             return _github_error_page("Invalid or expired state. Please try again.")
         # Invalidate state by overwriting with short TTL
         store.cache.set(f"github_state:{state}", "", ttl=1)
+        # Read before invalidating, above: "1" means the visit carried no tag.
+        github_source = None if state_value == "1" else clean_source(state_value)
 
         # Exchange code for access token
         import urllib.request
@@ -6495,7 +6508,7 @@ m.delete_webhook(webhook_id=1)</code></pre>
             return _github_existing_page(email)
 
         # New user — create account + key
-        user_id = store.create_user(email)
+        user_id = store.create_user(email, github_source or "github-oauth")
         api_key = store.create_api_key(user_id, name="github-oauth")
         # Eagerly create free subscription so user isn't stuck in no_sub state
         store.get_subscription(user_id)
@@ -6839,7 +6852,10 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
         # Check if user exists, if not create
         user_id = store.get_user_by_email(email)
         if not user_id:
-            user_id = store.create_user(email)
+            # No landing page was involved: this account exists because someone
+            # added the connector inside their MCP client, which is itself the
+            # most precise answer to "where did they come from".
+            user_id = store.create_user(email, "oauth-connector")
             store.create_api_key(user_id)
 
         # Generate and send 6-digit code

--- a/cloud/attribution.py
+++ b/cloud/attribution.py
@@ -1,0 +1,37 @@
+"""Where a signup came from, normalised.
+
+Kept out of api.py so the rule is importable and testable without the web
+stack, the same way the redirect policy is.
+
+The tag arrives in a query string, which means anyone can put anything in it:
+it is copied from a link we published, but also from a link somebody else
+wrote. It ends up in a database column and in every report read afterwards, so
+it is reduced to a small alphabet rather than trusted. The point is not
+security — the insert is parameterised — but that a column used for counting
+stays countable: `Reddit`, `reddit ` and `reddit` must not become three
+different channels.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: Everything outside this collapses to a single dash.
+_UNSAFE = re.compile(r"[^a-z0-9._-]+")
+
+#: Long enough for `r-localllama-weekly-thread`, short enough that a pasted
+#: essay cannot become a channel name.
+MAX_LENGTH = 64
+
+
+def clean_source(raw) -> str | None:
+    """Normalise an attribution tag, or None if nothing usable is left.
+
+    None rather than "" on purpose: the column is NULL for every account
+    created before attribution existed, and "we never knew" should not be
+    confused with "they arrived with an empty tag".
+    """
+    if not raw:
+        return None
+    cleaned = _UNSAFE.sub("-", str(raw).strip().lower()).strip("-")
+    return cleaned[:MAX_LENGTH].strip("-") or None

--- a/cloud/landing.html
+++ b/cloud/landing.html
@@ -2759,7 +2759,7 @@ POST /v1/add → {<span class="c-str">"messages"</span>: [...], <span class="c-s
             <div class="signup-box reveal">
                 <h2>Get your free API key</h2>
                 <p>No credit card. Start in 30 seconds.</p>
-                <a href="/auth/github" class="signup-btn" style="display:inline-flex;align-items:center;justify-content:center;gap:8px;text-decoration:none;margin-bottom:12px;background:#24292f;">
+                <a href="/auth/github" data-keep-source="1" class="signup-btn" style="display:inline-flex;align-items:center;justify-content:center;gap:8px;text-decoration:none;margin-bottom:12px;background:#24292f;">
                     <svg width="20" height="20" viewBox="0 0 16 16" fill="white"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                     Sign up with GitHub
                 </a>
@@ -2974,6 +2974,33 @@ POST /v1/add → {<span class="c-str">"messages"</span>: [...], <span class="c-s
             }
         }
 
+        // Where this visit came from. Captured once and kept for the session:
+        // signup is two steps, the tag only exists in the URL of the first, and
+        // a reload between them would otherwise lose it. sessionStorage rather
+        // than localStorage — attribution belongs to the visit that produced the
+        // account, not to the browser forever.
+        function signupSource() {
+            try {
+                const p = new URLSearchParams(window.location.search);
+                const fresh = p.get("ref") || p.get("utm_source") || "";
+                if (fresh) sessionStorage.setItem("mengram_src", fresh);
+                return sessionStorage.getItem("mengram_src") || "";
+            } catch (e) {
+                return "";   // private mode, storage disabled — not worth failing a signup over
+            }
+        }
+
+        // Signing in through GitHub leaves this page, so the tag has to ride
+        // along in the URL or it is gone by the time an account is created.
+        document.addEventListener("DOMContentLoaded", function () {
+            const src = signupSource();
+            if (!src) return;
+            document.querySelectorAll('a[data-keep-source]').forEach(function (a) {
+                const sep = a.getAttribute("href").includes("?") ? "&" : "?";
+                a.setAttribute("href", a.getAttribute("href") + sep + "ref=" + encodeURIComponent(src));
+            });
+        });
+
         let _signupEmail = '';
 
         async function sendCode() {
@@ -2995,7 +3022,7 @@ POST /v1/add → {<span class="c-str">"messages"</span>: [...], <span class="c-s
                 const resp = await fetch(`${API_URL}/v1/signup`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ email, website }),
+                    body: JSON.stringify({ email, website, source: signupSource() }),
                 });
                 const data = await resp.json();
 
@@ -3055,7 +3082,7 @@ POST /v1/add → {<span class="c-str">"messages"</span>: [...], <span class="c-s
                 const resp = await fetch(`${API_URL}/v1/verify`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ email: _signupEmail, code }),
+                    body: JSON.stringify({ email: _signupEmail, code, source: signupSource() }),
                 });
                 const data = await resp.json();
 

--- a/cloud/schema.sql
+++ b/cloud/schema.sql
@@ -12,6 +12,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE TABLE users (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     email VARCHAR(255) UNIQUE,
+    signup_source TEXT,                    -- where this signup came from (NULL = unknown)
     created_at TIMESTAMP DEFAULT NOW()
 );
 

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -348,6 +348,14 @@ class CloudStore:
                 ALTER TABLE users ADD COLUMN IF NOT EXISTS settings JSONB DEFAULT '{}'
             """)
 
+            # v2.31: where a signup came from. Without it a launch can only be
+            # guessed at — a spike in registrations tells you something worked
+            # but never which thing. NULL for everyone who arrived before this
+            # existed, which is honest: we genuinely do not know.
+            cur.execute("""
+                ALTER TABLE users ADD COLUMN IF NOT EXISTS signup_source TEXT
+            """)
+
             # --- v1.5 Hybrid search: tsvector on embeddings ---
             cur.execute("""
                 ALTER TABLE embeddings ADD COLUMN IF NOT EXISTS tsv tsvector
@@ -1359,12 +1367,18 @@ class CloudStore:
         self.cache.invalidate(f"capture_policy:{user_id}")
         return (row[0] if row else policy) or policy
 
-    def create_user(self, email: str) -> str:
-        """Create user, return user_id."""
+    def create_user(self, email: str, source: str = None) -> str:
+        """Create user, return user_id.
+
+        `source` records where they came from — a campaign tag off the landing
+        URL, or the flow they signed up through. It is written once, at
+        creation, and never updated: attribution that changes later is not
+        attribution.
+        """
         with self._cursor() as cur:
             cur.execute(
-                "INSERT INTO users (email) VALUES (%s) RETURNING id",
-                (email,)
+                "INSERT INTO users (email, signup_source) VALUES (%s, %s) RETURNING id",
+                (email, source or None)
             )
             return str(cur.fetchone()[0])
 

--- a/tests/test_signup_source.py
+++ b/tests/test_signup_source.py
@@ -1,0 +1,52 @@
+"""Tests for signup attribution.
+
+The point of the column is counting: if `Reddit`, `reddit ` and `reddit` land
+as three rows, the number it produces is worse than no number, because it
+looks like an answer.
+"""
+
+from cloud.attribution import MAX_LENGTH, clean_source
+
+
+class TestCleanSource:
+    def test_plain_tag_survives(self):
+        assert clean_source("reddit") == "reddit"
+        assert clean_source("memfmt") == "memfmt"
+
+    def test_case_and_padding_collapse(self):
+        """The whole reason this exists — one channel, one row."""
+        assert clean_source("Reddit") == clean_source(" reddit ") == clean_source("REDDIT")
+
+    def test_separators_normalise(self):
+        assert clean_source("r/AI_Agents") == "r-ai_agents"
+        assert clean_source("show hn") == "show-hn"
+
+    def test_nothing_usable_is_none_not_empty(self):
+        """NULL means we never knew. An empty string would claim we asked and
+        got nothing, which is a different fact."""
+        for value in ("", "   ", "!!!", "///", None, 0):
+            assert clean_source(value) is None
+
+    def test_non_latin_is_dropped_rather_than_mangled(self):
+        assert clean_source("Показ") is None
+
+    def test_length_is_capped_without_trailing_separator(self):
+        long = clean_source("a" * 200)
+        assert len(long) == MAX_LENGTH
+        # A cut landing mid-separator must not leave a dangling dash, or the
+        # same channel truncates two ways.
+        assert clean_source("x" * (MAX_LENGTH - 1) + " tail").endswith("x")
+        assert not clean_source("y" * (MAX_LENGTH - 1) + " tail").endswith("-")
+
+    def test_hostile_input_is_reduced_to_a_tag(self):
+        assert clean_source("'; DROP TABLE users;--") == "drop-table-users"
+        assert clean_source("<script>alert(1)</script>") == "script-alert-1-script"
+        # Dots survive on purpose: `mengram.io` and `dev.to` are real tags.
+        assert clean_source("dev.to") == "dev.to"
+
+    def test_is_idempotent(self):
+        """Cleaning what was already cleaned must not change it — the GitHub
+        flow runs it twice, once on the way out and once on the way back."""
+        for value in ("reddit", "r/AI_Agents", "  Show HN  ", "a" * 200):
+            once = clean_source(value)
+            assert clean_source(once) == once


### PR DESCRIPTION
Yesterday's funnel measurement (5 signups in 21 days, 0.2–0.3/day) was taken so a launch could be compared against it. Right now that comparison cannot be made: a spike tells us something worked, never which thing.

### What lands

A `?ref=` / `?utm_source=` tag on the landing URL is carried to account creation and written once, at creation.

| path | how the tag survives |
|---|---|
| email signup (2 steps) | sessionStorage — the tag is only in the first step's URL |
| GitHub sign-in | the OAuth `state` token, already per-attempt and verified on return |
| MCP connector | no landing page exists; tagged `oauth-connector` |
| self-hosted instant signup | straight from the request |

No cookie is set and nothing is stored beyond the visit.

### Normalisation

The tag is somebody else's text from a query string, reduced to `[a-z0-9._-]` and capped at 64. Not for safety — the insert is parameterised — but so the column stays countable: `Reddit`, `reddit ` and `reddit` must be one channel. Anything that cleans to nothing is stored as **NULL**, because "we never knew" and "arrived with an empty tag" are different facts.

`cloud/attribution.py` is a pure module so the rule is testable without the web stack, same as `oauth_policy.py`. 8 tests, including idempotence — the GitHub path cleans twice.

### Migration

Added through the existing in-code `_migrate()` (advisory-locked, `ADD COLUMN IF NOT EXISTS`). No manual DDL, nothing to run by hand. `schema.sql` updated so fresh installs match.

### After deploy

Links to publish become `https://mengram.io/?ref=reddit`, `?ref=memfmt`, etc. Then the number we could not get before:

```sql
SELECT COALESCE(signup_source, 'unknown') AS source, count(*)
FROM users WHERE created_at > NOW() - INTERVAL '30 days'
GROUP BY 1 ORDER BY 2 DESC;
```

227 tests pass; the 3 failures in `test_parser.py` are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)