### PR TITLE
Policy gate: outcome history changes what the agent may run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `mengram auto-policy` — a Claude Code PreToolUse hook (installed by
+  `mengram hook install`, matcher `Bash`). A command that matches a learned
+  workflow with a weak record (`untested`, inherited `N% expected`, or below
+  `MENGRAM_POLICY_MIN_RELIABLE`, default 70) is answered with `ask`: the user
+  sees why, Claude gets the steps on record. Proven workflows stay silent; the
+  hook never denies. Offline mode via `MENGRAM_MEMORY_DIR` (memfmt folder).
+- `/v1/procedures/search` results now carry `reliability` and `last_used`
+  for both vector and text search (previously only text search had
+  `reliability`; neither had `last_used`).
+
 ## 2.31.0 — 2026-09-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ What happens:
 Session Start  →  Loads your cognitive profile (fires after /clear, compaction, and restarts)
 Every Prompt   →  Searches past sessions for relevant context (auto-recall)
 After Response →  Saves new knowledge in background (auto-save)
+Before a Bash  →  If the command matches a learned workflow with a weak record, asks you first (policy gate, CLI hooks)
 ```
 
 No manual saves. No tool calls. Claude just knows what you worked on yesterday — even after compaction ate the transcript.
@@ -317,7 +318,9 @@ mengram import files notes/*.md --cloud                          # Any text/mark
 mengram hook install
 ```
 
-3 hooks: profile on start, recall on every prompt, save after responses. Zero manual effort.
+4 hooks: profile on start, recall on every prompt, save after responses, and a policy gate before workflow-shaped Bash commands.
+
+**Policy gate.** Outcome history changes what the agent may do, not only how results rank. When a `git push`, `deploy`, `migrate`, `kubectl`, `rm -rf` … matches a learned workflow that is `untested`, inherits its record from an earlier version (`61% expected`), or sits below the bar (`58% reliable`, default 70), the hook answers `ask`: you see why, Claude gets the steps on record, nothing runs on the agent's say-so. A proven workflow stays silent. Works against the cloud, or fully offline against a [memfmt](https://github.com/alibaizhanov/memfmt) folder with `MENGRAM_MEMORY_DIR=./memory`. Only workflow-shaped commands trigger a lookup (one search each); `ls` and `cat` never do. Tune with `MENGRAM_POLICY_MIN_RELIABLE=80`, `MENGRAM_POLICY_PATTERN='\bmake\b'`; skip with `mengram hook install --no-policy`. The memory can ask; it never denies.
 
 [Docs](https://mengram.io/docs/claude-code)
 

--- a/cli.py
+++ b/cli.py
@@ -655,6 +655,69 @@ def cmd_auto_save(args):
         _emit_hook_exit(EVENT, args, HOOK, "error")
 
 
+def cmd_auto_policy(args):
+    """Hook handler — Claude Code PreToolUse on Bash.
+
+    If the command matches a learned workflow whose record is weak, answer
+    "ask" so the human confirms, and hand Claude the plan on record. Every
+    other path prints nothing and exits 0: a hook that fails must never
+    stop a command that would otherwise have run.
+    """
+    HOOK = "auto-policy"
+    from cloud import policy
+
+    def _exit(status, verdict=None):
+        marker = _hook_marker(HOOK, status) if getattr(args, "verbose", False) else None
+        out = policy.hook_output(verdict, marker)
+        if out is not None:
+            print(json.dumps(out))
+        sys.exit(0)
+
+    try:
+        try:
+            input_data = json.loads(sys.stdin.read())
+        except Exception:
+            _exit("no input")
+        if input_data.get("tool_name") != "Bash":
+            _exit("skipped (not Bash)")
+        command = (input_data.get("tool_input") or {}).get("command") or ""
+        if not policy.looks_like_workflow(command, os.environ.get("MENGRAM_POLICY_PATTERN")):
+            _exit("skipped (not a workflow command)")
+
+        min_reliable = getattr(args, "min_reliable", None)
+        if min_reliable is None:
+            try:
+                min_reliable = int(os.environ.get("MENGRAM_POLICY_MIN_RELIABLE", policy.DEFAULT_MIN_RELIABLE))
+            except ValueError:
+                min_reliable = policy.DEFAULT_MIN_RELIABLE
+
+        # Local memfmt folder first: no account, no network, no quota.
+        local_root = os.environ.get("MENGRAM_MEMORY_DIR", "").strip()
+        if local_root:
+            procs = policy.memfmt_procedures(local_root)
+        else:
+            api_key = _load_cloud_api_key()
+            if not api_key:
+                _exit("no API key")
+            from cloud.client import CloudMemory
+            user_id = getattr(args, "user_id", None) or os.environ.get("MENGRAM_USER_ID", "default")
+            mem = CloudMemory(api_key=api_key, base_url=_load_cloud_base_url())
+            procs = mem.procedures(query=command[:300], limit=3, user_id=user_id)
+
+        proc = policy.best_match(procs, command)
+        if not proc:
+            _exit("no matching workflow")
+        verdict = policy.decide(proc, command, min_reliable=min_reliable)
+        if verdict is None:
+            _exit(f"'{proc.get('name')}' {policy.reliability_of(proc)} — allowed")
+        _exit(f"'{verdict['name']}' {verdict['reliability']} — ask", verdict)
+
+    except SystemExit:
+        raise
+    except Exception:
+        _exit("error")
+
+
 def cmd_hook(args):
     """Manage Claude Code auto-save hook"""
     action = getattr(args, "hook_action", None)
@@ -673,8 +736,11 @@ def cmd_hook(args):
         sys.exit(1)
 
 
-def _upsert_hook(settings, event_name, command_marker, hook_def):
-    """Insert or update a hook in settings[hooks][event_name] matching command_marker."""
+def _upsert_hook(settings, event_name, command_marker, hook_def, matcher=None):
+    """Insert or update a hook in settings[hooks][event_name] matching command_marker.
+
+    `matcher` (a tool-name regex such as "Bash") is set only when the group is
+    created; an existing group keeps whatever matcher the user gave it."""
     if "hooks" not in settings:
         settings["hooks"] = {}
     if event_name not in settings["hooks"]:
@@ -692,7 +758,10 @@ def _upsert_hook(settings, event_name, command_marker, hook_def):
             break
 
     if not found:
-        settings["hooks"][event_name].append({"hooks": [hook_def]})
+        group = {"hooks": [hook_def]}
+        if matcher:
+            group = {"matcher": matcher, "hooks": [hook_def]}
+        settings["hooks"][event_name].append(group)
 
     return found
 
@@ -1445,10 +1514,12 @@ def cmd_hook_install(args):
     save_cmd = f"mengram auto-save --every {every}"
     recall_cmd = "mengram auto-recall"
     context_cmd = "mengram auto-context"
+    policy_cmd = "mengram auto-policy"
     if user_id:
         save_cmd += f" --user-id {user_id}"
         recall_cmd += f" --user-id {user_id}"
         context_cmd += f" --user-id {user_id}"
+        policy_cmd += f" --user-id {user_id}"
 
     # Read existing settings
     settings_path = get_claude_code_settings_path()
@@ -1482,6 +1553,16 @@ def cmd_hook_install(args):
         "timeout": 15,
     })
 
+    # 4. PreToolUse hook — a Bash command that matches a learned workflow with
+    #    a weak record (never run, inherited only, or below the bar) is turned
+    #    into a confirmation prompt instead of running on the agent's say-so.
+    if not getattr(args, "no_policy", False):
+        _upsert_hook(settings, "PreToolUse", "mengram auto-policy", {
+            "type": "command",
+            "command": policy_cmd,
+            "timeout": 10,
+        }, matcher="Bash")
+
     # Write settings
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     with open(settings_path, "w") as f:
@@ -1491,6 +1572,8 @@ def cmd_hook_install(args):
     print(f"  Auto-save:    every {every} response(s) (background)")
     print(f"  Auto-recall:  search memory on each prompt")
     print(f"  Session context: load profile on session start")
+    if not getattr(args, "no_policy", False):
+        print(f"  Policy gate:  confirm before running a workflow with a weak record")
     print(f"  Settings: {settings_path}")
     print(f"\nRestart Claude Code for hooks to take effect.")
 
@@ -1515,6 +1598,7 @@ def cmd_hook_uninstall(args):
     removed |= _remove_hook(settings, "Stop", "mengram auto-save")
     removed |= _remove_hook(settings, "UserPromptSubmit", "mengram auto-recall")
     removed |= _remove_hook(settings, "SessionStart", "mengram auto-context")
+    removed |= _remove_hook(settings, "PreToolUse", "mengram auto-policy")
 
     if not removed:
         print("No Mengram hooks found. Nothing to uninstall.")
@@ -1559,6 +1643,7 @@ def cmd_hook_status(args):
     save_cmd = _find_hook("Stop", "mengram auto-save")
     recall_cmd = _find_hook("UserPromptSubmit", "mengram auto-recall")
     context_cmd = _find_hook("SessionStart", "mengram auto-context")
+    policy_cmd = _find_hook("PreToolUse", "mengram auto-policy")
 
     if save_cmd:
         every_n = 3
@@ -1573,6 +1658,7 @@ def cmd_hook_status(args):
 
     print(f"  Auto-recall:    {'installed' if recall_cmd else 'not installed'}")
     print(f"  Session context: {'installed' if context_cmd else 'not installed'}")
+    print(f"  Policy gate:    {'installed' if policy_cmd else 'not installed'}")
 
     # Check API key
     api_key = os.environ.get("MENGRAM_API_KEY", "")
@@ -2048,6 +2134,8 @@ def main():
                                  help="Save every Nth response (default: 3)")
     p_hook_install.add_argument("--user-id", default=None,
                                  help="Mengram user_id (default: 'default')")
+    p_hook_install.add_argument("--no-policy", action="store_true", dest="no_policy",
+                                 help="Skip the PreToolUse policy gate")
     hook_sub.add_parser("uninstall", help="Remove auto-save hook")
     hook_sub.add_parser("status", help="Check hook status")
 
@@ -2071,6 +2159,14 @@ def main():
                                 help="Emit a status marker for each hook invocation")
     p_autocontext.add_argument("--no-weekly", action="store_true",
                                 help="Suppress the once-a-week memory report")
+
+    # auto-policy (internal, called by Claude Code PreToolUse hook on Bash)
+    p_autopolicy = sub.add_parser("auto-policy", help=argparse.SUPPRESS)
+    p_autopolicy.add_argument("--user-id", default=None)
+    p_autopolicy.add_argument("--verbose", action="store_true",
+                               help="Emit a status marker for each hook invocation")
+    p_autopolicy.add_argument("--min-reliable", type=int, default=None, dest="min_reliable",
+                               help="Percent below which a workflow with a record is confirmed (default 70)")
 
     # web
     p_web = sub.add_parser("web", help="Start Web UI (chat + knowledge graph)")
@@ -2135,6 +2231,8 @@ def main():
         cmd_auto_recall(args)
     elif args.command == "auto-context":
         cmd_auto_context(args)
+    elif args.command == "auto-policy":
+        cmd_auto_policy(args)
     elif args.command == "web":
         cmd_web(args)
     elif args.command == "weekly":

--- a/cloud/policy.py
+++ b/cloud/policy.py
@@ -1,0 +1,227 @@
+"""Turn a workflow's track record into a decision about running it.
+
+Retrieval already ranks a weak procedure lower. That is not the same as
+changing what the agent is allowed to do with it: a workflow that has never
+been run, or that exists only because an earlier version failed, should not
+be executed on the agent's own say-so. It should come back to the human as a
+plan first.
+
+This module is the pure part of that gate. It takes a procedure record (the
+shape `/v1/procedures/search` returns, or a memfmt file) and a shell command,
+and says whether the command should be confirmed before it runs, and why.
+The Claude Code hook in `cli.py` is a thin wrapper around `decide()`. Nothing
+here touches the network, and no decision is ever `deny`: the memory can ask,
+it does not get to forbid.
+"""
+
+from __future__ import annotations
+
+import re
+
+from cloud.reliability import estimate
+
+#: Commands that look like a workflow rather than a lookup. Anything else is
+#: waved through without a search, which keeps the hook cheap: a `ls` should
+#: never cost a memory query. Override with MENGRAM_POLICY_PATTERN.
+DEFAULT_PATTERN = (
+    r"\b(deploy|publish|release|migrat\w*|rollback|terraform|pulumi|ansible|"
+    r"kubectl|helm|docker\s+(compose\s+)?(up|push|build|run)|"
+    r"git\s+push|twine\s+upload|npm\s+publish|cargo\s+publish|"
+    r"railway|vercel|heroku|fly\s+deploy|gcloud|aws\s+\w+|"
+    r"ssh|scp|rsync|psql|mysql|drop\s+table|truncate|rm\s+-rf?)\b"
+)
+
+#: Below this a procedure with a real record still gets a confirmation.
+DEFAULT_MIN_RELIABLE = 70
+
+_STOPWORDS = {
+    "the", "and", "for", "with", "from", "into", "then", "that", "this",
+    "when", "after", "before", "your", "run", "runs", "running", "make",
+    "using", "used", "step", "steps", "check", "verify", "wait", "true",
+    "false", "none", "null", "echo", "cd", "&&", "||",
+}
+
+_WORD = re.compile(r"[A-Za-z][A-Za-z0-9_./-]{2,}")
+
+
+def looks_like_workflow(command: str, pattern: str | None = None) -> bool:
+    """Is this command worth a memory lookup at all?"""
+    if not command:
+        return False
+    pat = DEFAULT_PATTERN if pattern is None else pattern
+    if pat.strip() in ("", ".*", "*"):
+        return True
+    try:
+        return re.search(pat, command, re.IGNORECASE) is not None
+    except re.error:
+        return re.search(DEFAULT_PATTERN, command, re.IGNORECASE) is not None
+
+
+def tokens(text: str) -> set[str]:
+    """Words worth matching on: lowercase, 3+ chars, not glue."""
+    return {
+        w.lower().strip("./-")
+        for w in _WORD.findall(text or "")
+        if w.lower() not in _STOPWORDS
+    } - {""}
+
+
+def _procedure_text(proc: dict) -> str:
+    parts = [proc.get("name") or "", proc.get("trigger_condition") or proc.get("trigger") or ""]
+    for step in proc.get("steps") or []:
+        if isinstance(step, dict):
+            parts.append(step.get("action") or "")
+            parts.append(step.get("detail") or "")
+        else:
+            parts.append(str(step))
+    return " ".join(parts)
+
+
+def procedure_matches(proc: dict, command: str) -> bool:
+    """Lexical sanity check on top of semantic search.
+
+    Vector search returns *something* for almost any query. Before a
+    confirmation prompt interrupts the user, the procedure has to share at
+    least one real word with the command it is supposedly about.
+    """
+    return bool(tokens(_procedure_text(proc)) & tokens(command))
+
+
+def reliability_of(proc: dict) -> str:
+    """The record in words, computed here when the source did not include it."""
+    label = proc.get("reliability")
+    if isinstance(label, str) and label:
+        return label
+    return estimate(int(proc.get("success_count") or 0), int(proc.get("fail_count") or 0))
+
+
+def parse_reliability(label: str) -> tuple[str, int | None]:
+    """`untested` → ("untested", None); `61% expected` → ("expected", 61)."""
+    label = (label or "").strip().lower()
+    if label == "untested" or not label:
+        return "untested", None
+    m = re.match(r"(\d+)%\s+(expected|reliable)", label)
+    if not m:
+        return "untested", None
+    return m.group(2), int(m.group(1))
+
+
+def decide(proc: dict, command: str, min_reliable: int = DEFAULT_MIN_RELIABLE) -> dict | None:
+    """Should this command be confirmed before it runs?
+
+    Returns None when the record is strong enough to let the agent act on it
+    alone. Otherwise returns `{"decision": "ask", "reason": ..., "plan": ...}`
+    where `reason` is for the human and `plan` is for the agent.
+    """
+    if not proc or not procedure_matches(proc, command):
+        return None
+
+    name = proc.get("name") or "unnamed workflow"
+    version = proc.get("version") or 1
+    label = reliability_of(proc)
+    kind, pct = parse_reliability(label)
+    s = int(proc.get("success_count") or 0)
+    f = int(proc.get("fail_count") or 0)
+
+    if kind == "untested":
+        why = f"'{name}' has never been run"
+    elif kind == "expected":
+        why = (f"'{name}' v{version} has no runs of its own — {pct}% is inherited "
+               f"from the version it replaced")
+    elif pct is not None and pct < min_reliable:
+        why = f"'{name}' is {pct}% reliable ({s}✓/{f}✗), below the {min_reliable}% bar"
+    else:
+        return None
+
+    return {
+        "decision": "ask",
+        "reason": f"Mengram: learned workflow {why}. Review the plan before it runs.",
+        "plan": _plan(proc, label),
+        "name": name,
+        "reliability": label,
+    }
+
+
+def _plan(proc: dict, label: str) -> str:
+    lines = [f"[Mengram] Matched learned workflow '{proc.get('name')}' (v{proc.get('version') or 1}, {label})."]
+    trig = proc.get("trigger_condition") or proc.get("trigger")
+    if trig:
+        lines.append(f"When: {trig}")
+    steps = proc.get("steps") or []
+    if steps:
+        lines.append("Steps on record:")
+        for i, step in enumerate(steps, 1):
+            if isinstance(step, dict):
+                text = step.get("action") or ""
+                if step.get("detail"):
+                    text += f" — {step['detail']}"
+                rel = step.get("reliability")
+                if rel:
+                    text += f" ({rel})"
+            else:
+                text = str(step)
+            lines.append(f"  {i}. {text}")
+    pre = (proc.get("metadata") or {}).get("preconditions") or proc.get("preconditions")
+    if pre:
+        lines.append("Preconditions: " + "; ".join(str(p) for p in (pre if isinstance(pre, list) else [pre])))
+    lines.append("The evidence for this workflow is weak, so the user was asked to confirm. "
+                 "If they decline, show them the plan and what you would verify first.")
+    return "\n".join(lines)
+
+
+def hook_output(verdict: dict | None, verbose_marker: str | None = None) -> dict | None:
+    """The JSON a Claude Code PreToolUse hook prints for this verdict.
+
+    None means print nothing: no decision, the call proceeds as it would have.
+    """
+    if verdict is None:
+        if verbose_marker:
+            return {"systemMessage": verbose_marker}
+        return None
+    out = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": verdict["decision"],
+            "permissionDecisionReason": verdict["reason"],
+            "additionalContext": verdict["plan"],
+        }
+    }
+    if verbose_marker:
+        out["systemMessage"] = verbose_marker
+    return out
+
+
+def best_match(procs: list[dict], command: str) -> dict | None:
+    """First procedure that actually shares words with the command."""
+    for proc in procs or []:
+        if procedure_matches(proc, command):
+            return proc
+    return None
+
+
+def memfmt_procedures(root: str) -> list[dict]:
+    """Procedures from a memfmt folder, in the dict shape `decide()` reads.
+
+    memfmt is optional: if it is not installed, local mode is simply off.
+    """
+    try:
+        import memfmt  # type: ignore
+    except ImportError:
+        return []
+    memory = memfmt.load(root)
+    out = []
+    for p in memory.procedures:
+        out.append({
+            "name": p.name,
+            "version": p.version,
+            "success_count": p.success_count,
+            "fail_count": p.fail_count,
+            "trigger_condition": p.trigger,
+            "preconditions": list(p.preconditions or []),
+            "steps": [
+                {"action": s.action, "detail": s.detail,
+                 "success_count": s.success_count, "fail_count": s.fail_count}
+                for s in (p.steps or [])
+            ],
+        })
+    return out

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -5670,7 +5670,9 @@ REFLECTIONS/PATTERNS:
                     "entity_names": row.get("entity_names") or [],
                     "success_count": s_count,
                     "fail_count": f_count,
+                    "reliability": estimate(s_count, f_count),
                     "version": row.get("version") or 1,
+                    "last_used": last_used.isoformat() if last_used else None,
                     "score": final_score,
                     "updated_at": row["updated_at"].isoformat() if row.get("updated_at") else None,
                     "metadata": row.get("metadata") or {},
@@ -5694,7 +5696,7 @@ REFLECTIONS/PATTERNS:
             query = query.replace("\x00", "")
         sql = """
             SELECT p.id, p.name, p.trigger_condition, p.steps, p.entity_names,
-                   p.success_count, p.fail_count, p.version, p.updated_at, p.metadata,
+                   p.success_count, p.fail_count, p.last_used, p.version, p.updated_at, p.metadata,
                    ts_rank_cd(pe.tsv, plainto_tsquery('english', %s), 32) AS score
             FROM procedure_embeddings pe
             JOIN procedures p ON p.id = pe.procedure_id
@@ -5728,6 +5730,7 @@ REFLECTIONS/PATTERNS:
                     "reliability": estimate(row["success_count"] or 0,
                                             row["fail_count"] or 0),
                     "version": row["version"] or 1,
+                    "last_used": row["last_used"].isoformat() if row.get("last_used") else None,
                     "score": round(float(row["score"]), 4),
                     "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
                     "metadata": row.get("metadata") or {},

--- a/tests/test_policy_hook.py
+++ b/tests/test_policy_hook.py
@@ -1,0 +1,237 @@
+"""Execution policy from a procedure's record — pure logic plus the hook's JSON."""
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import cli
+from cloud import policy
+
+
+DEPLOY = {
+    "id": "p1", "name": "deploy to Railway", "version": 3,
+    "trigger_condition": "a change lands on main",
+    "steps": [
+        {"action": "push to main", "detail": "the webhook does the rest"},
+        {"action": "watch the boot log"},
+        {"action": "verify /health", "detail": "expect 200 within 60s"},
+    ],
+}
+
+
+def _with(counts, **extra):
+    p = dict(DEPLOY, **extra)
+    p["success_count"], p["fail_count"] = counts
+    return p
+
+
+# --- what counts as a workflow command -------------------------------------
+
+def test_lookup_commands_are_not_workflows():
+    assert not policy.looks_like_workflow("ls -la")
+    assert not policy.looks_like_workflow("cat README.md")
+    assert not policy.looks_like_workflow("")
+
+
+def test_workflow_commands_match_default_pattern():
+    for cmd in ("git push origin main", "railway up", "twine upload dist/*",
+                "kubectl apply -f k8s/", "rm -rf build", "alembic migrate head"):
+        assert policy.looks_like_workflow(cmd), cmd
+
+
+def test_pattern_override_and_wildcard():
+    assert policy.looks_like_workflow("make lint", pattern=r"\bmake\b")
+    assert not policy.looks_like_workflow("git push", pattern=r"\bmake\b")
+    assert policy.looks_like_workflow("anything at all", pattern=".*")
+
+
+def test_bad_pattern_falls_back_to_default():
+    assert policy.looks_like_workflow("git push", pattern="([")
+
+
+# --- the lexical guard on top of semantic search ---------------------------
+
+def test_procedure_must_share_a_word_with_the_command():
+    assert policy.procedure_matches(DEPLOY, "git push origin main && curl /health")
+    assert not policy.procedure_matches(DEPLOY, "kubectl get pods")
+
+
+def test_best_match_skips_unrelated_results():
+    unrelated = {"name": "rotate API keys", "steps": [{"action": "open dashboard"}]}
+    assert policy.best_match([unrelated, DEPLOY], "git push origin main") is DEPLOY
+    assert policy.best_match([unrelated], "git push origin main") is None
+
+
+# --- the decision ---------------------------------------------------------
+
+def test_untested_asks():
+    v = policy.decide(_with((0, 0)), "git push origin main")
+    assert v and v["decision"] == "ask"
+    assert "never been run" in v["reason"]
+    assert "untested" in v["reliability"]
+
+
+def test_inherited_record_asks():
+    # A revision with no runs of its own, standing on the previous version.
+    v = policy.decide(_with((0, 0), reliability="61% expected"), "git push origin main")
+    assert v and "no runs of its own" in v["reason"]
+    assert "61%" in v["reason"]
+
+
+def test_below_bar_asks_and_names_the_counts():
+    v = policy.decide(_with((2, 3)), "git push origin main")
+    assert v and "below the 70% bar" in v["reason"]
+    assert "2✓/3✗" in v["reason"]
+
+
+def test_proven_record_is_silent():
+    assert policy.decide(_with((11, 1)), "git push origin main") is None
+
+
+def test_bar_is_configurable():
+    proc = _with((11, 1))                      # 86% reliable
+    assert policy.decide(proc, "git push origin main", min_reliable=90) is not None
+    assert policy.decide(proc, "git push origin main", min_reliable=80) is None
+
+
+def test_unrelated_procedure_never_asks():
+    assert policy.decide(_with((0, 0)), "kubectl get pods") is None
+
+
+def test_reliability_is_taken_from_the_record_when_present():
+    # The server's label wins over a local recompute, so one record means one thing.
+    assert policy.reliability_of({"reliability": "42% reliable", "success_count": 9}) == "42% reliable"
+    assert policy.reliability_of({"success_count": 0, "fail_count": 0}) == "untested"
+
+
+def test_plan_carries_steps_and_preconditions():
+    proc = _with((0, 0), metadata={"preconditions": ["migrations applied"]})
+    v = policy.decide(proc, "git push origin main")
+    assert "1. push to main — the webhook does the rest" in v["plan"]
+    assert "Preconditions: migrations applied" in v["plan"]
+
+
+# --- the hook's JSON -------------------------------------------------------
+
+def test_hook_output_is_empty_when_allowed():
+    assert policy.hook_output(None) is None
+
+
+def test_hook_output_shape_for_ask():
+    v = policy.decide(_with((0, 0)), "git push origin main")
+    out = policy.hook_output(v)
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PreToolUse"
+    assert hso["permissionDecision"] == "ask"
+    assert hso["permissionDecisionReason"].startswith("Mengram:")
+    assert "[Mengram] Matched learned workflow" in hso["additionalContext"]
+    assert "systemMessage" not in out
+
+
+def test_hook_never_denies():
+    for counts in ((0, 0), (0, 5), (1, 9)):
+        v = policy.decide(_with(counts), "git push origin main")
+        assert v["decision"] == "ask"
+
+
+# --- the CLI command end to end (no network) --------------------------------
+
+class _FakeMem:
+    def __init__(self, api_key=None, base_url=None):
+        self.calls = []
+
+    def procedures(self, query=None, limit=20, user_id="default"):
+        self.calls.append(query)
+        return [_with((0, 0))]
+
+
+def _run_hook(monkeypatch, capsys, payload, env=None, argv=()):
+    monkeypatch.setenv("MENGRAM_API_KEY", "k")
+    monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("MENGRAM_POLICY_PATTERN", raising=False)
+    for k, v in (env or {}).items():
+        monkeypatch.setenv(k, v)
+    import cloud.client
+    monkeypatch.setattr(cloud.client, "CloudMemory", _FakeMem)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(sys, "argv", ["mengram", "auto-policy", *argv])
+    with pytest.raises(SystemExit) as e:
+        cli.main()
+    assert e.value.code == 0
+    return capsys.readouterr().out.strip()
+
+
+def _bash(command):
+    return {"hook_event_name": "PreToolUse", "tool_name": "Bash",
+            "tool_input": {"command": command}}
+
+
+def test_cli_asks_for_untested_workflow(monkeypatch, capsys):
+    out = _run_hook(monkeypatch, capsys, _bash("git push origin main"))
+    data = json.loads(out)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "ask"
+
+
+def test_cli_is_silent_for_lookup_commands(monkeypatch, capsys):
+    assert _run_hook(monkeypatch, capsys, _bash("ls -la")) == ""
+
+
+def test_cli_is_silent_for_other_tools(monkeypatch, capsys):
+    payload = {"hook_event_name": "PreToolUse", "tool_name": "Read",
+               "tool_input": {"file_path": "/x"}}
+    assert _run_hook(monkeypatch, capsys, payload) == ""
+
+
+def test_cli_is_silent_on_garbage_input(monkeypatch, capsys):
+    monkeypatch.setenv("MENGRAM_API_KEY", "k")
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    monkeypatch.setattr(sys, "argv", ["mengram", "auto-policy"])
+    with pytest.raises(SystemExit) as e:
+        cli.main()
+    assert e.value.code == 0
+    assert capsys.readouterr().out.strip() == ""
+
+
+def test_cli_verbose_marker(monkeypatch, capsys):
+    out = _run_hook(monkeypatch, capsys, _bash("ls"), argv=("--verbose",))
+    assert json.loads(out)["systemMessage"].startswith("[mengram:auto-policy]")
+
+
+def test_cli_local_memfmt_folder(monkeypatch, capsys, tmp_path):
+    memfmt = pytest.importorskip("memfmt")
+    (tmp_path / "procedures").mkdir()
+    (tmp_path / "procedures" / "deploy.md").write_text(
+        "---\nmemfmt_type: procedure\nversion: 2\nsuccess_count: 0\nfail_count: 0\n---\n\n"
+        "# deploy to Railway (v2 · untested)\n\n**When** — a change lands on main\n\n"
+        "## Steps\n\n1. push to main\n2. verify /health\n"
+    )
+    out = _run_hook(monkeypatch, capsys, _bash("git push origin main"),
+                    env={"MENGRAM_MEMORY_DIR": str(tmp_path)})
+    data = json.loads(out)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert "deploy to Railway" in data["hookSpecificOutput"]["additionalContext"]
+
+
+# --- install wiring ---------------------------------------------------------
+
+def test_install_adds_pretooluse_group_with_bash_matcher():
+    settings = {}
+    cli._upsert_hook(settings, "PreToolUse", "mengram auto-policy",
+                     {"type": "command", "command": "mengram auto-policy", "timeout": 10},
+                     matcher="Bash")
+    group = settings["hooks"]["PreToolUse"][0]
+    assert group["matcher"] == "Bash"
+    assert group["hooks"][0]["command"] == "mengram auto-policy"
+
+
+def test_upsert_keeps_existing_matcher_on_update():
+    settings = {"hooks": {"PreToolUse": [{"matcher": "Bash|Edit", "hooks": [
+        {"type": "command", "command": "mengram auto-policy --verbose"}]}]}}
+    found = cli._upsert_hook(settings, "PreToolUse", "mengram auto-policy",
+                             {"type": "command", "command": "mengram auto-policy"},
+                             matcher="Bash")
+    assert found
+    assert settings["hooks"]["PreToolUse"][0]["matcher"] == "Bash|Edit"


### PR DESCRIPTION
A Claude Code PreToolUse hook, `mengram auto-policy` (matcher `Bash`), installed by `mengram hook install`.

When a workflow-shaped command (`git push`, `deploy`, `migrate`, `kubectl`, `rm -rf`, …) matches a learned procedure whose record is weak — `untested`, inherited `N% expected`, or below `MENGRAM_POLICY_MIN_RELIABLE` (default 70) — the hook answers `ask`: the user sees why, Claude gets the steps on record as `additionalContext`. Proven workflows stay silent. The hook never denies.

- Pure logic in `cloud/policy.py`; the CLI command is a thin wrapper. Lexical overlap guard on top of semantic search so a vector near-miss can't interrupt the user.
- Offline mode: `MENGRAM_MEMORY_DIR=./memory` reads a memfmt folder, no account or network.
- `/v1/procedures/search` now returns `reliability` and `last_used` on both vector and text paths (additive).
- `_upsert_hook` gained an optional `matcher` so the PreToolUse group only fires for Bash. `--no-policy` skips it on install.
- 25 tests (one skips when memfmt isn't installed; verified passing in a venv with memfmt 0.4.0). Full suite: 292 passed.

Verified end to end against a real memfmt folder: 11✓/1✗ → silent; bar 90 → ask with the plan; `ls` → no lookup.

Origin: r/hermesagent thread, comment by mageblex ("Outcome history should change what the agent is allowed to do").

Staleness (last successful run age) is deliberately not part of v1: `last_used` is touched by searches, so it is not a run timestamp. Needs its own field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt