### PR TITLE
procedures: carry step records across a revision, but only for unedited steps

### DIFF
--- a/cloud/reliability.py
+++ b/cloud/reliability.py
@@ -59,6 +59,63 @@ def prior_from_lineage(evolution: list = None) -> tuple:
     return NEUTRAL_PRIOR
 
 
+def _identity(step) -> str:
+    """What makes a step the same step across a revision: what it says.
+
+    Not its position. A revision that inserts a step at the top shifts every
+    index below it, and carrying records by index would hand each step the
+    history of its neighbour.
+    """
+    if not isinstance(step, dict):
+        return " ".join(str(step).lower().split())
+    parts = (step.get("action") or "", step.get("detail") or "")
+    return " ".join(" ".join(str(p) for p in parts).lower().split())
+
+
+def carry_step_history(old_steps: list, new_steps: list) -> list:
+    """Move per-step records onto a revision, but only for steps it left alone.
+
+    A revision rewrites one or two steps and leaves the rest verbatim. Dropping
+    every record at that boundary — which is what wholesale step replacement
+    did — means a workflow can never accumulate evidence about the parts of it
+    that were never in question.
+
+    The opposite mistake is worse, and it is the one worth being careful about:
+    if a rewritten step keeps the counters of the text it replaced, a new
+    `verify /health` inherits eleven successes it never earned, and the number
+    reads as evidence while being the newest-thing-wins bug in better clothes.
+    So a step keeps its record only when its text is unchanged; any edit starts
+    it at zero, which is the honest reading — nobody has run *this* yet.
+
+    Identical steps are matched one-for-one so a duplicated step cannot claim
+    the same runs twice.
+    """
+    available: dict = {}
+    for step in old_steps or []:
+        if not isinstance(step, dict):
+            continue
+        if step.get("success_count") is None and step.get("fail_count") is None:
+            continue
+        available.setdefault(_identity(step), []).append(step)
+
+    out = []
+    for step in new_steps or []:
+        if not isinstance(step, dict):
+            out.append(step)
+            continue
+        step = dict(step)
+        step.pop("success_count", None)      # never trust counters the LLM emitted
+        step.pop("fail_count", None)
+        match = available.get(_identity(step))
+        if match:
+            old = match.pop(0)
+            for key in ("success_count", "fail_count"):
+                if old.get(key) is not None:
+                    step[key] = old[key]
+        out.append(step)
+    return out
+
+
 def annotate_steps(steps: list) -> list:
     """Add `reliability` to each step that carries a record.
 

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from typing import Optional
 from contextlib import contextmanager
 
-from cloud.reliability import annotate_steps, estimate
+from cloud.reliability import annotate_steps, carry_step_history, estimate
 
 try:
     import psycopg2
@@ -5827,6 +5827,14 @@ REFLECTIONS/PATTERNS:
         old_version = old["version"]
         new_version = old_version + 1
         new_metadata = metadata if metadata is not None else (old.get("metadata") or {})
+
+        # The revision arrives as plain text from the LLM, with no counters on
+        # it. Written as-is it wipes the record of every step, including the
+        # ones the revision never touched — so a workflow could never build
+        # evidence about its stable parts. Steps whose text is unchanged keep
+        # their record; anything edited starts at zero, because nobody has run
+        # *that* yet.
+        new_steps = carry_step_history(old.get("steps") or [], new_steps)
 
         # --- Cross-procedure regression gate (v1) ---------------------------
         # Before promoting, check whether this revision silently breaks another

--- a/tests/test_step_outcomes.py
+++ b/tests/test_step_outcomes.py
@@ -9,6 +9,7 @@ ones have no reason to forget the runs behind them.
 Pure function, no database.
 """
 
+from cloud.reliability import carry_step_history as carry
 from cloud.store import CloudStore
 
 apply = CloudStore._apply_step_outcome
@@ -63,3 +64,75 @@ class TestStepOutcomes:
         original = steps(2)
         apply(original, success=True)
         assert original[0].get("success_count") is None
+
+
+class TestRecordSurvivesRevision:
+    """What a revision is allowed to keep.
+
+    Raised by deelight_0909 on r/hermesagent: if a rewritten step keeps the
+    counters of the text it replaced, a fresh `/health` check inherits eleven
+    successes it never earned — "newest thing wins" wearing better numbers.
+    They were right that it is the danger; the code had the opposite bug, and
+    dropped every record at the revision boundary instead.
+    """
+
+    def test_an_untouched_step_keeps_its_record(self):
+        old = [{"action": "push to main", "success_count": 12},
+               {"action": "verify health", "success_count": 9, "fail_count": 3}]
+        new = [{"action": "push to main"},
+               {"action": "verify health"}]
+        assert counts(carry(old, new)) == [(12, None), (9, 3)]
+
+    def test_an_edited_step_starts_over(self):
+        """The whole point. New text has no record, and saying otherwise is
+        the claim that makes the number worthless."""
+        old = [{"action": "verify health", "success_count": 11}]
+        new = [{"action": "verify health with backoff"}]
+        assert counts(carry(old, new)) == [(None, None)]
+
+    def test_an_inserted_step_does_not_shift_records_onto_neighbours(self):
+        old = [{"action": "push to main", "success_count": 12},
+               {"action": "verify health", "success_count": 9}]
+        new = [{"action": "wait for the pool"},
+               {"action": "push to main"},
+               {"action": "verify health"}]
+        assert counts(carry(old, new)) == [(None, None), (12, None), (9, None)]
+
+    def test_a_duplicated_step_cannot_claim_the_same_runs_twice(self):
+        old = [{"action": "retry upload", "success_count": 4}]
+        new = [{"action": "retry upload"}, {"action": "retry upload"}]
+        assert counts(carry(old, new)) == [(4, None), (None, None)]
+
+    def test_counters_invented_by_the_model_are_discarded(self):
+        """`new_steps` is LLM output. Anything numeric in it is hallucinated."""
+        old = [{"action": "push to main"}]
+        new = [{"action": "push to main", "success_count": 999}]
+        assert counts(carry(old, new)) == [(None, None)]
+
+    def test_detail_is_part_of_what_makes_a_step_the_same_step(self):
+        old = [{"action": "verify health", "detail": "expect 200 within 60s",
+                "success_count": 9}]
+        assert counts(carry(old, [{"action": "verify health",
+                                   "detail": "expect 200 within 5s"}])) == [(None, None)]
+        assert counts(carry(old, [{"action": "verify health",
+                                   "detail": "expect 200 within 60s"}])) == [(9, None)]
+
+    def test_whitespace_and_case_are_not_a_difference(self):
+        old = [{"action": "Push  to main", "success_count": 12}]
+        assert counts(carry(old, [{"action": "push to main"}])) == [(12, None)]
+
+    def test_a_step_nobody_measured_carries_nothing_and_crashes_nothing(self):
+        assert counts(carry([{"action": "a"}], [{"action": "a"}])) == [(None, None)]
+        assert carry([], []) == []
+        assert carry(None, None) == []
+
+    def test_non_dict_steps_survive(self):
+        assert carry([{"action": "a", "success_count": 1}],
+                     ["a", {"action": "a"}]) == ["a", {"action": "a", "success_count": 1}]
+
+    def test_the_originals_are_not_mutated(self):
+        old = [{"action": "a", "success_count": 3}]
+        new = [{"action": "a"}]
+        carry(old, new)
+        assert new[0].get("success_count") is None
+        assert old[0]["success_count"] == 3


### PR DESCRIPTION
Found by a commenter on r/hermesagent, checking the design described in the post rather than the code.

## What was wrong

`evolve_procedure` passes the LLM's revised steps straight into storage, and both write paths replace the column wholesale (`steps = EXCLUDED.steps` in `save_procedure`, a plain `UPDATE ... SET steps` in the revise-in-place path). The LLM emits `action`/`detail` and nothing else, so **every per-step counter went to zero on every revision** — including the steps the revision never touched.

That defeats the point of per-step records. Workflow-level counts are noisy because whole runs are rarely comparable; step-level counts are the useful signal precisely because they survive the parts that change. They weren't surviving anything.

The `_apply_step_outcome` docstring already claimed they did. That claim was aspirational.

## Why the obvious fix is worse

Carrying counters forward by position means a rewritten `verify /health` inherits the eleven successes of the text it replaced. The number then reads as evidence while being the newest-thing-wins bug in better clothes — the exact failure the whole procedure-versioning design exists to prevent.

## What this does

`carry_step_history(old_steps, new_steps)` in `cloud/reliability.py`, applied once in `evolve_procedure` before the regression gate so both write paths get it:

- a step keeps its record only when its **text is unchanged** — any edit starts at zero, which is the honest reading
- identity is `action + detail` normalised for case and whitespace, **not index**, so an inserted step doesn't shift records onto its neighbours
- identical steps match one-for-one, so a duplicated step can't claim the same runs twice
- counters appearing in LLM output are discarded as hallucinated

## Not done here

The commenter's actual proposal was stronger: immutable per-run receipts (workflow version, step version, environment fingerprint, verifier version, result including `unknown`, proving artifact) with the counts *derived* rather than stored. That's the right shape and it makes questions like "did this pass in an environment resembling the current one" answerable at all. It's a schema change and a bigger piece of work — this PR fixes the data loss without it.

## Tests

10 new cases in `tests/test_step_outcomes.py::TestRecordSurvivesRevision` covering unchanged / edited / inserted / duplicated steps, hallucinated counters, whitespace-and-case, empty input, non-dict legacy steps, and non-mutation of both inputs.

`275 passed`. The 3 failures in `test_parser.py` are pre-existing (missing `test_vault` fixture) and unrelated.
