### PR TITLE
Give the agent a per-step record instead of one verdict for the whole workflow

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -9252,7 +9252,9 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
             if ctx.plan in ("free", "starter"):
                 raise HTTPException(status_code=403, detail="Procedure evolution is a Pro feature. Upgrade at mengram.io/dashboard")
             use_quota(ctx, "add")
-        result = store.procedure_feedback(user_id, procedure_id, success, sub_user_id=sub_user_id)
+        result = store.procedure_feedback(user_id, procedure_id, success,
+                                          sub_user_id=sub_user_id,
+                                          failed_at_step=body.failed_at_step if body else None)
         if "error" in result:
             raise HTTPException(status_code=404, detail=result["error"])
 

--- a/cloud/markdown_export.py
+++ b/cloud/markdown_export.py
@@ -263,6 +263,13 @@ def procedure_file(procedure: dict, evolution: list = None) -> str:
                     text = f"{text} — {step['detail']}" if text else step["detail"]
             else:
                 text = str(step)
+            # Same bracket convention memfmt 0.3 reads back: a step's record
+            # rides at the end of its line, and its absence means untracked
+            # rather than failing.
+            if isinstance(step, dict) and (step.get("success_count") is not None
+                                           or step.get("fail_count") is not None):
+                text = (f"{text} ({int(step.get('success_count') or 0)}✓/"
+                        f"{int(step.get('fail_count') or 0)}✗)")
             body.append(f"{i}. {text}")
 
     for entry in (evolution or []):

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -5695,25 +5695,68 @@ REFLECTIONS/PATTERNS:
         self._touch_procedures_last_used([r["id"] for r in results])
         return results
 
-    def procedure_feedback(self, user_id: str, procedure_id: str, success: bool, sub_user_id: str = "default") -> dict:
-        """Record success/failure feedback for a procedure."""
+    @staticmethod
+    def _apply_step_outcome(steps: list, success: bool, failed_at_step: int = None) -> list:
+        """Credit the steps that ran and debit the one that broke.
+
+        A run does not tell you one thing, it tells you as many things as there
+        are steps. When step 3 of 5 fails, steps 1 and 2 *ran and worked* —
+        recording only "the procedure failed" throws that away and makes every
+        step look equally suspect. Steps after the failure never executed, so
+        they learn nothing either way.
+
+        This is also what keeps a record alive across versioning: a revision
+        usually touches one step, and the untouched ones have no reason to
+        forget the runs behind them.
+        """
+        updated = []
+        for i, step in enumerate(steps or [], 1):
+            if not isinstance(step, dict):
+                updated.append(step)
+                continue
+            step = dict(step)
+            if success:
+                ran, worked = True, True
+            elif failed_at_step is None:
+                ran, worked = False, False      # nothing to attribute
+            else:
+                ran, worked = i <= failed_at_step, i < failed_at_step
+            if ran:
+                key = "success_count" if worked else "fail_count"
+                step[key] = int(step.get(key) or 0) + 1
+            updated.append(step)
+        return updated
+
+    def procedure_feedback(self, user_id: str, procedure_id: str, success: bool,
+                           sub_user_id: str = "default", failed_at_step: int = None) -> dict:
+        """Record success/failure feedback for a procedure and for its steps."""
         col = "success_count" if success else "fail_count"
         with self._cursor(dict_cursor=True) as cur:
             cur.execute(
-                f"""UPDATE procedures
-                    SET {col} = {col} + 1, last_used = NOW(), updated_at = NOW()
-                    WHERE id = %s AND user_id = %s AND sub_user_id = %s
-                    RETURNING id, name, success_count, fail_count""",
+                """SELECT steps FROM procedures
+                   WHERE id = %s AND user_id = %s AND sub_user_id = %s""",
                 (procedure_id, user_id, sub_user_id)
             )
-            row = cur.fetchone()
-            if not row:
+            found = cur.fetchone()
+            if not found:
                 return {"error": "procedure not found"}
+            steps = self._apply_step_outcome(found["steps"] or [], success, failed_at_step)
+
+            cur.execute(
+                f"""UPDATE procedures
+                    SET {col} = {col} + 1, steps = %s::jsonb,
+                        last_used = NOW(), updated_at = NOW()
+                    WHERE id = %s AND user_id = %s AND sub_user_id = %s
+                    RETURNING id, name, success_count, fail_count, steps""",
+                (json.dumps(steps), procedure_id, user_id, sub_user_id)
+            )
+            row = cur.fetchone()
             return {
                 "id": str(row["id"]),
                 "name": row["name"],
                 "success_count": row["success_count"],
                 "fail_count": row["fail_count"],
+                "steps": row["steps"],
                 "feedback": "success" if success else "failure",
             }
 

--- a/tests/test_step_outcomes.py
+++ b/tests/test_step_outcomes.py
@@ -1,0 +1,65 @@
+"""A run does not teach one thing — it teaches as many as there are steps.
+
+When step 3 of 5 fails, steps 1 and 2 ran and worked. Recording only "the
+procedure failed" throws that away and leaves every step equally suspect, which
+is exactly what an agent cannot act on. It is also what kept the record from
+surviving a revision: a revision usually touches one step, and the untouched
+ones have no reason to forget the runs behind them.
+
+Pure function, no database.
+"""
+
+from cloud.store import CloudStore
+
+apply = CloudStore._apply_step_outcome
+
+
+def steps(n=5):
+    return [{"step": i, "action": f"step {i}", "detail": ""} for i in range(1, n + 1)]
+
+
+def counts(result):
+    return [(s.get("success_count"), s.get("fail_count")) for s in result]
+
+
+class TestStepOutcomes:
+    def test_success_credits_every_step(self):
+        assert counts(apply(steps(3), success=True)) == [(1, None), (1, None), (1, None)]
+
+    def test_failure_credits_the_steps_that_ran_and_debits_the_one_that_broke(self):
+        result = apply(steps(5), success=False, failed_at_step=3)
+        assert counts(result) == [(1, None), (1, None), (None, 1), (None, None), (None, None)]
+
+    def test_the_first_step_failing_credits_nothing(self):
+        assert counts(apply(steps(3), success=False, failed_at_step=1)) == [
+            (None, 1), (None, None), (None, None)]
+
+    def test_a_failure_with_no_step_named_attributes_nothing(self):
+        """Better a procedure-level count alone than blaming five steps for
+        something one of them did."""
+        assert counts(apply(steps(3), success=False)) == [
+            (None, None), (None, None), (None, None)]
+
+    def test_counts_accumulate_across_runs(self):
+        s = steps(3)
+        for _ in range(4):
+            s = apply(s, success=True)
+        s = apply(s, success=False, failed_at_step=3)
+        assert counts(s) == [(5, None), (5, None), (4, 1)]
+
+    def test_a_step_past_the_end_is_harmless(self):
+        """`failed_at_step` arrives from a caller and may not match the steps."""
+        assert counts(apply(steps(2), success=False, failed_at_step=9)) == [(1, None), (1, None)]
+
+    def test_non_dict_steps_survive(self):
+        """Older rows hold plain strings; a half-written update is worse than
+        no update."""
+        mixed = ["do the thing", {"step": 2, "action": "then this"}]
+        result = apply(mixed, success=True)
+        assert result[0] == "do the thing"
+        assert result[1]["success_count"] == 1
+
+    def test_the_original_is_not_mutated(self):
+        original = steps(2)
+        apply(original, success=True)
+        assert original[0].get("success_count") is None


### PR DESCRIPTION
`failed_at_step` has been arriving in feedback all along — it is in `FeedbackRequest`, it is in the MCP tool schema that agents call, and it was handed to the evolution engine and then dropped. Nothing ever counted it.

So a run taught exactly one thing: the procedure worked, or it did not.

### What changes

When step 3 of 5 fails, steps 1 and 2 **ran and worked**. Throwing that away leaves every step equally suspect, which is precisely what an agent cannot act on — it asks "which of these can I trust" and gets one number for the whole workflow.

| outcome | steps before | failing step | steps after |
|---|---|---|---|
| success | +1 ✓ | +1 ✓ | +1 ✓ |
| failure at step N | +1 ✓ | +1 ✗ | untouched — never ran |
| failure, no step named | untouched | — | untouched |

A failure with no step named still counts against the procedure and attributes nothing to any step. Blaming five steps for what one of them did is worse than staying silent.

### Why this matters beyond attribution

It is what keeps a record alive across versioning. A revision usually touches one step; the untouched ones have no reason to forget the runs behind them. That was the strongest argument anyone made for per-step counters, and it is not the argument I had — it came from a reader of the r/AI_Agents thread.

### No migration

`steps` is JSONB. The export carries the record in the bracket convention memfmt 0.3 already reads:

```
1. push code — to Railway (5✓/0✗)
2. run migrations (5✓/0✗)
3. verify /health — expect 200 (4✓/1✗)
```

Cross-checked against the **released** memfmt 0.4: it parses the tree, reads all three steps as tracked, and re-serialising returns identical bytes.

### Verification

8 hermetic tests on the pure function, including the cases that bite: a step index past the end of the list, plain-string steps from older rows, and that the input list is not mutated. 243 in the suite; the 3 failures in `test_parser.py` are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
