### PR TITLE
Stop serving GET on the MCP streamable endpoints

### DIFF
--- a/cloud/api.py
+++ b/cloud/api.py
@@ -10974,13 +10974,18 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
                             tg.start_soon(_run)
                             await transport.handle_request(scope, receive, send)
 
-            app.add_route("/mcp", _MCPStreamableHandler(), methods=["GET", "POST", "DELETE"])
+            # No GET: the transport is stateless (mcp_session_id=None), so the
+            # server never emits server-initiated messages and a GET SSE stream
+            # would hang until the edge kills it at 900s, pinning one of the two
+            # gunicorn workers until the --timeout 300 watchdog SIGABRTs it.
+            # The spec allows 405 here when a server offers no standalone stream.
+            app.add_route("/mcp", _MCPStreamableHandler(), methods=["POST", "DELETE"])
             logger.info("✅ MCP Streamable HTTP transport enabled at /mcp")
 
             # Slim, curated surface for the Claude Connectors Directory listing —
             # same handler, restricted to the DIRECTORY_CONNECTOR_TOOLS subset.
             app.add_route("/mcp/connector", _MCPStreamableHandler(DIRECTORY_CONNECTOR_TOOLS),
-                          methods=["GET", "POST", "DELETE"])
+                          methods=["POST", "DELETE"])
             logger.info("✅ MCP Connectors Directory surface at /mcp/connector (%d tools)",
                         len(DIRECTORY_CONNECTOR_TOOLS))
 


### PR DESCRIPTION
## What

Removes `GET` from the route registration for `/mcp` and `/mcp/connector`. They keep serving `POST` and `DELETE`; `GET` now returns `405` with an `Allow` header.

## Why

Both endpoints are served by a stateless transport (`mcp_session_id=None`), so the server never emits server-initiated messages. A `GET` opened the standalone SSE stream anyway and blocked on it until Railway's edge cut the connection at **900s** — the observed duration was exactly 900000ms, every time.

The Claude connector reconnects roughly every 15 minutes and opens **two** such streams simultaneously, which is exactly the number of gunicorn workers we run (`-w 2` in `start.sh`). With both workers pinned, the `--timeout 300` watchdog SIGABRTed them.

Measured over the four days to 2026-08-31 in the Railway logs:

- **52** `WORKER TIMEOUT` + SIGABRT events and **54** application starts — from a single container boot on 08-27, with no deploys in between
- **85%** of worker kills (33 of 39 within HTTP-log coverage) occurred while a `/mcp` GET stream was hanging
- `GET /mcp/connector` median duration **125s** vs `POST` median **58ms**
- 220 x HTTP 499 (client gave up); no 5xx — the damage showed as disconnects and restart churn, and every restart re-ran the full migration set

## Spec

The streamable HTTP spec allows a server that offers no standalone SSE stream to answer `GET` with `405 Method Not Allowed`, which is what Starlette returns from the route's `methods` list.

## Verification

- Reproduced the exact registration shape (ASGI class instance + `methods=[...]`) against the installed Starlette 1.0.0: `GET` -> 405 with `Allow: POST, DELETE`; `POST`/`DELETE` -> 200, unaffected
- Confirmed the hang source in `mcp==1.28.1`: `_handle_get_request` blocks on `async for` over a stream that stays empty in stateless mode
- Test suite: 275 passed. The 3 failures in `test_parser.py` are pre-existing (verified by stashing this change and re-running — they fail identically without it) and unrelated: they need a `test_vault` fixture directory.

Confirmed separately that OAuth discovery is **not** affected: `/.well-known/oauth-protected-resource/mcp/connector` and `/.well-known/oauth-authorization-server` both return 200 with a correct chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fAhZ64xzNeB7A9XRRjRe3