### PR TITLE
Read the failing step out of the failure text, and hand the agent a reading

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -7462,10 +7462,17 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
                             # thousand rows — and a revision inherited a prior
                             # from a predecessor whose record was empty by
                             # construction.
+                            # Nobody calls the feedback tool, so the step has
+                            # to be read out of what was already written. The
+                            # failure text usually names it outright.
+                            failed_step = EvolutionEngine.infer_failed_step(
+                                best_proc.get("steps") or [],
+                                f"{ep.summary or ''} {ep.context or ''} {ep.outcome or ''}")
                             try:
                                 store.procedure_feedback(
                                     user_id, best_proc["id"], success=False,
-                                    sub_user_id=sub_uid)
+                                    sub_user_id=sub_uid,
+                                    failed_at_step=failed_step)
                             except Exception as e:
                                 logger.warning(f"⚠️ Failure not recorded for "
                                                f"{best_proc.get('name')}: {e}")
@@ -7473,7 +7480,8 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
                             evo_result = evo.evolve_on_failure(
                                 user_id, best_proc["id"], episode_id,
                                 ep.context or ep.summary,
-                                sub_user_id=sub_uid)
+                                sub_user_id=sub_uid,
+                                failed_at_step=failed_step)
                             if evo_result:
                                 logger.info(
                                     f"🔄 Auto-evolved '{best_proc['name']}' "

--- a/cloud/evolution.py
+++ b/cloud/evolution.py
@@ -135,7 +135,8 @@ class EvolutionEngine:
 
     def evolve_on_failure(self, user_id: str, procedure_id: str,
                           episode_id: str, failure_context: str = "",
-                          sub_user_id: str = "default") -> dict | None:
+                          sub_user_id: str = "default",
+                          failed_at_step: int = None) -> dict | None:
         """Analyze a procedure failure and create an improved version.
 
         Args:
@@ -169,7 +170,7 @@ class EvolutionEngine:
             f"  Step {s.get('step', i+1)}: {s.get('action', '')} — {s.get('detail', '')}"
             for i, s in enumerate(proc["steps"])
         )
-        failed_step = episode.get("failed_at_step")
+        failed_step = episode.get("failed_at_step") or failed_at_step
         if failed_step is None and failure_context:
             failed_step = "unknown"
 
@@ -467,6 +468,65 @@ class EvolutionEngine:
             keyword_score = 0.0
 
         return round(0.5 * vec_score + 0.3 * entity_score + 0.2 * keyword_score, 4)
+
+    #: Words that carry no signal about *which* step broke.
+    _STEP_STOP = frozenset({
+        "the", "a", "an", "to", "of", "in", "on", "for", "and", "or", "is",
+        "was", "were", "it", "this", "that", "with", "at", "after", "before",
+        "when", "then", "failed", "failing", "error", "errors", "broke",
+        "broken", "step", "again", "during", "while", "because",
+        # Generic action verbs. They appear in most steps and in most failure
+        # reports, so letting one decide attribution means "error during the
+        # run" lands on "run migrations" — a step that may have been fine.
+        "run", "ran", "runs", "check", "checked", "checks", "get", "got",
+        "set", "make", "made", "use", "used", "call", "called", "try",
+        "tried", "add", "adds", "send", "sent", "do", "did", "done",
+    })
+
+    @staticmethod
+    def infer_failed_step(steps: list, text: str) -> int | None:
+        """Which step the failure text is describing, 1-based, or None.
+
+        Nobody reports the step. The feedback tool takes `failed_at_step` and
+        agents do not call it — zero calls in a month of production — so the
+        per-step record stays empty unless it can be read out of what was
+        already written. The failure text usually says it plainly: "timed out
+        on the migration", "health check never returned 200".
+
+        Deterministic on purpose: this runs on the add path, and a model call
+        per episode to guess an index is not worth it. Matching is word overlap
+        against each step's own words, ignoring the vocabulary of failure
+        itself — "failed" appears in every report and distinguishes nothing.
+
+        Returns None unless one step is both a real match and a clear winner.
+        A wrong index is worse than no index: it debits a step that did nothing
+        wrong, and that record is what an agent is meant to trust.
+        """
+        words = re.findall(r"[a-z0-9_]+", (text or "").lower())
+        said = {w for w in words if len(w) > 2 and w not in EvolutionEngine._STEP_STOP}
+        if not said:
+            return None
+
+        scored = []
+        for i, step in enumerate(steps or [], 1):
+            if not isinstance(step, dict):
+                continue
+            own = re.findall(r"[a-z0-9_]+",
+                             f"{step.get('action', '')} {step.get('detail', '')}".lower())
+            own = {w for w in own if len(w) > 2 and w not in EvolutionEngine._STEP_STOP}
+            if own:
+                scored.append((len(said & own), i))
+
+        matched = [(n, i) for n, i in scored if n]
+        if not matched:
+            return None
+        matched.sort(reverse=True)
+        best, index = matched[0]
+        if len(matched) > 1 and matched[1][0] == best:
+            return None                      # two steps fit equally; do not guess
+        if best == 1 and len(matched) > 1:
+            return None                      # a lone shared word among rivals is a coincidence
+        return index
 
     @staticmethod
     def is_failure_episode(emotional_valence: str, outcome: str = "",

--- a/cloud/markdown_export.py
+++ b/cloud/markdown_export.py
@@ -187,41 +187,7 @@ def episode_file(episode: dict) -> str:
     return "\n".join(body).rstrip() + "\n"
 
 
-#: Must match memfmt's LINEAGE_WEIGHT. These files are read back by that
-#: library, and two different discounts would render two different numbers for
-#: the same record — the one failure a shared format exists to prevent.
-LINEAGE_WEIGHT = 0.5
-
-
-def _prior(evolution: list = None) -> tuple:
-    """Beta prior for a version, taken from what its predecessor retired with.
-
-    A bare ratio punishes the revision: a new version opens at 0/0 and reads
-    worse than the one it was written to fix, so anything choosing between them
-    keeps the version that already failed. Progressive delivery and CI answered
-    this years ago by smoothing against a prior instead of comparing raw counts.
-    """
-    for entry in reversed(evolution or []):
-        success, fail = entry.get("success_count"), entry.get("fail_count")
-        if success is not None or fail is not None:
-            return (1.0 + LINEAGE_WEIGHT * (success or 0),
-                    1.0 + LINEAGE_WEIGHT * (fail or 0))
-    return (1.0, 1.0)
-
-
-def _reliability(success: int, fail: int, prior: tuple = (1.0, 1.0)) -> str:
-    """How much to trust this version, in words.
-
-    The word matters as much as the number: "never run" and "run and it worked"
-    must not read alike, so a version standing on its lineage says `expected`
-    and one with a record of its own says `reliable`.
-    """
-    alpha, beta = prior
-    observed = success + fail
-    if observed == 0 and (alpha, beta) == (1.0, 1.0):
-        return "untested"
-    estimate = (success + alpha) / (observed + alpha + beta)
-    return f"{round(100 * estimate)}% {'reliable' if observed else 'expected'}"
+from cloud.reliability import estimate as _reliability_estimate, prior_from_lineage as _prior
 
 
 def procedure_file(procedure: dict, evolution: list = None) -> str:
@@ -241,7 +207,7 @@ def procedure_file(procedure: dict, evolution: list = None) -> str:
             "fail_count": fail,
         }),
         "",
-        f"# {name} (v{version} · {_reliability(success, fail, _prior(evolution))})",
+        f"# {name} (v{version} · {_reliability_estimate(success, fail, _prior(evolution))})",
     ]
 
     if procedure.get("trigger_condition"):

--- a/cloud/reliability.py
+++ b/cloud/reliability.py
@@ -1,0 +1,79 @@
+"""How much to trust a workflow, or one step of it, in words.
+
+Kept in its own module because three places have to agree: what the API hands
+an agent, what the Markdown export writes, and what the published memfmt
+library reads back. Two of them already computed it separately and the third
+did not compute it at all, which is how the same record came to mean different
+things depending on where you read it.
+
+A bare success/total ratio is the wrong number twice over. It overstates small
+samples — one success is not 100% — and it punishes a revision, which opens at
+0/0 and so reads worse than the version it was written to fix. Progressive
+delivery and CI met both years ago (a canary confidence record, a flake
+quarantine ledger) and answered with the same move: smooth against a prior
+instead of comparing raw counts.
+
+The word matters as much as the number. "Never run" and "run and it worked"
+must not read alike, because an agent acts on the difference.
+"""
+
+from __future__ import annotations
+
+#: How much of a predecessor's record carries into its successor's prior.
+#: Half: enough that a long-reliable lineage does not re-earn trust from
+#: scratch, little enough that a few runs of the new version dominate it.
+#: Must match memfmt's LINEAGE_WEIGHT — these files are read back by it.
+LINEAGE_WEIGHT = 0.5
+
+NEUTRAL_PRIOR = (1.0, 1.0)
+
+
+def estimate(success: int, fail: int, prior: tuple = NEUTRAL_PRIOR) -> str:
+    """Trust in words: `untested`, `N% expected`, or `N% reliable`.
+
+    `expected` means the version has no runs of its own and is standing on what
+    came before it. `reliable` means it has a record. `untested` means there is
+    nothing to go on at all, and inventing a number for that would be worse
+    than saying so.
+    """
+    alpha, beta = prior
+    observed = int(success or 0) + int(fail or 0)
+    if observed == 0 and tuple(prior) == NEUTRAL_PRIOR:
+        return "untested"
+    value = (int(success or 0) + alpha) / (observed + alpha + beta)
+    return f"{round(100 * value)}% {'reliable' if observed else 'expected'}"
+
+
+def prior_from_lineage(evolution: list = None) -> tuple:
+    """Beta prior taken from what the previous version retired with.
+
+    A predecessor's history is evidence about a successor without being a claim
+    about it, so it is discounted rather than carried forward whole. Carrying
+    it forward whole would be the claim, and it would be false.
+    """
+    for entry in reversed(evolution or []):
+        success, fail = entry.get("success_count"), entry.get("fail_count")
+        if success is not None or fail is not None:
+            return (1.0 + LINEAGE_WEIGHT * (success or 0),
+                    1.0 + LINEAGE_WEIGHT * (fail or 0))
+    return NEUTRAL_PRIOR
+
+
+def annotate_steps(steps: list) -> list:
+    """Add `reliability` to each step that carries a record.
+
+    Steps with no record are left alone: absence means nobody measured, never
+    that something went wrong, and writing `untested` onto every step of every
+    old procedure would say the opposite.
+    """
+    out = []
+    for step in steps or []:
+        if not isinstance(step, dict):
+            out.append(step)
+            continue
+        if step.get("success_count") is not None or step.get("fail_count") is not None:
+            step = dict(step)
+            step["reliability"] = estimate(step.get("success_count") or 0,
+                                           step.get("fail_count") or 0)
+        out.append(step)
+    return out

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass
 from typing import Optional
 from contextlib import contextmanager
 
+from cloud.reliability import annotate_steps, estimate
+
 try:
     import psycopg2
     import psycopg2.extras
@@ -5490,10 +5492,15 @@ REFLECTIONS/PATTERNS:
                     "id": str(row["id"]),
                     "name": row["name"],
                     "trigger_condition": row["trigger_condition"],
-                    "steps": row["steps"] or [],
+                    # The agent reads this, and a model handed 4 and 1 will
+                    # answer 80% — the small-sample error the estimate exists
+                    # to prevent. Raw counts stay; the reading comes with them.
+                    "steps": annotate_steps(row["steps"] or []),
                     "entity_names": row["entity_names"] or [],
                     "success_count": row["success_count"] or 0,
                     "fail_count": row["fail_count"] or 0,
+                    "reliability": estimate(row["success_count"] or 0,
+                                            row["fail_count"] or 0),
                     "version": row["version"] or 1,
                     "last_used": row["last_used"].isoformat() if row["last_used"] else None,
                     "created_at": row["created_at"].isoformat() if row["created_at"] else None,
@@ -5682,10 +5689,15 @@ REFLECTIONS/PATTERNS:
                     "id": pid,
                     "name": row["name"],
                     "trigger_condition": row["trigger_condition"],
-                    "steps": row["steps"] or [],
+                    # The agent reads this, and a model handed 4 and 1 will
+                    # answer 80% — the small-sample error the estimate exists
+                    # to prevent. Raw counts stay; the reading comes with them.
+                    "steps": annotate_steps(row["steps"] or []),
                     "entity_names": row["entity_names"] or [],
                     "success_count": row["success_count"] or 0,
                     "fail_count": row["fail_count"] or 0,
+                    "reliability": estimate(row["success_count"] or 0,
+                                            row["fail_count"] or 0),
                     "version": row["version"] or 1,
                     "score": round(float(row["score"]), 4),
                     "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
@@ -5953,10 +5965,15 @@ REFLECTIONS/PATTERNS:
                     "id": str(row["id"]),
                     "name": row["name"],
                     "trigger_condition": row["trigger_condition"],
-                    "steps": row["steps"] or [],
+                    # The agent reads this, and a model handed 4 and 1 will
+                    # answer 80% — the small-sample error the estimate exists
+                    # to prevent. Raw counts stay; the reading comes with them.
+                    "steps": annotate_steps(row["steps"] or []),
                     "entity_names": row["entity_names"] or [],
                     "success_count": row["success_count"] or 0,
                     "fail_count": row["fail_count"] or 0,
+                    "reliability": estimate(row["success_count"] or 0,
+                                            row["fail_count"] or 0),
                     "version": row["version"] or 1,
                     "parent_version_id": str(row["parent_version_id"]) if row["parent_version_id"] else None,
                     "evolved_from_episode": str(row["evolved_from_episode"]) if row["evolved_from_episode"] else None,

--- a/tests/test_step_attribution.py
+++ b/tests/test_step_attribution.py
@@ -1,0 +1,92 @@
+"""Reading the failing step out of what was already written.
+
+Nobody calls the feedback tool with a step number — zero calls in a month of
+production — so the per-step record stays empty unless the step can be inferred
+from the failure text. It usually says it outright: "timed out on the
+migration", "health check never returned 200".
+
+A wrong index is worse than none: it debits a step that did nothing wrong, and
+that record is exactly what an agent is meant to trust. So these tests care
+more about the refusals than the hits.
+"""
+
+from cloud.evolution import EvolutionEngine
+from cloud.reliability import annotate_steps, estimate
+
+infer = EvolutionEngine.infer_failed_step
+
+STEPS = [
+    {"step": 1, "action": "push code", "detail": "to Railway"},
+    {"step": 2, "action": "run migrations", "detail": "against the primary"},
+    {"step": 3, "action": "verify health", "detail": "expect 200 within 60s"},
+]
+
+
+class TestInferFailedStep:
+    def test_it_finds_the_step_the_text_describes(self):
+        assert infer(STEPS, "the health check never returned 200, timed out") == 3
+        assert infer(STEPS, "migrations failed against the primary") == 2
+        assert infer(STEPS, "could not push code to Railway") == 1
+
+    def test_a_vague_report_names_nothing(self):
+        """"It broke" is every failure report ever written."""
+        for text in ("it broke again", "failed", "error during the run", ""):
+            assert infer(STEPS, text) is None
+
+    def test_a_lone_word_counts_when_only_one_step_matches(self):
+        """Terse reports are the norm. If exactly one step is mentioned at all,
+        that is the step — refusing here would mean never firing."""
+        assert infer(STEPS, "migrations broke") == 2
+
+    def test_a_lone_word_shared_with_rivals_is_a_coincidence(self):
+        steps = [{"action": "upload the report"}, {"action": "upload the invoice"},
+                 {"action": "send the digest"}]
+        assert infer(steps, "the upload failed") is None
+
+    def test_two_steps_fitting_equally_well_names_neither(self):
+        steps = [{"action": "upload the report"}, {"action": "upload the invoice"}]
+        assert infer(steps, "the upload failed") is None
+
+    def test_failure_vocabulary_does_not_decide(self):
+        """Every report contains 'failed'. If a step happened to say it too,
+        that word must not be what picks it."""
+        steps = [{"action": "retry on failed uploads"}, {"action": "send the digest"}]
+        assert infer(steps, "the digest never went out") == 2
+
+    def test_no_steps_is_not_an_error(self):
+        assert infer([], "anything") is None
+        assert infer(None, "anything") is None
+
+    def test_plain_string_steps_are_skipped_not_crashed(self):
+        assert infer(["push code", {"action": "run migrations"}], "migrations broke") == 2
+
+
+class TestReliabilityIsOneFormula:
+    """Three places have to agree: what the API hands an agent, what the export
+    writes, and what memfmt reads back."""
+
+    def test_small_samples_do_not_read_as_certainty(self):
+        assert estimate(1, 0) == "67% reliable"
+        assert estimate(5, 0) == "86% reliable"
+        assert estimate(4, 1) == "71% reliable"
+
+    def test_nothing_to_go_on_says_so(self):
+        assert estimate(0, 0) == "untested"
+
+    def test_a_lineage_prior_reads_as_expected_not_reliable(self):
+        assert estimate(0, 0, (6.5, 1.5)).endswith("expected")
+
+    def test_steps_with_a_record_get_a_reading(self):
+        out = annotate_steps([{"action": "a", "success_count": 4, "fail_count": 1}])
+        assert out[0]["reliability"] == "71% reliable"
+        assert out[0]["success_count"] == 4        # raw counts stay
+
+    def test_steps_without_a_record_are_left_alone(self):
+        """Absence means nobody measured, never that something went wrong."""
+        out = annotate_steps([{"action": "a"}])
+        assert "reliability" not in out[0]
+
+    def test_the_input_is_not_mutated(self):
+        original = [{"action": "a", "success_count": 1}]
+        annotate_steps(original)
+        assert "reliability" not in original[0]


### PR DESCRIPTION
Builds on #90, which added the per-step record. That record had **nobody filling it and nothing reading it correctly**. This closes both.

### Nobody was filling it

The feedback tool takes `failed_at_step`, agents can see it in the MCP schema, and it was called **zero times in a month of production**. Meanwhile the failure text almost always names the step outright — and we already infer *that* a failure happened from that same text. We just never asked *where*.

```
"health check never returned 200"   → step 3
"migrations broke"                  → step 2
"error during the run"              → nothing
"it broke again"                    → nothing
```

Deterministic, no model call on the add path. It **refuses more than it answers**, on purpose:

- two steps fitting equally well names neither
- a lone shared word among rivals is a coincidence
- generic verbs (`run`, `check`, `send`, `call`…) never decide — otherwise *"error during the run"* lands on *"run migrations"* and debits a step that was fine

A wrong index is worse than no index: the record it corrupts is the one an agent is meant to trust.

### Nothing was reading it correctly

The smoothed estimate lived in the exporter and in the published `memfmt` library. The API handed agents **raw counts**. A model given `4` and `1` answers 80% — precisely the small-sample error the smoothing exists to prevent, on the one path that reaches an agent.

All three now share one formula in `cloud/reliability.py`:

| | before | after |
|---|---|---|
| API response | `success_count: 4, fail_count: 1` | same, plus `reliability: "71% reliable"` |
| export | `71% reliable` (own copy of the formula) | same, shared |
| memfmt | `71% reliable` | unchanged |

Raw counts stay. The reading comes with them, not instead of them. Steps with no record are left untouched — absence means nobody measured, never that something failed.

### Verification

14 tests on the two pure functions, weighted toward the refusals. 265 in the suite; the 3 failures in `test_parser.py` are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
