### PR TITLE
Fix the two audit lifecycle bugs: facts that can't revive, procedures that vanish

### DIFF
--- a/cloud/store.py
+++ b/cloud/store.py
@@ -2340,13 +2340,21 @@ class CloudStore:
             for fact in (facts or []):
                 importance = self.estimate_importance(fact)
                 event_date = (fact_dates or {}).get(fact)
+                # A re-asserted fact is live again: the UNIQUE(entity_id, content)
+                # index also covers archived rows, so without the reset a fact
+                # that was superseded and later becomes true again stays
+                # archived while RETURNING reports success. Safe against the
+                # same add's contradiction pass — that runs before this upsert
+                # and never archives a fact identical to an incoming one.
                 if expires_at:
                     cur.execute(
                         """INSERT INTO facts (entity_id, content, importance, expires_at, event_date, metadata)
                            VALUES (%s, %s, %s, %s, %s, %s::jsonb)
                            ON CONFLICT (entity_id, content) DO UPDATE SET
                                event_date = COALESCE(EXCLUDED.event_date, facts.event_date),
-                               metadata = facts.metadata || EXCLUDED.metadata
+                               metadata = facts.metadata || EXCLUDED.metadata,
+                               archived = FALSE,
+                               superseded_by = NULL
                            RETURNING content""",
                         (entity_id, fact, importance, expires_at, event_date, meta_json)
                     )
@@ -2356,7 +2364,9 @@ class CloudStore:
                            VALUES (%s, %s, %s, %s, %s::jsonb)
                            ON CONFLICT (entity_id, content) DO UPDATE SET
                                event_date = COALESCE(EXCLUDED.event_date, facts.event_date),
-                               metadata = facts.metadata || EXCLUDED.metadata
+                               metadata = facts.metadata || EXCLUDED.metadata,
+                               archived = FALSE,
+                               superseded_by = NULL
                            RETURNING content""",
                         (entity_id, fact, importance, event_date, meta_json)
                     )
@@ -5418,6 +5428,13 @@ REFLECTIONS/PATTERNS:
             if existing:
                 name = existing["name"]  # Use canonical casing
 
+        # Conflicts on version 1 come from re-extraction (add/reflection) and
+        # must not resurrect a retired v1 next to a newer current version, so
+        # its lifecycle fields stay untouched. Conflicts on version > 1 only
+        # come from evolve_procedure landing on a stale quarantined copy of the
+        # same version number — there the incoming row is authoritative: without
+        # taking its is_current/metadata the old version is already retired and
+        # the procedure is left with no current version at all.
         try:
             with self._cursor() as cur:
                 cur.execute(
@@ -5432,6 +5449,18 @@ REFLECTIONS/PATTERNS:
                            trigger_condition = COALESCE(EXCLUDED.trigger_condition, procedures.trigger_condition),
                            steps = EXCLUDED.steps,
                            entity_names = EXCLUDED.entity_names,
+                           is_current = CASE WHEN procedures.version > 1
+                                             THEN EXCLUDED.is_current
+                                             ELSE procedures.is_current END,
+                           metadata = CASE WHEN procedures.version > 1
+                                           THEN EXCLUDED.metadata
+                                           ELSE procedures.metadata END,
+                           parent_version_id = CASE WHEN procedures.version > 1
+                                                    THEN EXCLUDED.parent_version_id
+                                                    ELSE procedures.parent_version_id END,
+                           evolved_from_episode = CASE WHEN procedures.version > 1
+                                                       THEN EXCLUDED.evolved_from_episode
+                                                       ELSE procedures.evolved_from_episode END,
                            updated_at = NOW()
                        RETURNING id""",
                     (user_id, sub_user_id, name, trigger_condition, steps_json, entities,

--- a/tests/test_upsert_lifecycle.py
+++ b/tests/test_upsert_lifecycle.py
@@ -1,0 +1,105 @@
+"""Regression tests for the two audit H-bugs in upsert lifecycle handling.
+
+H1 — a re-asserted fact must come back to life. UNIQUE(entity_id, content)
+also covers archived rows, so the fact upsert used to hit DO UPDATE on a
+superseded fact, report success via RETURNING, and leave it archived —
+"lives in Almaty" could never return after being superseded.
+
+H2 — a procedure must never end up with zero current versions. evolve_procedure
+retires the old current version before inserting the new one; when the new
+(name, version) collides with a stale quarantined row, the old DO UPDATE
+rewrote steps but not is_current/metadata, so the quarantined row stayed
+non-current (and kept its needs_review flag) while the old version was already
+retired — the procedure vanished from every listing.
+
+Hermetic: CloudStore is constructed without __init__ and given a stub cursor,
+so no database is required. The assertions pin the SQL the store actually
+sends, normalized to single spaces.
+"""
+
+import contextlib
+
+from cloud.store import CloudStore
+
+
+class _FakeCursor:
+    """Records normalized SQL; serves queued fetchone/fetchall results."""
+
+    def __init__(self, fetchone_results=None, fetchall_results=None):
+        self._ones = list(fetchone_results or [])
+        self._alls = list(fetchall_results or [])
+        self.sql = []
+
+    def execute(self, sql, params=None):
+        self.sql.append(" ".join(sql.split()))
+
+    def fetchone(self):
+        return self._ones.pop(0) if self._ones else None
+
+    def fetchall(self):
+        return self._alls.pop(0) if self._alls else []
+
+
+def _store(cursor):
+    store = CloudStore.__new__(CloudStore)
+
+    @contextlib.contextmanager
+    def _cursor(dict_cursor=False):
+        yield cursor
+
+    store._cursor = _cursor
+    store._schedule_matview_refresh = lambda: None
+    return store
+
+
+class TestFactUpsertRevives:
+    def _fact_upserts(self, expires_at=None):
+        cur = _FakeCursor(fetchone_results=[{"content": "lives in Almaty"}])
+        store = _store(cur)
+        store._add_facts_knowledge_relations(
+            "eid", "uid", "Frank",
+            facts=["lives in Almaty"], expires_at=expires_at,
+        )
+        return [s for s in cur.sql if "INSERT INTO facts" in s]
+
+    def test_upsert_resets_archived_and_superseded(self):
+        (sql,) = self._fact_upserts()
+        assert "ON CONFLICT (entity_id, content) DO UPDATE" in sql
+        assert "archived = FALSE" in sql
+        assert "superseded_by = NULL" in sql
+
+    def test_expiring_branch_resets_too(self):
+        (sql,) = self._fact_upserts(expires_at="2027-01-01")
+        assert "expires_at" in sql
+        assert "archived = FALSE" in sql
+        assert "superseded_by = NULL" in sql
+
+
+class TestProcedureUpsertLifecycle:
+    def _save_sql(self):
+        cur = _FakeCursor(fetchone_results=[
+            None,                                             # canonical-name lookup
+            ("11111111-1111-1111-1111-111111111111",),        # INSERT ... RETURNING id
+        ])
+        store = _store(cur)
+        store.save_procedure(
+            "uid", "deploy", trigger_condition="on release",
+            steps=[{"action": "ship"}], version=2, is_current=True,
+        )
+        return next(s for s in cur.sql if "INSERT INTO procedures" in s)
+
+    def test_conflict_takes_incoming_lifecycle_on_evolved_versions(self):
+        sql = self._save_sql()
+        assert "ON CONFLICT ON CONSTRAINT uq_procedures_user_sub_name_ver" in sql
+        for field in ("is_current", "metadata", "parent_version_id", "evolved_from_episode"):
+            assert (
+                f"{field} = CASE WHEN procedures.version > 1 THEN EXCLUDED.{field} ELSE procedures.{field} END"
+                in sql
+            ), f"{field} must follow the incoming row only for evolved versions"
+
+    def test_version_one_conflicts_keep_existing_lifecycle(self):
+        """Re-extraction hitting a retired v1 must not mint a second current
+        version — the CASE arms fall back to the row's own values there."""
+        sql = self._save_sql()
+        assert "ELSE procedures.is_current END" in sql
+        assert "ELSE procedures.metadata END" in sql


### PR DESCRIPTION
Closes the two H-severity items left open from the 2026-08-06 audit (`specs/audit-2026-08-06.md` §1).

## H1 — a re-asserted fact stayed archived forever

`UNIQUE(entity_id, content)` also covers archived rows. Re-asserting a superseded fact ("lives in Almaty" → superseded → true again) hit `ON CONFLICT DO UPDATE`, reported success via `RETURNING`, and left the fact archived — invisible to search with no way back except manual SQL.

**Fix:** the fact upsert resets `archived = FALSE, superseded_by = NULL` (both branches).
**Why it's safe:** the contradiction pass (`archive_contradicted_facts`) runs *before* the upsert in the add flow and has an exact-match guard, so it never archives a fact identical to an incoming one — revival can't undo a same-request archival. The revived fact is re-embedded in the same add: `build_entity_chunks` runs after the save and builds from full entity state.

## H2 — a procedure could end up with zero current versions

`evolve_procedure` retires the old current version *before* inserting the new one (no transactions). When the new `(name, version)` collided with a stale quarantined row of the same version number, `DO UPDATE` rewrote steps but not `is_current`/`metadata` — the old version was already retired, the quarantined row stayed non-current with its `needs_review` flag, and the procedure disappeared from every listing.

**Fix:** lifecycle fields (`is_current`, `metadata`, `parent_version_id`, `evolved_from_episode`) now follow the incoming row — but **only for `version > 1`**, where the only writer is `evolve_procedure` and the incoming row is authoritative. Version-1 conflicts come from re-extraction (add/reflection) and keep the row's own lifecycle, so a retired v1 is never resurrected next to a newer current version (which a blanket `is_current = EXCLUDED.is_current` would have caused).

## Tests

`tests/test_upsert_lifecycle.py` — 4 hermetic tests in the repo's fake-cursor style, pinning both DO UPDATE clauses and the version-gated CASE arms. Full suite: 279 passed; the 3 `test_parser.py` failures are pre-existing (missing `test_vault` fixture, fail identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fAhZ64xzNeB7A9XRRjRe3