### PR TITLE
Stop minting a version for a workflow nobody ran, and write the failure down

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -7454,6 +7454,21 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
                             context=ep.context or "",
                         )
                         if is_failure and plan not in ("free", "starter"):
+                            # Record the failure on the version that failed
+                            # before revising it. This path revised procedures
+                            # 1,810 times in production and never once wrote
+                            # the failure down, so the ledger we build the
+                            # whole feature on showed six failures in ten
+                            # thousand rows — and a revision inherited a prior
+                            # from a predecessor whose record was empty by
+                            # construction.
+                            try:
+                                store.procedure_feedback(
+                                    user_id, best_proc["id"], success=False,
+                                    sub_user_id=sub_uid)
+                            except Exception as e:
+                                logger.warning(f"⚠️ Failure not recorded for "
+                                               f"{best_proc.get('name')}: {e}")
                             evo = EvolutionEngine(store, embedder, extractor.llm)
                             evo_result = evo.evolve_on_failure(
                                 user_id, best_proc["id"], episode_id,

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -5801,6 +5801,42 @@ REFLECTIONS/PATTERNS:
             gate_meta["quarantine_reason"] = regressions
             new_metadata = gate_meta
 
+        # A version that has never succeeded is a hypothesis, not evidence.
+        # Superseding one with another mints a version number for something
+        # nobody tried, and the production data shows where that leads: a chain
+        # 32 deep, fourteen versions in two days, and the one ancestor with a
+        # real record (9 successes) buried under revisions that were never run.
+        # So an unproven version is revised in place. Its successor inherits
+        # nothing because there was nothing to inherit, and the last version
+        # that actually worked stays the lineage's most recent evidence.
+        #
+        # A gated revision still takes the versioned path: quarantine needs a
+        # row of its own to hold the flagged copy while the old one serves.
+        if not gated and int(old.get("success_count") or 0) == 0:
+            with self._cursor() as cur:
+                cur.execute(
+                    """UPDATE procedures
+                       SET steps = %s::jsonb, trigger_condition = %s,
+                           metadata = %s::jsonb, evolved_from_episode = %s,
+                           updated_at = NOW()
+                       WHERE id = %s AND user_id = %s AND sub_user_id = %s""",
+                    (json.dumps(new_steps), new_trigger or old["trigger_condition"],
+                     json.dumps(new_metadata), episode_id,
+                     procedure_id, user_id, sub_user_id)
+                )
+            with self._cursor() as cur:
+                cur.execute(
+                    """INSERT INTO procedure_evolution
+                       (procedure_id, episode_id, change_type, diff,
+                        version_before, version_after)
+                       VALUES (%s, %s, %s, %s::jsonb, %s, %s)""",
+                    (procedure_id, episode_id, "revised_in_place",
+                     json.dumps(dict(diff or {})), old_version, old_version)
+                )
+            logger.info(f"✏️ Procedure revised in place: {old['name']} v{old_version} "
+                        f"(never succeeded, so no new version minted)")
+            return procedure_id
+
         # Only retire the old current version if the new one is safe to promote.
         if not gated:
             with self._cursor() as cur:

--- a/tests/test_evolution_churn.py
+++ b/tests/test_evolution_churn.py
@@ -1,0 +1,137 @@
+"""A version nobody ran should not be superseded by another one nobody ran.
+
+Production showed what the old rule cost: one procedure reached version 32 in
+ten days, fourteen of those versions inside two days, none of them run even
+once. The one ancestor with a real record — nine successes — was retired early
+and everything after it started blank, so ten days of evidence produced a
+current version that knows nothing about itself.
+
+Hermetic: CloudStore is built without __init__ and handed a stub cursor, the
+same way test_entity_chunks does it, so no database is required.
+"""
+
+import contextlib
+import json
+
+from cloud.store import CloudStore
+
+
+class _FakeCursor:
+    """Records SQL and hands back queued rows."""
+
+    def __init__(self, rows=None):
+        self._rows = list(rows or [])
+        self.sql = []
+        self.params = []
+
+    def execute(self, sql, params=None):
+        self.sql.append(" ".join(sql.split()))
+        self.params.append(params)
+
+    def fetchone(self):
+        return self._rows.pop(0) if self._rows else None
+
+    def fetchall(self):
+        return []
+
+
+def _store(procedure, rows=None):
+    """A store whose only real behaviour is evolve_procedure."""
+    store = CloudStore.__new__(CloudStore)
+    cursor = _FakeCursor(rows)
+
+    @contextlib.contextmanager
+    def _cursor(dict_cursor=False):
+        yield cursor
+
+    store._cursor = _cursor
+    store.cursor = cursor
+    store.get_procedure_by_id = lambda *a, **k: procedure
+    store.get_procedures = lambda *a, **k: []          # nothing to regress against
+    store.save_procedure = lambda **kw: (
+        store.saved.append(kw) or "new-version-id")
+    store.saved = []
+    return store
+
+
+def _procedure(success_count, fail_count=0, version=3):
+    return {
+        "id": "p1", "name": "deploy", "version": version,
+        "success_count": success_count, "fail_count": fail_count,
+        "entity_names": ["Railway"], "trigger_condition": "on merge",
+        "steps": [{"step": 1, "action": "push", "detail": ""}],
+        "metadata": {},
+    }
+
+
+NEW_STEPS = [{"step": 1, "action": "run migrations", "detail": ""},
+             {"step": 2, "action": "push", "detail": ""}]
+
+
+class TestUnprovenVersionsAreRevisedInPlace:
+    def test_a_version_that_never_succeeded_is_edited_not_superseded(self):
+        store = _store(_procedure(success_count=0))
+
+        returned = store.evolve_procedure("u", "p1", NEW_STEPS, sub_user_id="default")
+
+        assert returned == "p1"                 # same row, not a new version
+        assert store.saved == []                # save_procedure never called
+        assert any("UPDATE procedures SET steps" in s for s in store.cursor.sql)
+
+    def test_a_failure_alone_does_not_earn_a_version(self):
+        """Failures are what trigger revisions. If a failure counted as being
+        proven, every revision would mint a version and nothing would change."""
+        store = _store(_procedure(success_count=0, fail_count=5))
+        assert store.evolve_procedure("u", "p1", NEW_STEPS) == "p1"
+        assert store.saved == []
+
+    def test_a_proven_version_still_gets_a_successor(self):
+        store = _store(_procedure(success_count=9))
+
+        returned = store.evolve_procedure("u", "p1", NEW_STEPS)
+
+        assert returned == "new-version-id"
+        assert store.saved and store.saved[0]["version"] == 4
+        assert store.saved[0]["parent_version_id"] == "p1"
+
+    def test_the_proven_version_is_retired_only_when_replaced(self):
+        store = _store(_procedure(success_count=9))
+        store.evolve_procedure("u", "p1", NEW_STEPS)
+        assert any("is_current = FALSE" in s for s in store.cursor.sql)
+
+    def test_an_in_place_revision_is_still_logged(self):
+        """The reason a workflow changed is the part worth keeping, so an edit
+        writes history even though the version number does not move."""
+        store = _store(_procedure(success_count=0))
+        store.evolve_procedure("u", "p1", NEW_STEPS, diff={"reason": "cold pool"})
+
+        logged = [i for i, s in enumerate(store.cursor.sql)
+                  if "INSERT INTO procedure_evolution" in s]
+        assert logged
+        params = store.cursor.params[logged[0]]
+        assert params[2] == "revised_in_place"
+        assert params[4] == params[5] == 3          # version_before == version_after
+        assert json.loads(params[3])["reason"] == "cold pool"
+
+
+class TestQuarantineStillWins:
+    def test_a_flagged_revision_takes_the_versioned_path_even_if_unproven(self, monkeypatch):
+        """Quarantine needs a row of its own to hold the flagged copy while the
+        old version keeps serving. Editing in place would apply the very
+        revision the gate just refused."""
+        import cloud.regression_gate as gate
+        monkeypatch.setattr(gate, "find_regressions",
+                            lambda *a, **k: [{"dependent_id": "b",
+                                              "dependent_name": "seed",
+                                              "broken_preconditions": ["migrate first"],
+                                              "broken_orderings": []}])
+        store = _store(_procedure(success_count=0))
+
+        returned = store.evolve_procedure("u", "p1", NEW_STEPS)
+
+        assert returned == "new-version-id"
+        assert store.saved, "a quarantined revision still needs its own row"
+        assert store.saved[0]["is_current"] is False
+        assert store.saved[0]["metadata"]["status"] == "needs_review"
+        # and the old version must NOT be retired while it is still serving
+        assert not any("is_current = FALSE" in s for s in store.cursor.sql)


### PR DESCRIPTION
Found by reading production, not the code.

One procedure there reached **version 32 in ten days** — fourteen of them inside two days, none run even once. The ancestor with the only real record, nine successes, was retired early and every version after it started blank. Ten days of learning produced a current version that knows nothing about itself.

```
v6   9✓   ← the only version with evidence
v7   8✓
...
v11–v24  fourteen versions in two days, all 0 runs
...
v32  0✓   ← current
```

### Defect 1 — a hypothesis superseding a hypothesis

A version that has never succeeded has proven nothing, so minting a successor for it spends a version number on something nobody tried. It is now **revised in place**: the steps change, the history still gets written (the reason a workflow changed is the part worth keeping), but the version number does not move until something has actually worked.

A **gated** revision still takes the versioned path. Quarantine needs a row of its own to hold the flagged copy while the old version keeps serving — editing in place would apply the very revision the gate just refused. There is a test for exactly that.

### Defect 2 — the failure was never written down

Revisions are triggered by failures inferred from episodes in the add pipeline, and that path never recorded the failure it acted on:

| | |
|---|---|
| revisions in production | 1,810 |
| procedures with `fail_count > 0` | 6 |

So the evidence ledger the whole feature rests on was near-empty by construction — and this morning's lineage prior, which reads the retiring version's record, had nothing to read. It records the failure now, before revising.

### What this changes for the 12 users who have evolution

Chains stop growing on every negative-valence episode. The last version that actually worked stays the lineage's most recent evidence instead of being buried, which is also what makes the smoothed estimate mean anything in production.

### Verification

6 hermetic tests on the stub-cursor pattern from `test_entity_chunks` — no database. 243 in the suite; the 3 failures in `test_parser.py` are pre-existing on `main`.

Not covered: whether `is_failure_episode` itself over-fires. It is a careful heuristic and was hardened once already, but a streak-alert procedure revised fourteen times in two days suggests negative valence is a broad trigger. That is a separate question and wants its own evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
