### PR TITLE
Export why a workflow last failed, and show it in the policy gate's plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   different name and the existing one has never been run, the existing one
   is refreshed in place; if the existing one has a record, it is kept
   untouched. One user had reached 450 current procedures this way.
+- Markdown export writes `last_failure` / `last_failed` on a procedure (memfmt
+  0.5): the violated assumption recorded by the most recent failure revision,
+  and its date. The counts say how often a workflow fails; this says what to
+  look at first. The policy gate shows it in the plan it hands Claude.
 - `/v1/procedures/search` results now carry `reliability` and `last_used`
   for both vector and text search (previously only text search had
   `reliability`; neither had `last_used`).

--- a/cloud/markdown_export.py
+++ b/cloud/markdown_export.py
@@ -190,6 +190,21 @@ def episode_file(episode: dict) -> str:
 from cloud.reliability import estimate as _reliability_estimate, prior_from_lineage as _prior
 
 
+def _last_failure(evolution: list = None) -> tuple:
+    """(why, when) of the most recent failure that changed this procedure.
+
+    A failure revision records the assumption that turned out false; that is
+    the one line an agent should read before running the workflow again. The
+    counts say how often it fails, this says what to look at first. Nothing is
+    invented: a revision without a recorded assumption contributes nothing.
+    """
+    for entry in reversed(evolution or []):
+        why = " ".join(str((entry.get("diff") or {}).get("violated_assumption") or "").split())
+        if why:
+            return why, _day(entry.get("created_at")) or None
+    return None, None
+
+
 def procedure_file(procedure: dict, evolution: list = None) -> str:
     """The differentiator, and the reason the export is worth having: a workflow
     with its track record and the failures that changed it."""
@@ -197,6 +212,7 @@ def procedure_file(procedure: dict, evolution: list = None) -> str:
     success = int(procedure.get("success_count") or 0)
     fail = int(procedure.get("fail_count") or 0)
     version = procedure.get("version") or 1
+    last_failure, last_failed = _last_failure(evolution)
 
     body = [
         frontmatter({
@@ -205,6 +221,8 @@ def procedure_file(procedure: dict, evolution: list = None) -> str:
             "version": version,
             "success_count": success,
             "fail_count": fail,
+            "last_failure": last_failure,
+            "last_failed": last_failed,
         }),
         "",
         f"# {name} (v{version} · {_reliability_estimate(success, fail, _prior(evolution))})",
@@ -216,6 +234,12 @@ def procedure_file(procedure: dict, evolution: list = None) -> str:
     preconditions = [p for p in ((procedure.get("metadata") or {}).get("preconditions") or []) if p]
     if preconditions:
         body += ["", "**Preconditions**", ""] + [f"- {p}" for p in preconditions]
+
+    # Rendered from the frontmatter for the reader, as memfmt 0.5 does; the
+    # parser on the other side never reads this line.
+    if last_failure:
+        when = f"{last_failed}: " if last_failed else ""
+        body += ["", f"**Last failure** — {when}{last_failure}"]
 
     steps = procedure.get("steps") or []
     if steps:

--- a/cloud/policy.py
+++ b/cloud/policy.py
@@ -164,6 +164,9 @@ def _plan(proc: dict, label: str) -> str:
     pre = (proc.get("metadata") or {}).get("preconditions") or proc.get("preconditions")
     if pre:
         lines.append("Preconditions: " + "; ".join(str(p) for p in (pre if isinstance(pre, list) else [pre])))
+    if proc.get("last_failure"):
+        when = f"{proc['last_failed']}: " if proc.get("last_failed") else ""
+        lines.append(f"Last failure: {when}{proc['last_failure']}")
     lines.append("The evidence for this workflow is weak, so the user was asked to confirm. "
                  "If they decline, show them the plan and what you would verify first.")
     return "\n".join(lines)
@@ -206,9 +209,11 @@ def memfmt_procedures(root: str) -> list[dict]:
     """
     try:
         import memfmt  # type: ignore
-    except ImportError:
+        memory = memfmt.load(root)
+    except Exception:
+        # Not installed, a namespace package shadowing it, or a folder that
+        # is not a memory: local mode is off, and the hook stays silent.
         return []
-    memory = memfmt.load(root)
     out = []
     for p in memory.procedures:
         out.append({
@@ -218,6 +223,9 @@ def memfmt_procedures(root: str) -> list[dict]:
             "fail_count": p.fail_count,
             "trigger_condition": p.trigger,
             "preconditions": list(p.preconditions or []),
+            # memfmt 0.5 fields; absent on an older library, and then absent here.
+            "last_failure": getattr(p, "last_failure", None),
+            "last_failed": getattr(p, "last_failed", None),
             "steps": [
                 {"action": s.action, "detail": s.detail,
                  "success_count": s.success_count, "fail_count": s.fail_count}

--- a/tests/test_markdown_export.py
+++ b/tests/test_markdown_export.py
@@ -127,6 +127,26 @@ class TestProcedures:
         out = procedure_file({"name": "P", "metadata": {"preconditions": ["run migrations"]}})
         assert "**Preconditions**" in out and "- run migrations" in out
 
+    def test_last_failure_comes_from_the_latest_failure_revision(self):
+        """The counts say how often; the violated assumption says what to look
+        at first. It goes in the frontmatter (memfmt 0.5) and is rendered once."""
+        out = procedure_file({"name": "P", "version": 3, "fail_count": 2}, evolution=[
+            {"version_before": 1, "version_after": 2, "created_at": "2026-06-02T10:00:00",
+             "diff": {"reason": "old", "violated_assumption": "the token was still valid"}},
+            {"version_before": 2, "version_after": 3, "created_at": "2026-08-27T09:30:00",
+             "diff": {"reason": "new", "violated_assumption": "the migration had been applied"}},
+        ])
+        assert "last_failure: the migration had been applied" in out
+        assert "last_failed: 2026-08-27" in out
+        assert "**Last failure** — 2026-08-27: the migration had been applied" in out
+        assert "the token was still valid" not in out.split("---")[1]
+
+    def test_a_revision_without_an_assumption_contributes_no_failure(self):
+        out = procedure_file({"name": "P", "version": 2, "fail_count": 1}, evolution=[
+            {"version_before": 1, "version_after": 2, "created_at": "2026-06-02",
+             "diff": {"reason": "tightened a check"}}])
+        assert "last_failure" not in out and "Last failure" not in out
+
 
 class TestEpisodes:
     def test_filename_leads_with_the_date(self):

--- a/tests/test_policy_hook.py
+++ b/tests/test_policy_hook.py
@@ -107,6 +107,12 @@ def test_reliability_is_taken_from_the_record_when_present():
     assert policy.reliability_of({"success_count": 0, "fail_count": 0}) == "untested"
 
 
+def test_plan_carries_the_last_failure_when_known():
+    proc = _with((2, 3), last_failure="the pool was cold", last_failed="2026-07-30")
+    v = policy.decide(proc, "git push origin main")
+    assert "Last failure: 2026-07-30: the pool was cold" in v["plan"]
+
+
 def test_plan_carries_steps_and_preconditions():
     proc = _with((0, 0), metadata={"preconditions": ["migrations applied"]})
     v = policy.decide(proc, "git push origin main")
@@ -202,6 +208,8 @@ def test_cli_verbose_marker(monkeypatch, capsys):
 
 def test_cli_local_memfmt_folder(monkeypatch, capsys, tmp_path):
     memfmt = pytest.importorskip("memfmt")
+    if not hasattr(memfmt, "load"):
+        pytest.skip("memfmt is a namespace package here, not the library")
     (tmp_path / "procedures").mkdir()
     (tmp_path / "procedures" / "deploy.md").write_text(
         "---\nmemfmt_type: procedure\nversion: 2\nsuccess_count: 0\nfail_count: 0\n---\n\n"


### PR DESCRIPTION
memfmt 0.5.0 (alibaizhanov/memfmt@ff97ad6) adds two optional frontmatter fields to a procedure: `last_failure` (one line of why) and `last_failed` (when). The counts say how often a workflow fails; this says what to look at first. Asked for in the r/AI_Agents thread on the memfmt post.

Server side:
- `cloud/markdown_export.py`: the procedure file writes both fields from the most recent failure revision's `violated_assumption` and its date, and renders one `**Last failure**` line in the body (derived, never parsed). A revision without a recorded assumption contributes nothing — no reason is invented.
- `cloud/policy.py`: the plan the gate hands Claude includes "Last failure: …" when known; offline mode reads it from a memfmt folder (getattr, so an older library just lacks it). Local mode is now robust to a namespace package shadowing the library.
- Tests: 3 new, full suite 306 passed; hook suite verified in a venv with memfmt 0.5.0 (26 passed) and end to end against a folder carrying `last_failure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt