### PR TITLE
fix(mcp): render facts in activity feed

### DIFF
--- a/api/cloud_mcp_server.py
+++ b/api/cloud_mcp_server.py
@@ -49,6 +49,22 @@ DIRECTORY_CONNECTOR_TOOLS = {
 }
 
 
+def _format_activity_feed(feed: list[dict]) -> str:
+    """Format feed items using the fields returned by the feed API."""
+    lines = [f"📰 **Activity Feed** ({len(feed)} items)\n"]
+    for item in feed:
+        fact = item.get("fact", item.get("detail", "?"))
+        entity = item.get("entity", "?")
+        ts = item.get("created_at", "")[:16] if item.get("created_at") else ""
+
+        entry = f"- **{entity}** — {fact}"
+        if ts:
+            entry += f" ({ts})"
+        lines.append(entry)
+
+    return "\n".join(lines)
+
+
 def create_cloud_mcp_server(
     mem: CloudMemory,
     user_id: str = "default",
@@ -1237,21 +1253,7 @@ def create_cloud_mcp_server(
                 if not feed:
                     return [TextContent(type="text", text="No activity yet.")]
 
-                lines = [f"📰 **Activity Feed** ({len(feed)} items)\n"]
-                for item in feed:
-                    action = item.get("action", "?")
-                    entity = item.get("entity", "?")
-                    ts = item.get("created_at", "")[:16] if item.get("created_at") else ""
-                    detail = item.get("detail", "")
-
-                    entry = f"- **{action}** {entity}"
-                    if ts:
-                        entry += f" ({ts})"
-                    lines.append(entry)
-                    if detail:
-                        lines.append(f"  {detail}")
-
-                return [TextContent(type="text", text="\n".join(lines))]
+                return [TextContent(type="text", text=_format_activity_feed(feed))]
 
             elif name == "archive_fact":
                 uid = arguments.get("user_id", user_id)

--- a/tests/test_cloud_mcp_feed.py
+++ b/tests/test_cloud_mcp_feed.py
@@ -1,0 +1,16 @@
+"""Tests for cloud MCP activity-feed formatting."""
+
+from api.cloud_mcp_server import _format_activity_feed
+
+
+def test_activity_feed_renders_fact_field():
+    text = _format_activity_feed([
+        {
+            "entity": "smoochy",
+            "fact": "uses speedtest-tracker on port 8003",
+            "created_at": "2026-07-30T13:21:56.175549+00:00",
+        },
+    ])
+
+    assert "- **smoochy** — uses speedtest-tracker on port 8003 (2026-07-30T13:21)" in text
+    assert "?" not in text


### PR DESCRIPTION
Fixes #70.

The cloud MCP `get_feed` formatter was reading `action` and `detail`, but `/v1/feed` returns `entity`, `fact`, and `created_at`. This made every entry render as `?`.

This change mirrors the existing fact-first fallback in `_get_recent()` and renders each item as `entity — fact`, preserving the existing timestamp. Added a focused regression test with a fact-only feed item.

Tests:
- `python3 -m pytest -q tests/test_cloud_mcp_feed.py`
- `python3 -m pytest -q --ignore=tests/test_parser.py` (268 passed; the ignored parser tests require the absent `test_vault` fixture)