### PR TITLE
release 2.32.0: policy gate, procedure dedup, last_failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.32.0 — 2026-09-04
 
 ### Added
 - `mengram auto-policy` — a Claude Code PreToolUse hook (installed by

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.31.0"
+__version__ = "2.32.0"
 """Mengram — AI memory layer for apps."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.31.0"
+version = "2.32.0"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump 2.31.0 → 2.32.0. Everything merged after 2.31.0 was built: the policy gate (#101), write-time procedure dedup (#102), last_failure in the export and the gate's plan (#103), reliability/last_used on search results.

CHANGELOG's Unreleased section becomes 2.32.0. Wheel + sdist build, twine check passes, 306 tests pass.

After merge: tag v2.32.0, publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt