### PR TITLE
procinterfere README: the twelfth surface is Railway, not DNS

### DIFF
--- a/benchmark/procinterfere/README.md
+++ b/benchmark/procinterfere/README.md
@@ -19,7 +19,7 @@ interference."* Nobody measures it. This does.
 procedure and get promoted anyway, with no flag. Lower is better.
 
 Over 20 paired cases across 12 domains (Postgres, S3, Stripe, GitHub, Terraform,
-Redis, Kafka, SQS, Cloudflare, OpenAI, LaunchDarkly, DNS):
+Redis, Kafka, SQS, Cloudflare, OpenAI, LaunchDarkly, Railway):
 
 ```
 system          silent-regression   false-quarantine


### PR DESCRIPTION
One-word docs fix before Show HN: cases.jsonl has no DNS case — the named surfaces end with Railway. A reader diffing README vs data would catch the mismatch. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fAhZ64xzNeB7A9XRRjRe3