### PR TITLE
Stop minting a near-duplicate procedure on every re-extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   `MENGRAM_POLICY_MIN_RELIABLE`, default 70) is answered with `ask`: the user
   sees why, Claude gets the steps on record. Proven workflows stay silent; the
   hook never denies. Offline mode via `MENGRAM_MEMORY_DIR` (memfmt folder).
+- Extraction no longer mints a near-duplicate procedure. A freshly extracted
+  workflow is compared (normalised name tokens + step tokens) against the
+  user's current procedures: if it is the same workflow under a slightly
+  different name and the existing one has never been run, the existing one
+  is refreshed in place; if the existing one has a record, it is kept
+  untouched. One user had reached 450 current procedures this way.
 - `/v1/procedures/search` results now carry `reliability` and `last_used`
   for both vector and text search (previously only text search had
   `reliability`; neither had `last_used`).

--- a/cloud/api.py
+++ b/cloud/api.py
@@ -7375,7 +7375,9 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
                         _policy_dropped += 1
                         continue
                 try:
-                    proc_id = store.save_procedure(
+                    # A near-duplicate of a proven procedure is kept as it is:
+                    # its vector stays too, so nothing below re-embeds it.
+                    proc_id, proc_action = store.save_extracted_procedure(
                         user_id=user_id,
                         name=pr.name,
                         trigger_condition=pr.trigger,
@@ -7385,6 +7387,8 @@ document.getElementById('code').addEventListener('keydown', e => {{ if(e.key==='
                         expires_at=expiration_date,
                         sub_user_id=sub_uid,
                     )
+                    if proc_action == "kept":
+                        continue
                     if embedder:
                         steps_summary = "; ".join(
                             (s.get("action", "") if isinstance(s, dict) else str(s)) for s in pr.steps[:10]

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import logging
 import math
+import re
 import secrets
 import sys
 import threading
@@ -66,6 +67,58 @@ def _normalize_step(s) -> str:
     if isinstance(s, dict):
         return s.get("action", "") or s.get("step", "") or s.get("description", "") or str(s)
     return str(s)
+
+_PROC_NAME_STOPWORDS = {
+    "the", "a", "an", "to", "for", "of", "in", "on", "at", "by", "with", "and",
+    "or", "via", "using", "use", "how", "into", "from", "up", "your", "my",
+    "our", "new", "process", "procedure", "workflow", "steps", "step", "routine",
+}
+
+
+def _proc_stem(word: str) -> str:
+    """Crude suffix stripping so 'deploying', 'deployed' and 'deploys' agree.
+
+    Not a stemmer. It only has to make the same workflow, named three ways by
+    three extraction runs, land on the same tokens; it does not have to be
+    right about English."""
+    for suffix in ("ing", "ed", "es", "s"):
+        if word.endswith(suffix) and len(word) - len(suffix) >= 3 and not word.endswith("ss"):
+            return word[: -len(suffix)]
+    return word
+
+
+def _proc_name_tokens(text: str) -> set:
+    words = re.findall(r"[a-z0-9]+", (text or "").lower())
+    return {_proc_stem(w) for w in words if w not in _PROC_NAME_STOPWORDS and len(w) > 1}
+
+
+def _proc_step_tokens(steps: list) -> set:
+    out = set()
+    for s in steps or []:
+        out |= _proc_name_tokens(_normalize_step(s))
+    return out
+
+
+def _jaccard(a: set, b: set) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def procedure_similarity(name_a: str, steps_a: list, name_b: str, steps_b: list) -> tuple:
+    """(name overlap, step overlap), each 0..1. Pure; used by the write-time dedup."""
+    return (_jaccard(_proc_name_tokens(name_a), _proc_name_tokens(name_b)),
+            _jaccard(_proc_step_tokens(steps_a), _proc_step_tokens(steps_b)))
+
+
+def is_near_duplicate_procedure(name_sim: float, step_sim: float) -> bool:
+    """Same workflow under a slightly different name.
+
+    A near-identical name is enough on its own ("Deploy to Railway" vs
+    "Deploying to Railway"). A merely similar name needs the steps to agree
+    too, so "Deploy backend" and "Deploy docs" stay apart."""
+    return name_sim >= 0.8 or (name_sim >= 0.5 and step_sim >= 0.5)
+
 
 
 def _safe_parse_json(raw: str, fallback=None):
@@ -5483,6 +5536,91 @@ REFLECTIONS/PATTERNS:
                     raise
         logger.info(f"⚙️ Procedure saved: {name} v{version}")
         return proc_id
+
+    def find_near_duplicate_procedure(self, user_id: str, name: str, steps: list,
+                                      sub_user_id: str = "default") -> dict | None:
+        """The current procedure this extraction is really about, if one exists.
+
+        Extraction names the same workflow a little differently every run, and
+        the unique constraint only catches an exact (case-insensitive) match,
+        so one user ends up with "Deploy to Railway", "Deploying to Railway"
+        and "Railway deploy" as three procedures competing in every search.
+        This compares normalised name tokens and step tokens against the
+        user's current procedures and returns the best near-duplicate."""
+        with self._cursor(dict_cursor=True) as cur:
+            cur.execute(
+                """SELECT id, name, steps, success_count, fail_count
+                   FROM procedures
+                   WHERE user_id = %s AND sub_user_id = %s AND is_current = TRUE
+                     AND (expires_at IS NULL OR expires_at > NOW())
+                   ORDER BY updated_at DESC
+                   LIMIT 2000""",
+                (user_id, sub_user_id)
+            )
+            rows = cur.fetchall()
+        best, best_score = None, 0.0
+        for row in rows:
+            if (row["name"] or "").strip().lower() == (name or "").strip().lower():
+                continue    # exact match is the unique constraint's job, not ours
+            name_sim, step_sim = procedure_similarity(name, steps, row["name"], row["steps"] or [])
+            if is_near_duplicate_procedure(name_sim, step_sim) and name_sim + step_sim > best_score:
+                best, best_score = row, name_sim + step_sim
+        if best is None:
+            return None
+        return {
+            "id": str(best["id"]),
+            "name": best["name"],
+            "steps": best["steps"] or [],
+            "success_count": best["success_count"] or 0,
+            "fail_count": best["fail_count"] or 0,
+        }
+
+    def save_extracted_procedure(self, user_id: str, name: str, trigger_condition: str = None,
+                                 steps: list = None, entity_names: list = None,
+                                 metadata: dict = None, expires_at: str = None,
+                                 sub_user_id: str = "default") -> tuple:
+        """Save a freshly extracted v1 procedure without minting a near-duplicate.
+
+        Returns (procedure_id, action) where action is one of:
+          "created"   — no near-duplicate; saved as usual (exact-name conflicts
+                        still take the ON CONFLICT path inside save_procedure).
+          "refreshed" — a near-duplicate exists but has never been run; its
+                        steps, trigger and entities are updated in place under
+                        its existing name. Nothing was ever learned about it,
+                        so the newer extraction is the better description.
+          "kept"      — a near-duplicate exists and has a record. It is left
+                        exactly as it is: an extraction is a description, not
+                        a run, and must not overwrite evidence.
+        """
+        dup = self.find_near_duplicate_procedure(user_id, name, steps or [], sub_user_id=sub_user_id)
+        if dup is None:
+            proc_id = self.save_procedure(
+                user_id=user_id, name=name, trigger_condition=trigger_condition,
+                steps=steps, entity_names=entity_names, metadata=metadata,
+                expires_at=expires_at, sub_user_id=sub_user_id,
+            )
+            return proc_id, "created"
+
+        if dup["success_count"] + dup["fail_count"] > 0:
+            logger.info(f"⚙️ Procedure kept: '{name}' is '{dup['name']}' "
+                        f"({dup['success_count']}✓/{dup['fail_count']}✗) — not overwritten")
+            return dup["id"], "kept"
+
+        with self._cursor() as cur:
+            cur.execute(
+                """UPDATE procedures
+                   SET steps = %s::jsonb,
+                       trigger_condition = COALESCE(%s, trigger_condition),
+                       entity_names = CASE WHEN %s::text[] IS NULL OR cardinality(%s::text[]) = 0
+                                           THEN entity_names ELSE %s::text[] END,
+                       updated_at = NOW()
+                   WHERE id = %s AND user_id = %s AND sub_user_id = %s""",
+                (json.dumps(steps or []), trigger_condition,
+                 entity_names, entity_names, entity_names,
+                 dup["id"], user_id, sub_user_id)
+            )
+        logger.info(f"⚙️ Procedure refreshed: '{name}' → '{dup['name']}' (untested, updated in place)")
+        return dup["id"], "refreshed"
 
     def save_procedure_embedding(self, procedure_id: str, chunk_text: str, embedding: list[float]):
         """Save embedding for a procedure. Routes by vector size."""

--- a/tests/test_procedure_dedup.py
+++ b/tests/test_procedure_dedup.py
@@ -1,0 +1,146 @@
+"""Write-time dedup of extracted procedures.
+
+Extraction names the same workflow a little differently on every run, and the
+unique constraint only catches an exact name. One user reached 450 current
+procedures that way, with near-duplicates competing in every search faster
+than the curator (which sees 50 at a time) could merge them.
+
+Hermetic: CloudStore without __init__ and a stub cursor, as in
+test_upsert_lifecycle.py.
+"""
+
+import contextlib
+
+from cloud.store import (
+    CloudStore, procedure_similarity, is_near_duplicate_procedure,
+    _proc_name_tokens,
+)
+
+
+class _FakeCursor:
+    def __init__(self, fetchall_results=None, fetchone_results=None):
+        self._alls = list(fetchall_results or [])
+        self._ones = list(fetchone_results or [])
+        self.sql = []
+        self.params = []
+
+    def execute(self, sql, params=None):
+        self.sql.append(" ".join(sql.split()))
+        self.params.append(params)
+
+    def fetchall(self):
+        return self._alls.pop(0) if self._alls else []
+
+    def fetchone(self):
+        return self._ones.pop(0) if self._ones else None
+
+
+def _store(cursor):
+    store = CloudStore.__new__(CloudStore)
+
+    @contextlib.contextmanager
+    def _cursor(dict_cursor=False):
+        yield cursor
+
+    store._cursor = _cursor
+    return store
+
+
+STEPS = [{"action": "push to main"}, {"action": "watch the boot log"},
+         {"action": "verify /health", "detail": "expect 200"}]
+
+
+def _row(name, s=0, f=0, steps=STEPS, id="p-existing"):
+    return {"id": id, "name": name, "steps": steps, "success_count": s, "fail_count": f}
+
+
+# --- the similarity itself --------------------------------------------------
+
+def test_tokens_drop_glue_and_stem():
+    assert _proc_name_tokens("Deploying the backend to Railway") == {"deploy", "backend", "railway"}
+    assert _proc_name_tokens("deploys") == _proc_name_tokens("deployed") == {"deploy"}
+
+
+def test_renamed_same_workflow_is_a_duplicate():
+    for other in ("Deploying to Railway", "Railway deploy", "deploy to railway (v2)"):
+        n, st = procedure_similarity("Deploy to Railway", STEPS, other, STEPS)
+        assert is_near_duplicate_procedure(n, st), other
+
+
+def test_similar_name_different_steps_is_not():
+    docs_steps = [{"action": "build the docs"}, {"action": "upload to S3"}]
+    n, st = procedure_similarity("Deploy backend", STEPS, "Deploy docs", docs_steps)
+    assert not is_near_duplicate_procedure(n, st)
+
+
+def test_similar_name_same_steps_is():
+    n, st = procedure_similarity("Deploy backend service", STEPS, "Deploy backend", STEPS)
+    assert is_near_duplicate_procedure(n, st)
+
+
+def test_unrelated_workflows_are_not():
+    n, st = procedure_similarity("Rotate API keys", [{"action": "open dashboard"}],
+                                 "Deploy to Railway", STEPS)
+    assert not is_near_duplicate_procedure(n, st)
+
+
+# --- the store method ---------------------------------------------------------
+
+def test_no_candidates_creates_as_before():
+    cur = _FakeCursor(fetchall_results=[[]])
+    store = _store(cur)
+    store.save_procedure = lambda **kw: "p-new"
+    assert store.save_extracted_procedure("u", "Deploy to Railway", steps=STEPS) == ("p-new", "created")
+
+
+def test_exact_name_is_left_to_the_unique_constraint():
+    # Same name → not a near-duplicate; save_procedure's ON CONFLICT handles it.
+    cur = _FakeCursor(fetchall_results=[[_row("deploy to railway", s=5)]])
+    store = _store(cur)
+    store.save_procedure = lambda **kw: "p-existing"
+    assert store.save_extracted_procedure("u", "Deploy to Railway", steps=STEPS) == ("p-existing", "created")
+
+
+def test_proven_duplicate_is_kept_untouched():
+    cur = _FakeCursor(fetchall_results=[[_row("Deploy to Railway", s=11, f=1)]])
+    store = _store(cur)
+    store.save_procedure = lambda **kw: (_ for _ in ()).throw(AssertionError("must not insert"))
+    pid, action = store.save_extracted_procedure("u", "Deploying to Railway", steps=STEPS)
+    assert (pid, action) == ("p-existing", "kept")
+    assert not any("UPDATE procedures" in q for q in cur.sql)
+
+
+def test_untested_duplicate_is_refreshed_in_place():
+    cur = _FakeCursor(fetchall_results=[[_row("Deploy to Railway")]])
+    store = _store(cur)
+    store.save_procedure = lambda **kw: (_ for _ in ()).throw(AssertionError("must not insert"))
+    new_steps = STEPS + [{"action": "check the pool"}]
+    pid, action = store.save_extracted_procedure(
+        "u", "Deploying to Railway", trigger_condition="after merge",
+        steps=new_steps, entity_names=["Railway"])
+    assert (pid, action) == ("p-existing", "refreshed")
+    upd = [q for q in cur.sql if "UPDATE procedures" in q]
+    assert len(upd) == 1
+    assert "SET steps = %s::jsonb" in upd[0]
+    assert "COALESCE(%s, trigger_condition)" in upd[0]
+    assert "WHERE id = %s AND user_id = %s AND sub_user_id = %s" in upd[0]
+    params = cur.params[-1]
+    assert params[-3:] == ("p-existing", "u", "default")
+
+
+def test_best_candidate_wins_when_several_match():
+    rows = [_row("Deploy backend", steps=STEPS, id="weaker"),
+            _row("Deploying to Railway", steps=STEPS, id="closer")]
+    cur = _FakeCursor(fetchall_results=[rows])
+    store = _store(cur)
+    dup = store.find_near_duplicate_procedure("u", "Deploy to Railway", STEPS)
+    assert dup["id"] == "closer"
+
+
+def test_candidates_are_scoped_to_user_and_current():
+    cur = _FakeCursor(fetchall_results=[[]])
+    store = _store(cur)
+    store.find_near_duplicate_procedure("u", "x", STEPS, sub_user_id="s")
+    (q,) = cur.sql
+    assert "WHERE user_id = %s AND sub_user_id = %s AND is_current = TRUE" in q
+    assert cur.params[0] == ("u", "s")


### PR DESCRIPTION
Extraction names the same workflow a little differently each run, and the unique constraint only catches an exact (case-insensitive) name. One user reached 450 current procedures that way — "Deploy to Railway", "Deploying to Railway", "Railway deploy" — competing in every search, faster than the curator (50 at a time) could merge them.

**Change.** `store.save_extracted_procedure()` compares a freshly extracted workflow against the user's current procedures using normalised name tokens (lowercase, stopwords dropped, crude suffix stripping) and step tokens. Near-duplicate = name overlap ≥ 0.8, or ≥ 0.5 with step overlap ≥ 0.5.

- **created** — no near-duplicate; `save_procedure` as before (exact-name conflicts still take its ON CONFLICT path).
- **refreshed** — the existing one has never been run: steps/trigger/entities updated in place under its existing name.
- **kept** — the existing one has a record: left untouched, and not re-embedded. An extraction is a description, not a run, and must not overwrite evidence.

The add/reflection path in `api.py` now goes through it. `evolve_procedure` and the curator are unchanged. No schema change, no LLM call, one SELECT per extracted procedure (capped at 2000 rows).

Tests: 11 new (hermetic, stub cursor), full suite 303 passed.

Not done here: merging the near-duplicates that already exist in prod. That is a one-off read-first job and needs its own approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt