### PR TITLE
Match memfmt's smoothed reliability so the format has one meaning

### DIFF
--- a/cloud/markdown_export.py
+++ b/cloud/markdown_export.py
@@ -187,11 +187,41 @@ def episode_file(episode: dict) -> str:
     return "\n".join(body).rstrip() + "\n"
 
 
-def _reliability(success: int, fail: int) -> str:
-    total = success + fail
-    if total == 0:
+#: Must match memfmt's LINEAGE_WEIGHT. These files are read back by that
+#: library, and two different discounts would render two different numbers for
+#: the same record — the one failure a shared format exists to prevent.
+LINEAGE_WEIGHT = 0.5
+
+
+def _prior(evolution: list = None) -> tuple:
+    """Beta prior for a version, taken from what its predecessor retired with.
+
+    A bare ratio punishes the revision: a new version opens at 0/0 and reads
+    worse than the one it was written to fix, so anything choosing between them
+    keeps the version that already failed. Progressive delivery and CI answered
+    this years ago by smoothing against a prior instead of comparing raw counts.
+    """
+    for entry in reversed(evolution or []):
+        success, fail = entry.get("success_count"), entry.get("fail_count")
+        if success is not None or fail is not None:
+            return (1.0 + LINEAGE_WEIGHT * (success or 0),
+                    1.0 + LINEAGE_WEIGHT * (fail or 0))
+    return (1.0, 1.0)
+
+
+def _reliability(success: int, fail: int, prior: tuple = (1.0, 1.0)) -> str:
+    """How much to trust this version, in words.
+
+    The word matters as much as the number: "never run" and "run and it worked"
+    must not read alike, so a version standing on its lineage says `expected`
+    and one with a record of its own says `reliable`.
+    """
+    alpha, beta = prior
+    observed = success + fail
+    if observed == 0 and (alpha, beta) == (1.0, 1.0):
         return "untested"
-    return f"{round(100 * success / total)}% reliable"
+    estimate = (success + alpha) / (observed + alpha + beta)
+    return f"{round(100 * estimate)}% {'reliable' if observed else 'expected'}"
 
 
 def procedure_file(procedure: dict, evolution: list = None) -> str:
@@ -211,7 +241,7 @@ def procedure_file(procedure: dict, evolution: list = None) -> str:
             "fail_count": fail,
         }),
         "",
-        f"# {name} (v{version} · {_reliability(success, fail)})",
+        f"# {name} (v{version} · {_reliability(success, fail, _prior(evolution))})",
     ]
 
     if procedure.get("trigger_condition"):
@@ -241,7 +271,14 @@ def procedure_file(procedure: dict, evolution: list = None) -> str:
         when = _day(entry.get("created_at"))
         if "## Evolution" not in body:
             body += ["", "## Evolution", ""]
-        stamp = f" ({when})" if when else ""
+        # The parenthetical carries when it happened and what the version being
+        # retired had achieved by then; the second part is what a successor
+        # draws its prior from, so it travels with the file.
+        meta = [m for m in (when,) if m]
+        prev_s, prev_f = entry.get("success_count"), entry.get("fail_count")
+        if prev_s is not None or prev_f is not None:
+            meta.append(f"{prev_s or 0}✓/{prev_f or 0}✗")
+        stamp = f" ({', '.join(meta)})" if meta else ""
         body.append(f"- v{before} → v{after}{stamp}: {note}")
 
     return "\n".join(body).rstrip() + "\n"

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -5897,9 +5897,21 @@ REFLECTIONS/PATTERNS:
         with self._cursor(dict_cursor=True) as cur:
             cur.execute(
                 """SELECT pe.id, pe.procedure_id, pe.episode_id, pe.change_type,
-                          pe.diff, pe.version_before, pe.version_after, pe.created_at
+                          pe.diff, pe.version_before, pe.version_after, pe.created_at,
+                          prev.success_count AS prev_success,
+                          prev.fail_count   AS prev_fail
                    FROM procedure_evolution pe
                    JOIN procedures p ON p.id = pe.procedure_id
+                   -- The record the retiring version carried. A successor draws
+                   -- its prior from this, so without it every revision reads as
+                   -- untested next to the version it was written to fix.
+                   -- UNIQUE(user_id, sub_user_id, name, version) keeps the join
+                   -- to at most one row.
+                   LEFT JOIN procedures prev
+                          ON prev.user_id     = p.user_id
+                         AND prev.sub_user_id = p.sub_user_id
+                         AND prev.name        = p.name
+                         AND prev.version     = pe.version_before
                    WHERE p.user_id = %s AND p.sub_user_id = %s AND p.name = %s
                    ORDER BY pe.created_at ASC""",
                 (user_id, sub_user_id, proc["name"])
@@ -5915,6 +5927,8 @@ REFLECTIONS/PATTERNS:
                     "version_before": row["version_before"],
                     "version_after": row["version_after"],
                     "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+                    "success_count": row["prev_success"],
+                    "fail_count": row["prev_fail"],
                 })
             return results
 

--- a/tests/test_markdown_export.py
+++ b/tests/test_markdown_export.py
@@ -104,7 +104,7 @@ class TestProcedures:
     def test_title_carries_version_and_reliability(self):
         out = procedure_file({"name": "Deploy", "version": 3,
                               "success_count": 11, "fail_count": 1})
-        assert "# Deploy (v3 · 92% reliable)" in out
+        assert "# Deploy (v3 · 86% reliable)" in out
 
     def test_an_untested_procedure_does_not_claim_a_rate(self):
         out = procedure_file({"name": "Deploy", "version": 1})
@@ -166,3 +166,32 @@ class TestWholeTree:
     def test_every_file_ends_with_exactly_one_newline(self):
         for text in build_tree([entity("A")], [], [{"id": "p", "name": "P"}]).values():
             assert text.endswith("\n") and not text.endswith("\n\n")
+
+
+class TestSmoothing:
+    """The exported heading is read by memfmt, so the two must agree. A bare
+    ratio also punished revisions: a new version opened at 0/0 and read worse
+    than the one it was written to fix."""
+
+    def test_small_samples_do_not_read_as_certainty(self):
+        out = procedure_file({"name": "P", "version": 1, "success_count": 1, "fail_count": 0})
+        assert "67% reliable" in out
+
+    def test_nothing_to_go_on_stays_untested(self):
+        assert "untested" in procedure_file({"name": "P", "version": 1})
+
+    def test_a_revision_stands_on_its_lineage(self):
+        evolution = [{"version_before": 2, "version_after": 3, "diff": {"reason": "fix"},
+                      "success_count": 11, "fail_count": 1}]
+        out = procedure_file({"name": "P", "version": 3}, evolution)
+        assert "(v3 · 81% expected)" in out
+        # and the record that produced the prior travels with the file
+        assert "- v2 → v3 (11✓/1✗): fix" in out
+
+    def test_lineage_without_a_record_changes_nothing(self):
+        """Old rows have no counts to join; the file must still be valid."""
+        evolution = [{"version_before": 1, "version_after": 2, "change_type": "revised",
+                      "success_count": None, "fail_count": None}]
+        out = procedure_file({"name": "P", "version": 2}, evolution)
+        assert "untested" in out
+        assert "- v1 → v2: revised" in out


### PR DESCRIPTION
[memfmt 0.2.0](https://github.com/alibaizhanov/memfmt/releases/tag/0.2.0) stopped rendering a bare ratio. The server still did, so our export and the format we publish disagreed about the same file.

### Why the ratio was wrong

A new v3 opens at 0✓/0✗ and reads `untested` beside the v2 it was written to fix, which still reads 92%. Anything comparing them keeps choosing the version that already failed. Progressive delivery calls the same record a canary confidence score and CI calls the per-test version a flake quarantine ledger; both smooth against a prior instead of comparing raw counts.

### What changed

| | before | after |
|---|---|---|
| 11✓/1✗ | `92% reliable` | `86% reliable` |
| 1✓/0✗ | `100% reliable` | `67% reliable` |
| new version, v2 retired at 11✓/1✗ | `untested` | `81% expected` |

The prior is the retiring version's record, discounted by half. That record was never in the evolution log — the rows carry the diff and the versions, not the counts — so `get_procedure_evolution` now joins the retired version's row. The unique constraint on `(user_id, sub_user_id, name, version)` keeps it to one row per revision, and the `## Evolution` line carries it into the file:

```
- v2 → v3 (9✓/1✗): wait for the pool before probing
```

Raw counts in frontmatter are untouched. Only the derived percentage moves.

### Verification

Not a second copy of the formula asserted twice — the tree this builds was parsed by the **released** memfmt 0.2.0, both sides computed the same 87% from the same prior, and re-serialising returned identical bytes.

Evolution rows with nothing to join (everything written before this) render exactly as they did, and there is a test for that.

38 export tests pass. The 3 failures in `test_parser.py` are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
