### PR TITLE
Local mode: memory in a folder — store, failure → revision, CLI, hooks, MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.33.0 — 2026-09-04
 
 ### Added
 - **Local mode — memory in a folder, no account.** `mengram local init|add|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Local mode — memory in a folder, no account.** `mengram local init|add|
+  search|procedures|feedback|stat|quarantine` on a memfmt tree you own; the
+  four Claude Code hooks and the policy gate run against it with
+  `--memory DIR` (or `MENGRAM_MEMORY_DIR`); `mengram server --memory DIR`
+  serves the connector's four tools plus `procedure_feedback` over stdio.
+  Same procedures-with-outcomes as the cloud: versions, per-step counts,
+  `last_failure`, write-time dedup of near-duplicate names, failure →
+  revision with the violated assumption, and the cross-procedure regression
+  gate (a fix that would break another workflow is quarantined to
+  `.mengram/quarantine.json`). Extraction and revision use the model you
+  configure (Anthropic, OpenAI, Ollama); everything else needs none.
+- `cloud/procedure_match.py`: the pure procedure helpers, shared by the cloud
+  store and the folder store.
+
+### Changed
+- `memfmt>=0.5,<0.6` is now a dependency.
+
 ## 2.32.0 — 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ No manual saves. No tool calls. Claude just knows what you worked on yesterday â
 
 Prefer CLI-managed hooks instead of the plugin? `pip install mengram-ai && mengram setup` does the same via `mengram hook install`.
 
+### No account? Keep the memory in a folder
+
+```bash
+pip install mengram-ai
+mengram local init ./memory --provider anthropic --api-key sk-ant-...   # or openai / ollama
+mengram hook install --memory ./memory                                   # the same four hooks, all local
+mengram server --memory ./memory                                         # MCP for Claude Desktop, Cursor, any client
+```
+
+The folder is the memory: a [memfmt](https://github.com/alibaizhanov/memfmt) tree of Markdown you own â€” git diffs it, Obsidian draws it, `memfmt validate` checks it. Same procedures-with-outcomes as the cloud: versions, success/fail counts per step, the policy gate, and the regression gate that quarantines a fix that would break another workflow. Only extraction and a failure revision need a model, and that one you bring. Nothing expires and nothing asks for a key. [Docs](https://docs.mengram.io/local-mode).
+
 ---
 
 ## Why Mengram?

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.32.0"
+__version__ = "2.33.0"
 """Mengram — AI memory layer for apps."""

--- a/api/local_mcp_server.py
+++ b/api/local_mcp_server.py
@@ -1,0 +1,235 @@
+"""MCP over stdio for a memory folder — no account, no server, no network.
+
+The same four tools the Claude connector exposes (remember, recall,
+context_for, list_procedures) plus procedure_feedback, because outcomes are
+the point of the format and an agent should be able to record one without
+leaving its tool call. `handle_tool` is a plain function so the surface can
+be tested without a transport; `create_server` wraps it for MCP.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from local.config import describe_model, llm_client
+from local.store import LocalStore
+
+TOOLS = [
+    {
+        "name": "remember",
+        "description": ("Save what matters from a conversation into the memory folder: facts about "
+                        "people, projects and tools, events with their outcome, and workflows. Needs "
+                        "the folder's configured model; says so if there is none."),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "text": {"type": "string", "description": "Text to remember (or use 'conversation')"},
+                "conversation": {
+                    "type": "array",
+                    "items": {"type": "object", "properties": {
+                        "role": {"type": "string"}, "content": {"type": "string"}},
+                        "required": ["role", "content"]},
+                    "description": "Messages to extract from",
+                },
+            },
+        },
+    },
+    {
+        "name": "recall",
+        "description": ("What the memory folder knows about a topic: facts, past events with their "
+                        "outcome, and learned workflows with their track record. Word overlap, no model."),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "What to recall"},
+                "limit": {"type": "integer", "default": 5},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "context_for",
+        "description": ("Context pack for a task: who the user is (profile) plus whatever in memory "
+                        "bears on the task. Call once at the start of a piece of work."),
+        "inputSchema": {
+            "type": "object",
+            "properties": {"task": {"type": "string", "description": "What you are about to do"}},
+            "required": ["task"],
+        },
+    },
+    {
+        "name": "list_procedures",
+        "description": ("Learned workflows with their record: version, success/fail counts, a "
+                        "reliability reading (untested / N% expected / N% reliable), per-step counts, "
+                        "preconditions and the last failure. Read the record before following one."),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Filter by words (optional)"},
+                "limit": {"type": "integer", "default": 10},
+            },
+        },
+    },
+    {
+        "name": "procedure_feedback",
+        "description": ("Record that a workflow was run and whether it worked. On failure, give the "
+                        "step that broke and what happened; with a model configured the workflow is "
+                        "revised (or the revision quarantined if it would break another workflow)."),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "success": {"type": "boolean"},
+                "failed_at_step": {"type": "integer", "description": "1-based step that failed"},
+                "context": {"type": "string", "description": "What happened (failures only)"},
+            },
+            "required": ["name", "success"],
+        },
+    },
+]
+
+
+def _procedures_markdown(procs: list) -> str:
+    if not procs:
+        return "No learned workflows yet."
+    lines = ["# Learned workflows", ""]
+    for p in procs:
+        lines.append(f"## {p['name']} (v{p['version']} · {p['reliability']}, "
+                     f"{p['success_count']}✓/{p['fail_count']}✗)")
+        if p.get("trigger_condition"):
+            lines.append(f"When: {p['trigger_condition']}")
+        for pre in p.get("preconditions") or []:
+            lines.append(f"- precondition: {pre}")
+        for i, s in enumerate(p["steps"], 1):
+            rec = f" ({s['success_count']}✓/{s['fail_count']}✗)" if "success_count" in s else ""
+            lines.append(f"{i}. {s['action']}" + (f" — {s['detail']}" if s.get("detail") else "") + rec)
+        if p.get("last_failure"):
+            when = f"{p['last_failed']}: " if p.get("last_failed") else ""
+            lines.append(f"Last failure: {when}{p['last_failure']}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def handle_tool(store: LocalStore, name: str, arguments: dict | None) -> str:
+    """One tool call → one text result. Never raises for a bad argument."""
+    args = arguments or {}
+    if name == "remember":
+        conversation = args.get("conversation") or args.get("text") or ""
+        if not conversation:
+            return "Nothing to remember: pass 'text' or 'conversation'."
+        client = llm_client(store.root)
+        if client is None:
+            return ("No model configured for this folder, so nothing was extracted. Set one: "
+                    "mengram local init --provider anthropic|openai|ollama (or export ANTHROPIC_API_KEY / OPENAI_API_KEY).")
+        stats = store.add(conversation, client)
+        procs = stats["procedures"]
+        return (f"Remembered: entities +{stats['entities_created']} (updated {stats['entities_updated']}), "
+                f"facts +{stats['facts_added']}, episodes +{stats['episodes_saved']}, workflows created "
+                f"{procs['created']} / refreshed {procs['refreshed']} / kept {procs['kept']}.")
+
+    if name == "recall":
+        query = (args.get("query") or "").strip()
+        if not query:
+            return "Nothing to recall: pass 'query'."
+        return store.recall(query, limit=int(args.get("limit") or 5)) or "Nothing relevant in memory."
+
+    if name == "context_for":
+        task = (args.get("task") or "").strip()
+        parts = []
+        profile = store.profile()
+        if profile:
+            parts.append("# Who this is for\n\n" + profile)
+        relevant = store.recall(task, limit=5) if task else ""
+        if relevant:
+            parts.append("# Relevant memory\n\n" + relevant)
+        return "\n\n".join(parts) or "Memory is empty."
+
+    if name == "list_procedures":
+        query = (args.get("query") or "").strip() or None
+        return _procedures_markdown(store.procedures(query=query, limit=int(args.get("limit") or 10)))
+
+    if name == "procedure_feedback":
+        pname = (args.get("name") or "").strip()
+        if not pname or "success" not in args:
+            return "Pass 'name' and 'success'."
+        success = bool(args["success"])
+        step = args.get("failed_at_step")
+        step = int(step) if step not in (None, "") else None
+        context = (args.get("context") or "").strip() or None
+        result = store.procedure_feedback(pname, success=success, failed_at_step=step,
+                                          reason=context if not success else None)
+        if "error" in result:
+            return f"{result['error']}: {pname}"
+        line = (f"Recorded: {result['name']} v{result['version']} is now "
+                f"{result['success_count']}✓/{result['fail_count']}✗ ({result['reliability']}).")
+        if success or not context:
+            return line
+        client = llm_client(store.root)
+        if client is None:
+            return line + " No model configured, so the workflow was not revised."
+        from local.evolve import evolve_on_failure
+        r = evolve_on_failure(store, pname, context, client, failed_at_step=step)
+        status = r.get("status")
+        if status == "promoted":
+            return line + (f" Revised to v{r['version']} ({r['reliability']}); violated assumption: "
+                           f"{r.get('violated_assumption')}.")
+        if status == "revised_in_place":
+            return line + f" Revised in place (it had never run); violated assumption: {r.get('violated_assumption')}."
+        if status == "quarantined":
+            names = ", ".join(x["dependent_name"] for x in r["regressions"])
+            return line + f" The revision was QUARANTINED: it would break {names}. Review: {r['quarantine']}."
+        if status == "no_change":
+            return line + f" No revision: {r.get('reason')}."
+        return line + f" Revision failed: {r.get('error')}."
+
+    return f"Unknown tool: {name}"
+
+
+def create_server(root: str | Path):
+    from mcp.server import Server
+    from mcp.types import TextContent, Tool
+
+    root = Path(root)
+    store = LocalStore(root)
+    instructions = (
+        "Mengram, local mode: the user's memory is a folder of Markdown they own, at "
+        f"{root.resolve()} ({store.stats()['entities']} entities, "
+        f"{store.stats()['procedures']} workflows; model: {describe_model(root)}).\n"
+        "Call recall (or context_for) before answering anything about the user's work. "
+        "Before following a learned workflow, read its record with list_procedures; after "
+        "running one, call procedure_feedback so the record moves. Call remember after a "
+        "conversation that taught you something durable."
+    )
+    server = Server("mengram-local", instructions=instructions)
+
+    @server.list_tools()
+    async def list_tools():
+        return [Tool(name=t["name"], description=t["description"], inputSchema=t["inputSchema"]) for t in TOOLS]
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict | None):
+        # Re-read the folder on every call: another process (a hook, the
+        # user's editor) may have changed it since the server started.
+        live = LocalStore(root)
+        try:
+            text = handle_tool(live, name, arguments)
+        except Exception as e:  # a folder problem must reach the agent as text, not as a dead server
+            text = f"Error: {e}"
+        return [TextContent(type="text", text=text)]
+
+    return server
+
+
+async def main(root: str | Path):
+    from mcp.server.stdio import stdio_server
+    server = create_server(root)
+    print(f"mengram local MCP server on {Path(root).resolve()}", file=sys.stderr)
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main(sys.argv[1] if len(sys.argv) > 1 else "memory"))

--- a/cli.py
+++ b/cli.py
@@ -196,6 +196,16 @@ cd "{home_dir}"
 
 def cmd_server(args):
     """Start MCP server"""
+    local_dir = _local_dir(args)
+    if local_dir:
+        # Local mode — the folder is the memory; no key, no network.
+        if not local_dir.is_dir():
+            print(f"❌ No memory folder at {local_dir} — run: mengram local init {local_dir}", file=sys.stderr)
+            sys.exit(1)
+        import asyncio
+        from api.local_mcp_server import main as local_mcp_main
+        asyncio.run(local_mcp_main(local_dir))
+        return
     if getattr(args, 'cloud', False):
         # Cloud mode — connect to cloud API. Credentials resolve env-first,
         # then ~/.mengram/config.json — same order as hooks (issue #41 class:
@@ -2118,6 +2128,7 @@ def main():
     p_server = sub.add_parser("server", help="Start MCP server")
     p_server.add_argument("--config", help="Config path (default: ~/.mengram/config.yaml)")
     p_server.add_argument("--cloud", action="store_true", help="Use cloud API instead of local vault")
+    p_server.add_argument("--memory", default=None, help="Local mode: serve a memory folder (no account)")
 
     # status
     sub.add_parser("status", help="Check setup status")

--- a/cli.py
+++ b/cli.py
@@ -376,13 +376,49 @@ def _is_quota_error(e: Exception) -> bool:
     return type(e).__name__ == "QuotaExceededError"
 
 
+def _local_dir(args):
+    """The memory folder when local mode is on (--memory or MENGRAM_MEMORY_DIR)."""
+    from local.config import memory_dir
+    return memory_dir(getattr(args, "memory", None))
+
+
+def _local_store(local_dir):
+    from local.store import LocalStore
+    return LocalStore(local_dir)
+
+
+def _local_auto_recall(args, EVENT, HOOK, local_dir, prompt):
+    context = _local_store(local_dir).recall(prompt, limit=3)
+    if not context:
+        _emit_hook_exit(EVENT, args, HOOK, "no memories found (local)")
+    _emit_hook_exit(EVENT, args, HOOK, "found memories (local)", context=context)
+
+
+def _local_auto_context(args, EVENT, HOOK, local_dir):
+    profile = _local_store(local_dir).profile()
+    if not profile:
+        _emit_hook_exit(EVENT, args, HOOK, "empty folder (local)")
+    context = f"[Mengram Memory — context loaded from {local_dir}]\n{profile}"
+    _emit_hook_exit(EVENT, args, HOOK, f"context loaded ({len(profile)} chars, local)", context=context)
+
+
+def _local_auto_save(args, EVENT, HOOK, local_dir, messages):
+    from local.config import llm_client
+    client = llm_client(local_dir)
+    if client is None:
+        _emit_hook_exit(EVENT, args, HOOK, "no model configured (local) — nothing saved")
+    _local_store(local_dir).add(messages, client)
+    _emit_hook_exit(EVENT, args, HOOK, "saved (local)")
+
+
 def cmd_auto_recall(args):
     """Hook handler — called by Claude Code on UserPromptSubmit. Searches Mengram for relevant context."""
     HOOK = "auto-recall"
     EVENT = "UserPromptSubmit"
     try:
-        api_key = _load_cloud_api_key()
-        if not api_key:
+        local_dir = _local_dir(args)
+        api_key = None if local_dir else _load_cloud_api_key()
+        if not local_dir and not api_key:
             _emit_hook_exit(EVENT, args, HOOK, "no API key")
 
         # Read hook input from stdin
@@ -400,6 +436,9 @@ def cmd_auto_recall(args):
         prompt_lower = prompt.strip().lower()
         if any(prompt_lower == p or prompt_lower.startswith(p + " ") for p in skip_prefixes):
             _emit_hook_exit(EVENT, args, HOOK, "skipped (short/command prompt)")
+
+        if local_dir:
+            _local_auto_recall(args, EVENT, HOOK, local_dir, prompt)
 
         from cloud.client import CloudMemory
         base_url = _load_cloud_base_url()
@@ -501,6 +540,9 @@ def cmd_auto_context(args):
     HOOK = "auto-context"
     EVENT = "SessionStart"
     try:
+        local_dir = _local_dir(args)
+        if local_dir:
+            _local_auto_context(args, EVENT, HOOK, local_dir)
         api_key = _load_cloud_api_key()
         if not api_key:
             _emit_hook_exit(EVENT, args, HOOK, "no API key")
@@ -541,8 +583,9 @@ def cmd_auto_save(args):
     HOOK = "auto-save"
     EVENT = "Stop"
     try:
-        api_key = _load_cloud_api_key()
-        if not api_key:
+        local_dir = _local_dir(args)
+        api_key = None if local_dir else _load_cloud_api_key()
+        if not local_dir and not api_key:
             _emit_hook_exit(EVENT, args, HOOK, "no API key")
 
         # Read hook input from stdin
@@ -623,6 +666,9 @@ def cmd_auto_save(args):
             messages.append({"role": "user", "content": user_message})
         messages.append({"role": "assistant", "content": last_msg})
 
+        if local_dir:
+            _local_auto_save(args, EVENT, HOOK, local_dir, messages)
+
         # Send to Mengram API
         from cloud.client import CloudMemory
         base_url = _load_cloud_base_url()
@@ -692,9 +738,9 @@ def cmd_auto_policy(args):
                 min_reliable = policy.DEFAULT_MIN_RELIABLE
 
         # Local memfmt folder first: no account, no network, no quota.
-        local_root = os.environ.get("MENGRAM_MEMORY_DIR", "").strip()
+        local_root = _local_dir(args)
         if local_root:
-            procs = policy.memfmt_procedures(local_root)
+            procs = policy.memfmt_procedures(str(local_root))
         else:
             api_key = _load_cloud_api_key()
             if not api_key:
@@ -1499,12 +1545,17 @@ def cmd_setup(args):
 
 
 def cmd_hook_install(args):
-    """Install Claude Code memory hooks (auto-save + auto-recall + session context)"""
+    """Install Claude Code memory hooks (auto-save + auto-recall + session context + policy gate)"""
+    local_dir = _local_dir(args)
     api_key = os.environ.get("MENGRAM_API_KEY", "")
-    if not api_key:
+    if not local_dir and not api_key:
         print("Set MENGRAM_API_KEY environment variable first", file=sys.stderr)
         print("Run 'mengram setup' to create an account and configure automatically", file=sys.stderr)
         print("Or get a key at: https://mengram.io/#signup", file=sys.stderr)
+        print("No account? Use a folder instead: mengram hook install --memory ./memory", file=sys.stderr)
+        sys.exit(1)
+    if local_dir and not local_dir.is_dir():
+        print(f"no memory folder at {local_dir} — run: mengram local init {local_dir}", file=sys.stderr)
         sys.exit(1)
 
     every = getattr(args, "every", 3) or 3
@@ -1520,6 +1571,14 @@ def cmd_hook_install(args):
         recall_cmd += f" --user-id {user_id}"
         context_cmd += f" --user-id {user_id}"
         policy_cmd += f" --user-id {user_id}"
+    if local_dir:
+        # Hooks run without the user's shell profile, so the folder travels
+        # in the command rather than in an env var that may not be there.
+        mem_arg = f' --memory "{local_dir.resolve()}"'
+        save_cmd += mem_arg
+        recall_cmd += mem_arg
+        context_cmd += mem_arg
+        policy_cmd += mem_arg
 
     # Read existing settings
     settings_path = get_claude_code_settings_path()
@@ -1568,7 +1627,7 @@ def cmd_hook_install(args):
     with open(settings_path, "w") as f:
         json.dump(settings, f, indent=2)
 
-    print("Mengram hooks installed:")
+    print("Mengram hooks installed" + (f" (local mode: {local_dir.resolve()})" if local_dir else "") + ":")
     print(f"  Auto-save:    every {every} response(s) (background)")
     print(f"  Auto-recall:  search memory on each prompt")
     print(f"  Session context: load profile on session start")
@@ -2136,6 +2195,8 @@ def main():
                                  help="Mengram user_id (default: 'default')")
     p_hook_install.add_argument("--no-policy", action="store_true", dest="no_policy",
                                  help="Skip the PreToolUse policy gate")
+    p_hook_install.add_argument("--memory", default=None,
+                                 help="Local mode: memory folder (no account needed)")
     hook_sub.add_parser("uninstall", help="Remove auto-save hook")
     hook_sub.add_parser("status", help="Check hook status")
 
@@ -2143,18 +2204,21 @@ def main():
     p_autosave = sub.add_parser("auto-save", help=argparse.SUPPRESS)
     p_autosave.add_argument("--every", type=int, default=3)
     p_autosave.add_argument("--user-id", default=None)
+    p_autosave.add_argument("--memory", default=None)
     p_autosave.add_argument("--verbose", action="store_true",
                              help="Emit a status marker for each hook invocation")
 
     # auto-recall (internal, called by Claude Code UserPromptSubmit hook)
     p_autorecall = sub.add_parser("auto-recall", help=argparse.SUPPRESS)
     p_autorecall.add_argument("--user-id", default=None)
+    p_autorecall.add_argument("--memory", default=None)
     p_autorecall.add_argument("--verbose", action="store_true",
                                help="Emit a status marker for each hook invocation")
 
     # auto-context (internal, called by Claude Code SessionStart hook)
     p_autocontext = sub.add_parser("auto-context", help=argparse.SUPPRESS)
     p_autocontext.add_argument("--user-id", default=None)
+    p_autocontext.add_argument("--memory", default=None)
     p_autocontext.add_argument("--verbose", action="store_true",
                                 help="Emit a status marker for each hook invocation")
     p_autocontext.add_argument("--no-weekly", action="store_true",
@@ -2163,10 +2227,15 @@ def main():
     # auto-policy (internal, called by Claude Code PreToolUse hook on Bash)
     p_autopolicy = sub.add_parser("auto-policy", help=argparse.SUPPRESS)
     p_autopolicy.add_argument("--user-id", default=None)
+    p_autopolicy.add_argument("--memory", default=None)
     p_autopolicy.add_argument("--verbose", action="store_true",
                                help="Emit a status marker for each hook invocation")
     p_autopolicy.add_argument("--min-reliable", type=int, default=None, dest="min_reliable",
                                help="Percent below which a workflow with a record is confirmed (default 70)")
+
+    # local — memory in a folder, no account
+    from local.cli import add_parser as _add_local_parser
+    _add_local_parser(sub)
 
     # web
     p_web = sub.add_parser("web", help="Start Web UI (chat + knowledge graph)")
@@ -2233,6 +2302,9 @@ def main():
         cmd_auto_context(args)
     elif args.command == "auto-policy":
         cmd_auto_policy(args)
+    elif args.command == "local":
+        from local.cli import run as _run_local
+        sys.exit(_run_local(args))
     elif args.command == "web":
         cmd_web(args)
     elif args.command == "weekly":

--- a/cloud/procedure_match.py
+++ b/cloud/procedure_match.py
@@ -1,0 +1,99 @@
+"""What makes two procedures the same workflow, and how a run is credited.
+
+Pure functions shared by the cloud store and the local folder store, kept
+out of `store.py` so that the local mode never has to import psycopg2 to
+decide whether "Deploying to Railway" is "Deploy to Railway".
+"""
+
+from __future__ import annotations
+
+import re
+
+_PROC_NAME_STOPWORDS = {
+    "the", "a", "an", "to", "for", "of", "in", "on", "at", "by", "with", "and",
+    "or", "via", "using", "use", "how", "into", "from", "up", "your", "my",
+    "our", "new", "process", "procedure", "workflow", "steps", "step", "routine",
+}
+
+
+def _proc_stem(word: str) -> str:
+    """Crude suffix stripping so 'deploying', 'deployed' and 'deploys' agree.
+
+    Not a stemmer. It only has to make the same workflow, named three ways by
+    three extraction runs, land on the same tokens; it does not have to be
+    right about English."""
+    for suffix in ("ing", "ed", "es", "s"):
+        if word.endswith(suffix) and len(word) - len(suffix) >= 3 and not word.endswith("ss"):
+            return word[: -len(suffix)]
+    return word
+
+
+def _proc_name_tokens(text: str) -> set:
+    words = re.findall(r"[a-z0-9]+", (text or "").lower())
+    return {_proc_stem(w) for w in words if w not in _PROC_NAME_STOPWORDS and len(w) > 1}
+
+
+def normalize_step(s) -> str:
+    """A step as text. Steps are dicts like {"action": ..., "detail": ...};
+    older rows and hand-written files may hold plain strings."""
+    if isinstance(s, str):
+        return s
+    if isinstance(s, dict):
+        return s.get("action", "") or s.get("step", "") or s.get("description", "") or str(s)
+    return str(s)
+
+
+def _proc_step_tokens(steps: list) -> set:
+    out = set()
+    for s in steps or []:
+        out |= _proc_name_tokens(normalize_step(s))
+    return out
+
+
+def _jaccard(a: set, b: set) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def procedure_similarity(name_a: str, steps_a: list, name_b: str, steps_b: list) -> tuple:
+    """(name overlap, step overlap), each 0..1."""
+    return (_jaccard(_proc_name_tokens(name_a), _proc_name_tokens(name_b)),
+            _jaccard(_proc_step_tokens(steps_a), _proc_step_tokens(steps_b)))
+
+
+def is_near_duplicate_procedure(name_sim: float, step_sim: float) -> bool:
+    """Same workflow under a slightly different name.
+
+    A near-identical name is enough on its own ("Deploy to Railway" vs
+    "Deploying to Railway"). A merely similar name needs the steps to agree
+    too, so "Deploy backend" and "Deploy docs" stay apart."""
+    return name_sim >= 0.8 or (name_sim >= 0.5 and step_sim >= 0.5)
+
+
+def apply_step_outcome(steps: list, success: bool, failed_at_step: int = None) -> list:
+    """Credit the steps that ran and debit the one that broke.
+
+    A run does not tell you one thing, it tells you as many things as there
+    are steps. When step 3 of 5 fails, steps 1 and 2 *ran and worked* —
+    recording only "the procedure failed" throws that away and makes every
+    step look equally suspect. Steps after the failure never executed, so
+    they learn nothing either way.
+    """
+    updated = []
+    for i, step in enumerate(steps or [], 1):
+        if not isinstance(step, dict):
+            updated.append(step)
+            continue
+        step = dict(step)
+        if success:
+            ran, worked = True, True
+        elif failed_at_step is None:
+            ran, worked = False, False      # nothing to attribute
+        else:
+            ran, worked = i <= failed_at_step, i < failed_at_step
+        if ran:
+            key = "success_count" if worked else "fail_count"
+            step[key] = int(step.get(key) or 0) + 1
+        updated.append(step)
+    return updated

--- a/cloud/store.py
+++ b/cloud/store.py
@@ -25,6 +25,9 @@ from typing import Optional
 from contextlib import contextmanager
 
 from cloud.reliability import annotate_steps, carry_step_history, estimate
+from cloud.procedure_match import (  # noqa: F401 — re-exported for callers and tests
+    _proc_name_tokens, procedure_similarity, is_near_duplicate_procedure, apply_step_outcome,
+)
 
 try:
     import psycopg2
@@ -67,57 +70,6 @@ def _normalize_step(s) -> str:
     if isinstance(s, dict):
         return s.get("action", "") or s.get("step", "") or s.get("description", "") or str(s)
     return str(s)
-
-_PROC_NAME_STOPWORDS = {
-    "the", "a", "an", "to", "for", "of", "in", "on", "at", "by", "with", "and",
-    "or", "via", "using", "use", "how", "into", "from", "up", "your", "my",
-    "our", "new", "process", "procedure", "workflow", "steps", "step", "routine",
-}
-
-
-def _proc_stem(word: str) -> str:
-    """Crude suffix stripping so 'deploying', 'deployed' and 'deploys' agree.
-
-    Not a stemmer. It only has to make the same workflow, named three ways by
-    three extraction runs, land on the same tokens; it does not have to be
-    right about English."""
-    for suffix in ("ing", "ed", "es", "s"):
-        if word.endswith(suffix) and len(word) - len(suffix) >= 3 and not word.endswith("ss"):
-            return word[: -len(suffix)]
-    return word
-
-
-def _proc_name_tokens(text: str) -> set:
-    words = re.findall(r"[a-z0-9]+", (text or "").lower())
-    return {_proc_stem(w) for w in words if w not in _PROC_NAME_STOPWORDS and len(w) > 1}
-
-
-def _proc_step_tokens(steps: list) -> set:
-    out = set()
-    for s in steps or []:
-        out |= _proc_name_tokens(_normalize_step(s))
-    return out
-
-
-def _jaccard(a: set, b: set) -> float:
-    if not a or not b:
-        return 0.0
-    return len(a & b) / len(a | b)
-
-
-def procedure_similarity(name_a: str, steps_a: list, name_b: str, steps_b: list) -> tuple:
-    """(name overlap, step overlap), each 0..1. Pure; used by the write-time dedup."""
-    return (_jaccard(_proc_name_tokens(name_a), _proc_name_tokens(name_b)),
-            _jaccard(_proc_step_tokens(steps_a), _proc_step_tokens(steps_b)))
-
-
-def is_near_duplicate_procedure(name_sim: float, step_sim: float) -> bool:
-    """Same workflow under a slightly different name.
-
-    A near-identical name is enough on its own ("Deploy to Railway" vs
-    "Deploying to Railway"). A merely similar name needs the steps to agree
-    too, so "Deploy backend" and "Deploy docs" stay apart."""
-    return name_sim >= 0.8 or (name_sim >= 0.5 and step_sim >= 0.5)
 
 
 
@@ -5879,35 +5831,9 @@ REFLECTIONS/PATTERNS:
 
     @staticmethod
     def _apply_step_outcome(steps: list, success: bool, failed_at_step: int = None) -> list:
-        """Credit the steps that ran and debit the one that broke.
-
-        A run does not tell you one thing, it tells you as many things as there
-        are steps. When step 3 of 5 fails, steps 1 and 2 *ran and worked* —
-        recording only "the procedure failed" throws that away and makes every
-        step look equally suspect. Steps after the failure never executed, so
-        they learn nothing either way.
-
-        This is also what keeps a record alive across versioning: a revision
-        usually touches one step, and the untouched ones have no reason to
-        forget the runs behind them.
-        """
-        updated = []
-        for i, step in enumerate(steps or [], 1):
-            if not isinstance(step, dict):
-                updated.append(step)
-                continue
-            step = dict(step)
-            if success:
-                ran, worked = True, True
-            elif failed_at_step is None:
-                ran, worked = False, False      # nothing to attribute
-            else:
-                ran, worked = i <= failed_at_step, i < failed_at_step
-            if ran:
-                key = "success_count" if worked else "fail_count"
-                step[key] = int(step.get(key) or 0) + 1
-            updated.append(step)
-        return updated
+        """Credit the steps that ran and debit the one that broke — see
+        cloud.procedure_match.apply_step_outcome, shared with the local store."""
+        return apply_step_outcome(steps, success, failed_at_step)
 
     def procedure_feedback(self, user_id: str, procedure_id: str, success: bool,
                            sub_user_id: str = "default", failed_at_step: int = None) -> dict:

--- a/local/__init__.py
+++ b/local/__init__.py
@@ -1,0 +1,10 @@
+"""Local mode — memory that lives in a folder.
+
+A memfmt tree is the memory: entities, episodes and procedures as Markdown
+you own, with the same procedures-with-outcomes the cloud keeps. No account,
+no server; only extraction needs a model, and that one you bring.
+"""
+
+from .store import LocalStore
+
+__all__ = ["LocalStore"]

--- a/local/cli.py
+++ b/local/cli.py
@@ -1,0 +1,251 @@
+"""`mengram local …` — the folder from the command line.
+
+Kept out of cli.py so the top-level file does not grow another thousand
+lines. cli.py registers `add_parser` and dispatches to `run`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .config import (config_path, describe_model, llm_client, memory_dir, read_config,
+                     write_config)
+from .store import LocalStore
+
+
+def _root(args) -> Path:
+    root = memory_dir(getattr(args, "memory", None))
+    if root is None:
+        root = Path("memory")
+    return root
+
+
+def _open(args) -> LocalStore:
+    root = _root(args)
+    if not root.is_dir():
+        print(f"no memory folder at {root} — run: mengram local init {root}", file=sys.stderr)
+        sys.exit(1)
+    return LocalStore(root)
+
+
+def cmd_init(args) -> int:
+    root = Path(args.dir).expanduser() if args.dir else _root(args)
+    root.mkdir(parents=True, exist_ok=True)
+    cfg = read_config(root)
+    provider = (args.provider or "").strip().lower()
+    if provider:
+        llm = {"provider": provider}
+        if provider in ("anthropic", "openai"):
+            block = {}
+            if args.api_key:
+                block["api_key"] = args.api_key
+            if args.model:
+                block["model"] = args.model
+            if not block.get("api_key"):
+                print(f"note: no --api-key given; {provider.upper()}_API_KEY from the environment "
+                      "will be used at run time", file=sys.stderr)
+            llm[provider] = block
+        elif provider == "ollama":
+            llm["ollama"] = {"model": args.model or "llama3.1:8b"}
+            if args.base_url:
+                llm["ollama"]["base_url"] = args.base_url
+        elif provider == "mock":
+            pass
+        else:
+            print(f"unknown provider: {provider} (anthropic | openai | ollama)", file=sys.stderr)
+            return 1
+        cfg["llm"] = llm
+    write_config(root, cfg)
+    store = LocalStore(root)
+    store.save()
+    print(f"memory folder: {root.resolve()}")
+    print(f"model: {describe_model(root)}")
+    print(f"config: {config_path(root)}")
+    print("")
+    print("next:")
+    print(f"  export MENGRAM_MEMORY_DIR={root.resolve()}")
+    print("  mengram local add \"I deploy to Railway from main; last time the pool was cold\"")
+    print("  mengram local search \"railway\"")
+    print("  mengram hook install        # Claude Code hooks, all local")
+    return 0
+
+
+def cmd_add(args) -> int:
+    store = _open(args)
+    text = sys.stdin.read() if args.stdin else " ".join(args.text or [])
+    if not text.strip():
+        print("nothing to add (pass text, or --stdin)", file=sys.stderr)
+        return 1
+    client = llm_client(store.root)
+    if client is None:
+        print("no model configured — extraction needs one.\n"
+              "  mengram local init --provider anthropic --api-key sk-ant-...   (or openai / ollama)\n"
+              "  or export ANTHROPIC_API_KEY / OPENAI_API_KEY", file=sys.stderr)
+        return 2
+    try:
+        conversation = json.loads(text) if text.lstrip().startswith("[") else text
+    except json.JSONDecodeError:
+        conversation = text
+    stats = store.add(conversation, client)
+    procs = stats["procedures"]
+    print(f"entities +{stats['entities_created']} (updated {stats['entities_updated']}), "
+          f"facts +{stats['facts_added']}, episodes +{stats['episodes_saved']}, "
+          f"procedures created {procs['created']} / refreshed {procs['refreshed']} / kept {procs['kept']}")
+    return 0
+
+
+def cmd_search(args) -> int:
+    store = _open(args)
+    hits = store.search(" ".join(args.query), limit=args.limit)
+    if not hits:
+        print("nothing relevant")
+        return 1
+    for h in hits:
+        if h["type"] == "entity":
+            print(f"{h['entity']}" + (f" ({h['entity_type']})" if h.get("entity_type") else ""))
+            for f in h["facts"][:5]:
+                print(f"  - {f}")
+        elif h["type"] == "episode":
+            when = f"{h['happened']}: " if h.get("happened") else ""
+            print(f"episode {when}{h['summary']}" + (f" → {h['outcome']}" if h.get("outcome") else ""))
+        else:
+            print(f"workflow {h['name']} (v{h['version']}, {h['reliability']})")
+    return 0
+
+
+def cmd_procedures(args) -> int:
+    store = _open(args)
+    procs = store.procedures(query=" ".join(args.query) if args.query else None, limit=args.limit)
+    if not procs:
+        print("no procedures yet")
+        return 1
+    for p in procs:
+        print(f"{p['name']}  v{p['version']}  {p['success_count']}✓/{p['fail_count']}✗  {p['reliability']}")
+        if p.get("trigger_condition"):
+            print(f"  when: {p['trigger_condition']}")
+        for i, s in enumerate(p["steps"], 1):
+            rec = f"  ({s['success_count']}✓/{s['fail_count']}✗)" if "success_count" in s else ""
+            print(f"  {i}. {s['action']}" + (f" — {s['detail']}" if s.get("detail") else "") + rec)
+        if p.get("last_failure"):
+            when = f"{p['last_failed']}: " if p.get("last_failed") else ""
+            print(f"  last failure: {when}{p['last_failure']}")
+    return 0
+
+
+def cmd_feedback(args) -> int:
+    store = _open(args)
+    success = bool(args.success)
+    result = store.procedure_feedback(args.name, success=success, failed_at_step=args.step,
+                                      reason=args.context if not success else None)
+    if "error" in result:
+        print(result["error"], file=sys.stderr)
+        return 1
+    print(f"{result['name']}  v{result['version']}  {result['success_count']}✓/{result['fail_count']}✗  "
+          f"{result['reliability']}")
+    if success or not args.context:
+        return 0
+    client = llm_client(store.root)
+    if client is None:
+        print("failure recorded; no model configured, so the workflow was not revised "
+              "(set one to let a failure produce a new version)", file=sys.stderr)
+        return 0
+    from .evolve import evolve_on_failure
+    r = evolve_on_failure(store, args.name, args.context, client, failed_at_step=args.step)
+    status = r.get("status")
+    if status == "promoted":
+        print(f"revised → v{r['version']} ({r['reliability']}); violated assumption: {r.get('violated_assumption')}")
+    elif status == "revised_in_place":
+        print(f"revised in place (v{r['version']} had never run); violated assumption: {r.get('violated_assumption')}")
+    elif status == "quarantined":
+        names = ", ".join(x["dependent_name"] for x in r["regressions"])
+        print(f"revision QUARANTINED — it would break: {names}. See {r['quarantine']}")
+    elif status == "no_change":
+        print(f"no revision: {r.get('reason')}")
+    else:
+        print(f"revision failed: {r.get('error')}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def cmd_stat(args) -> int:
+    store = _open(args)
+    s = store.stats()
+    print(f"{s['entities']} entities ({s['facts']} facts), {s['episodes']} episodes, "
+          f"{s['procedures']} procedures ({s['procedures_with_record']} with a record)")
+    print(f"model: {describe_model(store.root)}")
+    from .evolve import read_quarantine
+    q = read_quarantine(store)
+    if q:
+        print(f"{len(q)} quarantined revision(s) waiting for review — mengram local quarantine")
+    return 0
+
+
+def cmd_quarantine(args) -> int:
+    store = _open(args)
+    from .evolve import read_quarantine
+    q = read_quarantine(store)
+    if not q:
+        print("nothing quarantined")
+        return 0
+    for i, e in enumerate(q, 1):
+        names = ", ".join(r["dependent_name"] for r in e.get("regressions", []))
+        print(f"{i}. {e['procedure']} v{e['version']} ({e['date']}): {e['reason']}")
+        print(f"   would break: {names}")
+        if e.get("violated_assumption"):
+            print(f"   violated assumption: {e['violated_assumption']}")
+        for j, s in enumerate(e.get("proposed_steps", []), 1):
+            print(f"   {j}. {s['action']}" + (f" — {s['detail']}" if s.get("detail") else ""))
+    return 0
+
+
+def add_parser(sub) -> None:
+    p = sub.add_parser("local", help="Memory in a folder you own — no account, no server")
+    lsub = p.add_subparsers(dest="local_action", required=True)
+
+    def common(sp):
+        sp.add_argument("--memory", default=None, help="memory folder (default: $MENGRAM_MEMORY_DIR or ./memory)")
+
+    sp = lsub.add_parser("init", help="create a memory folder and choose a model")
+    sp.add_argument("dir", nargs="?", default=None)
+    sp.add_argument("--provider", default=None, help="anthropic | openai | ollama")
+    sp.add_argument("--api-key", default=None, dest="api_key")
+    sp.add_argument("--model", default=None)
+    sp.add_argument("--base-url", default=None, dest="base_url", help="Ollama URL")
+    common(sp); sp.set_defaults(local_func=cmd_init)
+
+    sp = lsub.add_parser("add", help="extract from text (or a JSON conversation) with your model")
+    sp.add_argument("text", nargs="*")
+    sp.add_argument("--stdin", action="store_true")
+    common(sp); sp.set_defaults(local_func=cmd_add)
+
+    sp = lsub.add_parser("search", help="facts, events and workflows that match")
+    sp.add_argument("query", nargs="+")
+    sp.add_argument("--limit", type=int, default=5)
+    common(sp); sp.set_defaults(local_func=cmd_search)
+
+    sp = lsub.add_parser("procedures", help="learned workflows with their record")
+    sp.add_argument("query", nargs="*")
+    sp.add_argument("--limit", type=int, default=20)
+    common(sp); sp.set_defaults(local_func=cmd_procedures)
+
+    sp = lsub.add_parser("feedback", help="record a run of a workflow")
+    sp.add_argument("name")
+    g = sp.add_mutually_exclusive_group(required=True)
+    g.add_argument("--success", action="store_true")
+    g.add_argument("--failure", action="store_true")
+    sp.add_argument("--step", type=int, default=None, help="1-based step that failed")
+    sp.add_argument("--context", default=None, help="what happened; with --failure, asks your model to revise")
+    common(sp); sp.set_defaults(local_func=cmd_feedback)
+
+    sp = lsub.add_parser("stat", help="what is in the folder")
+    common(sp); sp.set_defaults(local_func=cmd_stat)
+
+    sp = lsub.add_parser("quarantine", help="revisions the regression gate refused")
+    common(sp); sp.set_defaults(local_func=cmd_quarantine)
+
+
+def run(args) -> int:
+    return int(args.local_func(args) or 0)

--- a/local/config.py
+++ b/local/config.py
@@ -1,0 +1,83 @@
+"""Where the folder is, and which model to use.
+
+Two questions, answered in this order:
+
+- the folder: `--memory DIR` on the command, else `MENGRAM_MEMORY_DIR`;
+- the model: `DIR/.mengram/config.json` → `{"llm": {...}}`, else whichever
+  of ANTHROPIC_API_KEY / OPENAI_API_KEY is set, else Ollama if reachable is
+  *not* assumed — the user says so in the config.
+
+No model is a normal state. Search, recall, the policy gate and feedback
+work without one; only `add` and a failure revision need it, and they say so.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+CONFIG_REL = Path(".mengram") / "config.json"
+
+
+def memory_dir(explicit: str | None = None) -> Path | None:
+    """The memory folder for local mode, or None when local mode is off."""
+    raw = explicit or os.environ.get("MENGRAM_MEMORY_DIR", "").strip()
+    return Path(raw).expanduser() if raw else None
+
+
+def config_path(root: Path) -> Path:
+    return Path(root) / CONFIG_REL
+
+
+def read_config(root: Path) -> dict:
+    path = config_path(root)
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8")) or {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def write_config(root: Path, config: dict) -> Path:
+    path = config_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return path
+
+
+def llm_config(root: Path) -> dict | None:
+    """The `llm` block to hand `create_llm_client`, or None with no model."""
+    cfg = read_config(root).get("llm") or {}
+    provider = (cfg.get("provider") or "").strip().lower()
+    if provider:
+        return cfg
+    key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if key:
+        return {"provider": "anthropic", "anthropic": {"api_key": key}}
+    key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if key:
+        return {"provider": "openai", "openai": {"api_key": key}}
+    return None
+
+
+def llm_client(root: Path):
+    """A client for the user's model, or None. Never raises for "no model"."""
+    cfg = llm_config(root)
+    if not cfg:
+        return None
+    if cfg.get("provider") == "mock":
+        from engine.extractor.conversation_extractor import MockLLMClient
+        return MockLLMClient()
+    from engine.extractor.llm_client import create_llm_client
+    return create_llm_client(cfg)
+
+
+def describe_model(root: Path) -> str:
+    cfg = llm_config(root)
+    if not cfg:
+        return "no model configured"
+    provider = cfg.get("provider", "?")
+    model = (cfg.get(provider) or {}).get("model")
+    return f"{provider}" + (f" / {model}" if model else "")

--- a/local/evolve.py
+++ b/local/evolve.py
@@ -1,0 +1,169 @@
+"""Failure → revision, on files.
+
+A workflow that failed is not just a workflow with a worse record. Somewhere a
+belief turned out false, and the next version has to carry both the fix and
+the belief, or the same failure comes back with a different step number. This
+is the cloud's failure loop (`cloud/evolution.py`) applied to a memfmt folder:
+same prompt, same regression gate, same rule that a version nobody has ever
+run is revised in place rather than minted again.
+
+What is different from the cloud is only where the result goes: a promoted
+revision becomes the procedure file's next version, with the retiring record
+on the `Evolution` line and the violated assumption in `last_failure`; a
+revision the gate refuses goes to `.mengram/quarantine.json` for a human,
+never to the agent.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+from pathlib import Path
+
+from memfmt import Revision
+
+from cloud.evolution import EVOLVE_ON_FAILURE_PROMPT
+from cloud.regression_gate import find_regressions
+from cloud.reliability import carry_step_history
+
+from .store import LocalStore, _steps_as_dicts, _to_steps
+
+logger = logging.getLogger("mengram.local")
+
+QUARANTINE = Path(".mengram") / "quarantine.json"
+
+
+def _parse_json(text: str) -> dict | None:
+    text = (text or "").strip()
+    if text.startswith("```"):
+        text = "\n".join(line for line in text.split("\n") if not line.strip().startswith("```"))
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start, end = text.find("{"), text.rfind("}") + 1
+        if 0 <= start < end:
+            try:
+                return json.loads(text[start:end])
+            except json.JSONDecodeError:
+                pass
+    return None
+
+
+def _gate_shape(p, steps: list | None = None, trigger: str | None = None,
+                preconditions: list | None = None) -> dict:
+    """A procedure as the regression gate expects to see it."""
+    return {
+        "id": p.id or p.name,
+        "name": p.name,
+        "entity_names": list(p.extra.get("entities") or []),
+        "steps": _steps_as_dicts(steps if steps is not None else p.steps),
+        "trigger_condition": trigger if trigger is not None else p.trigger,
+        "metadata": {"preconditions": list(preconditions if preconditions is not None else p.preconditions)},
+    }
+
+
+def quarantine_path(store: LocalStore) -> Path:
+    return store.root / QUARANTINE
+
+
+def read_quarantine(store: LocalStore) -> list:
+    path = quarantine_path(store)
+    if not path.exists():
+        return []
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def evolve_on_failure(store: LocalStore, name: str, context: str, llm_client,
+                      failed_at_step: int | None = None) -> dict:
+    """Ask the model what belief broke, then promote or quarantine the fix.
+
+    Returns {"status": "promoted" | "revised_in_place" | "quarantined" |
+    "no_change" | "error", ...}. Writes the tree (or the quarantine file).
+    """
+    p = store._procedure(name)
+    if p is None:
+        return {"status": "error", "error": "procedure not found", "name": name}
+
+    steps_text = "\n".join(
+        f"{i}. {s.action}" + (f" — {s.detail}" if s.detail else "")
+        for i, s in enumerate(p.steps, 1)) or "(no steps)"
+    prompt = EVOLVE_ON_FAILURE_PROMPT.format(
+        procedure_name=p.name, trigger_condition=p.trigger or "N/A", steps_text=steps_text,
+        episode_summary=f"Procedure '{p.name}' failed",
+        episode_context=context or "N/A", episode_outcome="failure",
+        failed_at_step=failed_at_step or "unknown",
+    )
+    try:
+        result = _parse_json(llm_client.complete(prompt))
+    except Exception as e:  # the model is the user's; its failures are not ours to hide
+        return {"status": "error", "error": str(e), "name": p.name}
+    if not result or not result.get("new_steps"):
+        return {"status": "no_change", "name": p.name, "reason": "model returned no steps"}
+
+    new_steps = [s for s in result["new_steps"] if isinstance(s, dict)]
+    new_trigger = result.get("new_trigger") or None
+    if isinstance(new_trigger, str) and new_trigger.strip().lower() in ("", "null", "none"):
+        new_trigger = None
+    assumption = " ".join(str(result.get("violated_assumption") or "").split())
+    precondition = " ".join(str(result.get("precondition_check") or "").split())
+    reason = " ".join(str(result.get("change_description") or result.get("change_type") or "revised").split())
+
+    preconditions = list(p.preconditions)
+    if precondition and precondition not in preconditions:
+        preconditions = (preconditions + [precondition])[-10:]
+
+    # --- the gate: does this fix silently break a neighbour? ---------------
+    old_shape = _gate_shape(p)
+    new_shape = _gate_shape(p, steps=new_steps, trigger=new_trigger or p.trigger, preconditions=preconditions)
+    candidates = [_gate_shape(q) for q in store.memory.procedures if q is not p]
+    regressions = find_regressions(old_shape, new_shape, candidates)
+    if regressions:
+        entry = {
+            "procedure": p.name, "version": p.version, "date": _dt.date.today().isoformat(),
+            "reason": reason, "violated_assumption": assumption or None,
+            "precondition_check": precondition or None,
+            "proposed_steps": [{"action": s.get("action"), "detail": s.get("detail")} for s in new_steps],
+            "proposed_trigger": new_trigger, "regressions": regressions,
+        }
+        path = quarantine_path(store)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existing = read_quarantine(store)
+        existing.append(entry)
+        path.write_text(json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8")
+        logger.info("quarantined revision of %r: breaks %s", p.name,
+                    ", ".join(r["dependent_name"] for r in regressions))
+        return {"status": "quarantined", "name": p.name, "regressions": regressions,
+                "quarantine": str(path)}
+
+    # --- promote --------------------------------------------------------------
+    old_dicts = _steps_as_dicts(p.steps, with_counts=True)
+    carried = carry_step_history(old_dicts, new_steps)
+    today = _dt.date.today().isoformat()
+
+    if p.success_count == 0:
+        # Nothing was ever learned about this version: the fix is a better
+        # description, not a new lineage. Same rule as the cloud (PR #89).
+        p.steps = _to_steps(carried, keep_counts=True)
+        status = "revised_in_place"
+    else:
+        p.evolution.append(Revision(
+            version_before=p.version, version_after=p.version + 1, reason=reason, date=today,
+            success_count=p.success_count, fail_count=p.fail_count))
+        p.version += 1
+        p.success_count, p.fail_count = 0, 0
+        p.steps = _to_steps(carried, keep_counts=True)
+        status = "promoted"
+
+    if new_trigger:
+        p.trigger = new_trigger
+    p.preconditions = preconditions
+    if assumption:
+        p.last_failure, p.last_failed = assumption, today
+    store.save()
+    return {"status": status, "name": p.name, "version": p.version,
+            "violated_assumption": assumption or None, "precondition_check": precondition or None,
+            "reliability": p.reliability}

--- a/local/store.py
+++ b/local/store.py
@@ -1,0 +1,389 @@
+"""The folder store: a memfmt tree read into memory, changed, written back.
+
+Everything here is deliberately plain. The folder is the database; this class
+is only the in-memory view of it plus the rules for changing it — the same
+rules the cloud store applies, on the same pure helpers, so a workflow means
+one thing whether it lives in Postgres or in `procedures/deploy.md`.
+
+Retrieval is word overlap, the honest limit of files without a model. Past a
+few hundred entries you want embeddings, and that is what the cloud is for.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from pathlib import Path
+
+import memfmt
+from memfmt import Entity, Episode, Knowledge, Memory, Procedure, Relation, Step
+
+from cloud.procedure_match import (
+    apply_step_outcome, is_near_duplicate_procedure, normalize_step, procedure_similarity,
+)
+_WORD = re.compile(r"[a-z0-9][a-z0-9_./-]{1,}")
+_STOP = frozenset({
+    "the", "and", "for", "with", "from", "into", "then", "that", "this", "what",
+    "when", "where", "which", "who", "how", "why", "does", "did", "was", "were",
+    "are", "have", "has", "had", "you", "your", "our", "its", "his", "her", "they",
+    "them", "about", "after", "before", "over", "under", "just", "also", "not",
+})
+
+
+def _tokens(text: str) -> set:
+    return {w.strip("./-") for w in _WORD.findall((text or "").lower())
+            if w not in _STOP and len(w) > 2} - {""}
+
+
+def _norm(text: str) -> str:
+    return " ".join((text or "").lower().split()).rstrip(".")
+
+
+def _today() -> str:
+    return _dt.date.today().isoformat()
+
+
+class LocalStore:
+    """A memfmt folder with the cloud's rules for changing it."""
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root)
+        self.memory: Memory = memfmt.load(self.root) if self.root.is_dir() else Memory()
+
+    # ---- persistence ------------------------------------------------------
+
+    def save(self) -> list:
+        """Write the whole tree back. Returns the paths written."""
+        tree = memfmt.serialise(memfmt.canonical(self.memory), root="")
+        self.root.mkdir(parents=True, exist_ok=True)
+        return memfmt.write_dir(tree, self.root)
+
+    # ---- lookups ----------------------------------------------------------
+
+    def _entity(self, name: str) -> Entity | None:
+        key = _norm(name)
+        for e in self.memory.entities:
+            if _norm(e.name) == key:
+                return e
+        return None
+
+    def _procedure(self, name: str) -> Procedure | None:
+        key = _norm(name)
+        for p in self.memory.procedures:
+            if _norm(p.name) == key:
+                return p
+        return None
+
+    # ---- ingestion --------------------------------------------------------
+
+    def add_extraction(self, extraction) -> dict:
+        """Fold an `ExtractionResult` into the memory. Does not write; call save().
+
+        Entities merge by name, facts dedup by normalised text, relations and
+        knowledge append if new. Episodes append. Procedures go through the
+        same near-duplicate rule as the cloud: created, refreshed in place if
+        the existing one has never run, kept untouched if it has a record.
+        """
+        stats = {"entities_created": 0, "entities_updated": 0, "facts_added": 0,
+                 "episodes_saved": 0, "procedures": {"created": 0, "refreshed": 0, "kept": 0}}
+
+        for ext in extraction.entities or []:
+            if not ext.name:
+                continue
+            entity = self._entity(ext.name)
+            if entity is None:
+                entity = Entity(name=ext.name.strip(), entity_type=ext.entity_type or None)
+                self.memory.entities.append(entity)
+                stats["entities_created"] += 1
+            else:
+                stats["entities_updated"] += 1
+                if not entity.entity_type and ext.entity_type:
+                    entity.entity_type = ext.entity_type
+            known = {_norm(f) for f in entity.facts}
+            for fact in ext.facts or []:
+                text = fact.content if hasattr(fact, "content") else str(fact)
+                text = " ".join(str(text).split())
+                if text and _norm(text) not in known:
+                    entity.facts.append(text)
+                    known.add(_norm(text))
+                    stats["facts_added"] += 1
+
+        for rel in extraction.relations or []:
+            src = self._entity(rel.from_entity) if rel.from_entity else None
+            if src is None or not rel.to_entity:
+                continue
+            exists = any(_norm(r.target) == _norm(rel.to_entity) and _norm(r.type) == _norm(rel.relation_type)
+                         for r in src.relations)
+            if not exists:
+                src.relations.append(Relation(type=rel.relation_type or "related to",
+                                              target=rel.to_entity.strip(),
+                                              detail=rel.description or None))
+
+        for k in extraction.knowledge or []:
+            owner = self._entity(k.entity) if k.entity else None
+            if owner is None:
+                continue
+            if any(_norm(x.title) == _norm(k.title) for x in owner.knowledge):
+                continue
+            owner.knowledge.append(Knowledge(type=k.knowledge_type or "note", title=k.title or "",
+                                             content=k.content or "", artifact=k.artifact))
+
+        for ep in extraction.episodes or []:
+            if not ep.summary:
+                continue
+            happened = ep.happened_at or _today()
+            if any(_norm(e.summary) == _norm(ep.summary) and e.happened == happened
+                   for e in self.memory.episodes):
+                continue
+            importance = ep.importance
+            if isinstance(importance, float) and importance <= 1.0:
+                importance = round(importance * 5)
+            self.memory.episodes.append(Episode(
+                summary=" ".join(ep.summary.split()), happened=happened,
+                outcome=ep.outcome or None, valence=ep.emotional_valence or None,
+                importance=int(importance) if importance is not None else None,
+                participants=list(ep.participants or []), context=ep.context or None,
+            ))
+            stats["episodes_saved"] += 1
+
+        for pr in extraction.procedures or []:
+            if not pr.name or not pr.steps:
+                continue
+            action = self.save_extracted_procedure(pr.name, pr.trigger, pr.steps)
+            stats["procedures"][action] += 1
+
+        return stats
+
+    def save_extracted_procedure(self, name: str, trigger: str | None, steps: list) -> str:
+        """created | refreshed | kept — the cloud's write-time dedup, on files."""
+        new_steps = _to_steps(steps)
+        exact = self._procedure(name)
+        if exact is not None:
+            # The unique-name case: refresh the description, never the record.
+            if exact.success_count + exact.fail_count == 0:
+                exact.steps = new_steps
+                exact.trigger = trigger or exact.trigger
+                return "refreshed"
+            return "kept"
+
+        best, best_score = None, 0.0
+        for p in self.memory.procedures:
+            name_sim, step_sim = procedure_similarity(name, steps, p.name, _steps_as_dicts(p.steps))
+            if is_near_duplicate_procedure(name_sim, step_sim) and name_sim + step_sim > best_score:
+                best, best_score = p, name_sim + step_sim
+        if best is None:
+            self.memory.procedures.append(Procedure(name=name.strip(), trigger=trigger or None, steps=new_steps))
+            return "created"
+        if best.success_count + best.fail_count > 0:
+            return "kept"
+        best.steps = new_steps
+        best.trigger = trigger or best.trigger
+        return "refreshed"
+
+    def existing_context(self, max_entities: int = 40) -> str:
+        """What the extractor is told the memory already holds, so it reuses
+        names instead of minting near-duplicates."""
+        if not self.memory.entities:
+            return ""
+        lines = ["Known entities (reuse these names):"]
+        for e in self.memory.entities[:max_entities]:
+            facts = "; ".join(e.facts[:3])
+            kind = f" ({e.entity_type})" if e.entity_type else ""
+            lines.append(f"- {e.name}{kind}: {facts}" if facts else f"- {e.name}{kind}")
+        return "\n".join(lines)
+
+    def add(self, conversation, llm_client) -> dict:
+        """Extract with the user's model and fold the result in. Writes."""
+        from engine.extractor.conversation_extractor import ConversationExtractor
+        if isinstance(conversation, str):
+            conversation = [{"role": "user", "content": conversation}]
+        extraction = ConversationExtractor(llm_client).extract(
+            conversation, existing_context=self.existing_context())
+        stats = self.add_extraction(extraction)
+        self.save()
+        return stats
+
+    # ---- retrieval --------------------------------------------------------
+
+    def search(self, query: str, limit: int = 5) -> list[dict]:
+        """Entities, episodes and procedures that share words with the query,
+        best first. `score` is overlap count; ties break on density."""
+        q = _tokens(query)
+        if not q:
+            return []
+        hits = []
+        for e in self.memory.entities:
+            text = " ".join([e.name, e.name] + e.facts + [k.title + " " + k.content for k in e.knowledge])
+            words = _tokens(text)
+            overlap = q & words
+            if overlap:
+                hits.append(((len(overlap), 1 / (1 + len(words))), {
+                    "type": "entity", "entity": e.name, "entity_type": e.entity_type,
+                    "facts": list(e.facts), "score": len(overlap)}))
+        for ep in self.memory.episodes:
+            words = _tokens(" ".join([ep.summary, ep.context or "", ep.outcome or ""]))
+            overlap = q & words
+            if overlap:
+                hits.append(((len(overlap), 1 / (1 + len(words))), {
+                    "type": "episode", "summary": ep.summary, "happened": ep.happened,
+                    "outcome": ep.outcome, "valence": ep.valence, "score": len(overlap)}))
+        for p in self.memory.procedures:
+            words = _tokens(" ".join([p.name, p.trigger or ""] + [s.action + " " + (s.detail or "") for s in p.steps]))
+            overlap = q & words
+            if overlap:
+                d = self._procedure_dict(p)
+                d.update({"type": "procedure", "score": len(overlap)})
+                hits.append(((len(overlap), 1 / (1 + len(words))), d))
+        hits.sort(key=lambda h: h[0], reverse=True)
+        return [h[1] for h in hits[:limit]]
+
+    def recall(self, query: str, limit: int = 5) -> str:
+        """The search, as a context block an agent can read."""
+        hits = self.search(query, limit=limit)
+        if not hits:
+            return ""
+        lines = ["[Mengram Memory — relevant context from this folder]"]
+        for h in hits:
+            if h["type"] == "entity":
+                lines.append(f"\n{h['entity']}:")
+                lines.extend(f"  - {f}" for f in h["facts"][:5])
+            elif h["type"] == "episode":
+                when = f" ({h['happened']})" if h.get("happened") else ""
+                out = f" → {h['outcome']}" if h.get("outcome") else ""
+                lines.append(f"\nEpisode{when}: {h['summary']}{out}")
+            else:
+                lines.append(f"\nWorkflow: {h['name']} (v{h['version']}, {h['reliability']})")
+                for i, s in enumerate(h["steps"], 1):
+                    lines.append(f"  {i}. {s['action']}" + (f" — {s['detail']}" if s.get("detail") else ""))
+                if h.get("last_failure"):
+                    lines.append(f"  last failure: {h['last_failure']}")
+        return "\n".join(lines)
+
+    def procedures(self, query: str | None = None, limit: int = 20) -> list[dict]:
+        """Procedures in the cloud's dict shape (what the policy gate reads)."""
+        if query:
+            return [h for h in self.search(query, limit=limit * 3) if h["type"] == "procedure"][:limit]
+        return [self._procedure_dict(p) for p in self.memory.procedures[:limit]]
+
+    def _procedure_dict(self, p: Procedure) -> dict:
+        steps = []
+        for s in p.steps:
+            d = {"action": s.action, "detail": s.detail}
+            if s.tracked:
+                d["success_count"] = s.success_count or 0
+                d["fail_count"] = s.fail_count or 0
+                d["reliability"] = s.reliability
+            steps.append(d)
+        return {
+            "id": p.id, "name": p.name, "version": p.version,
+            "success_count": p.success_count, "fail_count": p.fail_count,
+            "reliability": p.reliability, "trigger_condition": p.trigger,
+            "preconditions": list(p.preconditions), "steps": steps,
+            "last_failure": p.last_failure, "last_failed": p.last_failed,
+            "evolution": [{"version_before": r.version_before, "version_after": r.version_after,
+                           "reason": r.reason, "date": r.date,
+                           "success_count": r.success_count, "fail_count": r.fail_count}
+                          for r in p.evolution],
+            "memory_type": "procedural",
+        }
+
+    # ---- outcomes ---------------------------------------------------------
+
+    def procedure_feedback(self, name: str, success: bool, failed_at_step: int | None = None,
+                           reason: str | None = None) -> dict:
+        """Record a run: the procedure's counts and the steps that ran.
+
+        A failure with a reason also sets `last_failure` / `last_failed`, so
+        the next reader knows what to look at first. Revising the steps in
+        response is `local.evolve`'s job, not this one's. Writes.
+        """
+        p = self._procedure(name)
+        if p is None:
+            return {"error": "procedure not found", "name": name}
+        if success:
+            p.success_count += 1
+        else:
+            p.fail_count += 1
+            if reason:
+                p.last_failure = " ".join(reason.split())
+                p.last_failed = _today()
+        step_dicts = apply_step_outcome(_steps_as_dicts(p.steps, with_counts=True), success, failed_at_step)
+        p.steps = _to_steps(step_dicts, keep_counts=True, template=p.steps)
+        self.save()
+        return self._procedure_dict(p)
+
+    # ---- overview ---------------------------------------------------------
+
+    def profile(self, max_entities: int = 15) -> str:
+        m = self.memory
+        if not (m.entities or m.episodes or m.procedures):
+            return ""
+        lines = [f"Memory folder: {len(m.entities)} entities, {len(m.episodes)} episodes, "
+                 f"{len(m.procedures)} procedures"]
+        if m.profile:
+            lines += ["", m.profile.strip()]
+        if m.entities:
+            lines.append("")
+            for e in m.entities[:max_entities]:
+                facts = "; ".join(e.facts[:2])
+                kind = f" ({e.entity_type})" if e.entity_type else ""
+                lines.append(f"- {e.name}{kind}" + (f": {facts}" if facts else ""))
+        tested = [p for p in m.procedures if p.success_count + p.fail_count]
+        if tested:
+            lines.append("")
+            lines.append("Workflows with a record:")
+            for p in sorted(tested, key=lambda p: -(p.success_count + p.fail_count))[:10]:
+                lines.append(f"- {p.name} v{p.version}: {p.success_count}✓/{p.fail_count}✗ {p.reliability}")
+        return "\n".join(lines)
+
+    def stats(self) -> dict:
+        m = self.memory
+        return {
+            "entities": len(m.entities),
+            "facts": sum(len(e.facts) for e in m.entities),
+            "episodes": len(m.episodes),
+            "procedures": len(m.procedures),
+            "procedures_with_record": sum(1 for p in m.procedures if p.success_count + p.fail_count),
+        }
+
+
+# ---- step conversion ---------------------------------------------------------
+
+def _to_steps(steps: list, keep_counts: bool = False, template: list | None = None) -> list:
+    """Extractor/cloud step dicts → memfmt Steps. Counters the model emitted are
+    dropped unless `keep_counts` (feedback path), matching the cloud's rule."""
+    out = []
+    for i, s in enumerate(steps or []):
+        if isinstance(s, Step):
+            out.append(s)
+            continue
+        if isinstance(s, dict):
+            action = " ".join(str(s.get("action") or s.get("step") or s.get("description") or "").split())
+            detail = s.get("detail")
+            detail = " ".join(str(detail).split()) if detail else None
+            step = Step(action=action, detail=detail)
+            if keep_counts:
+                step.success_count = s.get("success_count")
+                step.fail_count = s.get("fail_count")
+            if template and i < len(template) and isinstance(template[i], Step):
+                step.needs, step.gives = list(template[i].needs), list(template[i].gives)
+        else:
+            step = Step(action=" ".join(normalize_step(s).split()))
+        if step.action:
+            out.append(step)
+    return out
+
+
+def _steps_as_dicts(steps: list, with_counts: bool = False) -> list:
+    out = []
+    for s in steps or []:
+        if isinstance(s, Step):
+            d = {"action": s.action, "detail": s.detail}
+            if with_counts:
+                d["success_count"], d["fail_count"] = s.success_count, s.fail_count
+            out.append(d)
+        elif isinstance(s, dict):
+            out.append(dict(s))
+        else:
+            out.append({"action": str(s)})
+    return out

--- a/local/store.py
+++ b/local/store.py
@@ -149,20 +149,28 @@ class LocalStore:
         for pr in extraction.procedures or []:
             if not pr.name or not pr.steps:
                 continue
-            action = self.save_extracted_procedure(pr.name, pr.trigger, pr.steps)
+            action = self.save_extracted_procedure(pr.name, pr.trigger, pr.steps,
+                                                   entities=getattr(pr, "entities", None))
             stats["procedures"][action] += 1
 
         return stats
 
-    def save_extracted_procedure(self, name: str, trigger: str | None, steps: list) -> str:
-        """created | refreshed | kept — the cloud's write-time dedup, on files."""
+    def save_extracted_procedure(self, name: str, trigger: str | None, steps: list,
+                                 entities: list | None = None) -> str:
+        """created | refreshed | kept — the cloud's write-time dedup, on files.
+
+        `entities` (what the workflow touches) ride in the file's frontmatter
+        as `entities:`; the regression gate uses them to tell which
+        procedures share a surface."""
         new_steps = _to_steps(steps)
+        ents = [str(e).strip() for e in (entities or []) if str(e).strip()]
         exact = self._procedure(name)
         if exact is not None:
             # The unique-name case: refresh the description, never the record.
             if exact.success_count + exact.fail_count == 0:
                 exact.steps = new_steps
                 exact.trigger = trigger or exact.trigger
+                _merge_entities(exact, ents)
                 return "refreshed"
             return "kept"
 
@@ -172,12 +180,15 @@ class LocalStore:
             if is_near_duplicate_procedure(name_sim, step_sim) and name_sim + step_sim > best_score:
                 best, best_score = p, name_sim + step_sim
         if best is None:
-            self.memory.procedures.append(Procedure(name=name.strip(), trigger=trigger or None, steps=new_steps))
+            proc = Procedure(name=name.strip(), trigger=trigger or None, steps=new_steps)
+            _merge_entities(proc, ents)
+            self.memory.procedures.append(proc)
             return "created"
         if best.success_count + best.fail_count > 0:
             return "kept"
         best.steps = new_steps
         best.trigger = trigger or best.trigger
+        _merge_entities(best, ents)
         return "refreshed"
 
     def existing_context(self, max_entities: int = 40) -> str:
@@ -276,6 +287,7 @@ class LocalStore:
             steps.append(d)
         return {
             "id": p.id, "name": p.name, "version": p.version,
+            "entity_names": list(p.extra.get("entities") or []),
             "success_count": p.success_count, "fail_count": p.fail_count,
             "reliability": p.reliability, "trigger_condition": p.trigger,
             "preconditions": list(p.preconditions), "steps": steps,
@@ -345,6 +357,19 @@ class LocalStore:
             "procedures": len(m.procedures),
             "procedures_with_record": sum(1 for p in m.procedures if p.success_count + p.fail_count),
         }
+
+
+def _merge_entities(proc: Procedure, entities: list) -> None:
+    """Union into the `entities:` frontmatter list, order kept, case-insensitive."""
+    if not entities:
+        return
+    current = list(proc.extra.get("entities") or [])
+    seen = {e.lower() for e in current}
+    for e in entities:
+        if e.lower() not in seen:
+            current.append(e)
+            seen.add(e.lower())
+    proc.extra["entities"] = current
 
 
 # ---- step conversion ---------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.32.0"
+version = "2.33.0"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "numpy>=1.24",
     "certifi>=2024.0",
     "mcp==1.28.1",
+    "memfmt>=0.5,<0.6",
 ]
 
 [project.optional-dependencies]
@@ -72,7 +73,7 @@ Documentation = "https://mengram.io"
 mengram = "cli:main"
 
 [tool.setuptools.packages.find]
-include = ["engine*", "api*", "cloud*", "integrations*"]
+include = ["engine*", "api*", "cloud*", "integrations*", "local*"]
 
 [tool.setuptools]
 py-modules = ["mengram", "mengram_middleware", "cli", "importer"]

--- a/specs/local-mode.md
+++ b/specs/local-mode.md
@@ -1,0 +1,86 @@
+# Spec — Local mode: memory that lives in a folder
+
+**Status:** in progress · decided 2026-09-04 (Ali: «открывай ядро, делай локальную версию»)
+**Why:** in this category users arrive through an open, local tool that installs
+without an account (claude-mem, Mnemosyne), not through a hosted SaaS from one
+person. Hermes refused the cloud MCP for exactly that reason. The repo is already
+Apache-2.0 including the cloud; what is missing is a local mode that is equal to
+the cloud on the one thing nobody else has — procedures with outcomes — and
+installs in one line with no key to Mengram.
+
+## What "local" means
+
+- **The folder is the memory.** A [memfmt](https://github.com/alibaizhanov/memfmt)
+  tree (`entities/`, `episodes/`, `procedures/`, `MEMORY.md`) is the source of
+  truth. Git diffs it, Obsidian draws it, `memfmt validate` checks it. No SQLite
+  of record, no server, no account.
+- **Bring your own model.** Extraction and failure-revision need an LLM: an
+  Anthropic or OpenAI key the user already has, or Ollama (8B+, 8K+ context).
+  Everything else — search, procedures, feedback, the policy gate — runs with
+  no model and no network.
+- **Same differentiator as the cloud.** Versioned procedures, `success_count` /
+  `fail_count` per version and per step, smoothed reliability, `last_failure`,
+  the failure → revision loop with the violated assumption, the cross-procedure
+  regression gate (quarantine instead of silent promotion), write-time dedup of
+  near-duplicate names, and the Claude Code policy gate.
+- **The cloud is sync and history, not a gate.** Nothing local expires or asks
+  for a key. The cloud adds cross-machine sync, embeddings, background
+  extraction from sessions, and the dashboard.
+
+## What exists and what is reused
+
+| Piece | Reused from | Notes |
+|---|---|---|
+| Extraction (entities/facts/relations/knowledge/episodes/procedures) | `engine/extractor` | shared with the cloud already; `create_llm_client` supports anthropic/openai/ollama |
+| Format | `memfmt` (PyPI, pinned `>=0.5,<0.6`) | model + parse + serialise + `validate` |
+| Reliability words, per-step records | `cloud/reliability.py` | pure |
+| Near-duplicate procedure names | `cloud/procedure_match.py` (moved out of `store.py`) | pure |
+| Regression gate | `cloud/regression_gate.py` | pure |
+| Failure → revision prompt | `cloud/evolution.py` (`EVOLVE_ON_FAILURE_PROMPT`) | pure string |
+| Policy gate | `cloud/policy.py` | already reads a memfmt folder |
+
+The old vault engine (`engine/brain.py`, `.procedures.json`, sentence-transformers)
+is **not** extended. It stays for existing users of `mengram init`; the new path
+does not depend on it and does not require `sentence-transformers`.
+
+## Surface
+
+```
+mengram local init [DIR]                  # creates DIR (default ./memory), writes config
+mengram local add "text" | --stdin        # extract with your model, write files
+mengram local search "query"              # facts, events, workflows — word overlap, no model
+mengram local procedures [query]          # with reliability, last failure
+mengram local feedback NAME --success | --failure [--step N] [--context "..."]
+mengram local stat                        # delegates to memfmt stat + quarantine count
+mengram server --memory DIR               # MCP over stdio: remember/recall/list_procedures/procedure_feedback/context_for
+mengram hook install                      # with MENGRAM_MEMORY_DIR set, all four hooks run locally, no key
+```
+
+Config: `DIR/.mengram/config.json` — `{"llm": {"provider": "anthropic|openai|ollama", ...}}`.
+Env `MENGRAM_MEMORY_DIR` selects local mode for hooks and the MCP server.
+
+## Steps (each its own PR)
+
+1. **Store** — `local/store.py`: load/save a memfmt tree; `add_extraction` (entity
+   merge, fact dedup, episode append, procedure created/refreshed/kept);
+   `search`, `recall`, `procedures`, `procedure_feedback` (per-step outcomes),
+   `profile`, `stats`. Pure helpers moved to `cloud/procedure_match.py`. Tests
+   hermetic on a tmp folder.
+2. **Failure → revision** — `local/evolve.py`: on `--failure --context`, call the
+   model with the shared prompt, run `find_regressions` against the other
+   procedures, promote (new version, `Revision` with the retiring record,
+   `last_failure`/`last_failed`) or quarantine to `DIR/.mengram/quarantine.json`.
+   A version with no successes is revised in place, as in the cloud (PR #89).
+3. **CLI + hooks** — `mengram local …`; `auto-save` / `auto-recall` /
+   `auto-context` / `auto-policy` use the store when `MENGRAM_MEMORY_DIR` is set.
+4. **MCP server** — `api/local_mcp_server.py`, stdio, the connector's 4-tool
+   surface plus `procedure_feedback`.
+5. **Docs + release** — README "Local mode: no account", docs page, 2.33.0,
+   post in the threads that asked for it.
+
+## Not in v1
+
+Embeddings locally (word overlap only, as memfmt `context`), sync between
+machines, multiple users per folder, reflection/curator agents, deleting or
+renaming files that a rename left behind, staleness (`last_succeeded` — needs
+its own field, same as the cloud).

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1,0 +1,188 @@
+"""Local mode, step 3: the CLI and the Claude Code hooks against a folder.
+
+`provider: mock` in the folder's config makes the engine's MockLLMClient the
+model, so every command runs with no key and no network.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import cli  # noqa: E402
+from local.config import write_config  # noqa: E402
+
+
+def _run(monkeypatch, capsys, argv, stdin=None):
+    monkeypatch.setattr(sys, "argv", ["mengram", *argv])
+    if stdin is not None:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(stdin))
+    code = 0
+    try:
+        cli.main()
+    except SystemExit as e:
+        code = int(e.code or 0)
+    out = capsys.readouterr()
+    return code, out.out, out.err
+
+
+@pytest.fixture
+def folder(tmp_path, monkeypatch):
+    monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("MENGRAM_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    root = tmp_path / "memory"
+    root.mkdir()
+    write_config(root, {"llm": {"provider": "mock"}})
+    return root
+
+
+# --- mengram local … -------------------------------------------------------------
+
+def test_init_creates_the_folder_and_config(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "mem"
+    code, out, err = _run(monkeypatch, capsys, ["local", "init", str(root), "--provider", "ollama", "--model", "llama3.1:8b"])
+    assert code == 0
+    assert (root / "MEMORY.md").exists()
+    cfg = json.loads((root / ".mengram" / "config.json").read_text())
+    assert cfg["llm"] == {"provider": "ollama", "ollama": {"model": "llama3.1:8b"}}
+    assert "MENGRAM_MEMORY_DIR" in out
+
+
+def test_init_rejects_an_unknown_provider(tmp_path, monkeypatch, capsys):
+    code, out, err = _run(monkeypatch, capsys, ["local", "init", str(tmp_path / "m"), "--provider", "gpt9"])
+    assert code == 1 and "unknown provider" in err
+
+
+def test_add_search_procedures_feedback_stat(folder, monkeypatch, capsys):
+    mem = ["--memory", str(folder)]
+    code, out, _ = _run(monkeypatch, capsys, ["local", "add", "I work at Uzum Bank as a backend developer", *mem])
+    assert code == 0 and "entities +" in out
+    code, out, _ = _run(monkeypatch, capsys, ["local", "search", "uzum", *mem])
+    assert code == 0 and "Uzum Bank" in out
+    code, out, _ = _run(monkeypatch, capsys, ["local", "stat", *mem])
+    assert code == 0 and "entities" in out and "model: mock" in out
+
+
+def test_add_without_a_model_says_so(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "m"
+    root.mkdir()
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    code, out, err = _run(monkeypatch, capsys, ["local", "add", "hello", "--memory", str(root)])
+    assert code == 2 and "no model configured" in err
+
+
+def test_missing_folder_is_a_clear_error(tmp_path, monkeypatch, capsys):
+    code, out, err = _run(monkeypatch, capsys, ["local", "search", "x", "--memory", str(tmp_path / "nope")])
+    assert code == 1 and "mengram local init" in err
+
+
+def test_feedback_records_and_revises_with_the_model(folder, monkeypatch, capsys):
+    from local.store import LocalStore
+    from engine.extractor.conversation_extractor import ExtractedProcedure, ExtractionResult
+    store = LocalStore(folder)
+    store.add_extraction(ExtractionResult(procedures=[ExtractedProcedure(
+        "Deploy to Railway", "a change lands on main", [{"action": "push to main"}, {"action": "verify /health"}])]))
+    store.save()
+    mem = ["--memory", str(folder)]
+    code, out, _ = _run(monkeypatch, capsys, ["local", "feedback", "Deploy to Railway", "--success", *mem])
+    assert code == 0 and "1✓/0✗" in out
+    # a failure with context asks the (mock) model; whatever it says, the counts are recorded
+    code, out, err = _run(monkeypatch, capsys, ["local", "feedback", "Deploy to Railway", "--failure",
+                                                "--step", "2", "--context", "connection refused", *mem])
+    assert code in (0, 1)
+    assert "1✓/1✗" in out
+    code, out, _ = _run(monkeypatch, capsys, ["local", "procedures", *mem])
+    assert code == 0 and "Deploy to Railway" in out and "last failure: " in out
+    code, out, _ = _run(monkeypatch, capsys, ["local", "quarantine", *mem])
+    assert code == 0
+
+
+def test_env_var_selects_the_folder(folder, monkeypatch, capsys):
+    monkeypatch.setenv("MENGRAM_MEMORY_DIR", str(folder))
+    code, out, _ = _run(monkeypatch, capsys, ["local", "stat"])
+    assert code == 0 and "model: mock" in out
+
+
+# --- the hooks, all local ------------------------------------------------------------
+
+def _seeded(folder):
+    from local.store import LocalStore
+    from engine.extractor.conversation_extractor import (ExtractedEntity, ExtractedFact,
+                                                          ExtractedProcedure, ExtractionResult)
+    store = LocalStore(folder)
+    store.add_extraction(ExtractionResult(
+        entities=[ExtractedEntity("Railway", "service", [ExtractedFact("auto-deploys from main")])],
+        procedures=[ExtractedProcedure("Deploy to Railway", "a change lands on main",
+                                       [{"action": "push to main"}, {"action": "verify /health"}])]))
+    store.save()
+    return store
+
+
+def test_auto_recall_reads_the_folder_without_a_key(folder, monkeypatch, capsys):
+    _seeded(folder)
+    payload = json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "how do we deploy to railway?"})
+    code, out, _ = _run(monkeypatch, capsys, ["auto-recall", "--memory", str(folder)], stdin=payload)
+    assert code == 0
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "Railway" in ctx and "Deploy to Railway" in ctx
+
+
+def test_auto_context_loads_the_profile_from_the_folder(folder, monkeypatch, capsys):
+    _seeded(folder)
+    monkeypatch.setenv("MENGRAM_MEMORY_DIR", str(folder))
+    code, out, _ = _run(monkeypatch, capsys, ["auto-context", "--no-weekly"], stdin="{}")
+    assert code == 0
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "Memory folder: 1 entities" in ctx and "Railway" in ctx
+
+
+def test_auto_save_extracts_into_the_folder(folder, monkeypatch, capsys, tmp_path):
+    payload = json.dumps({"hook_event_name": "Stop", "session_id": "s1", "stop_hook_active": False,
+                          "last_assistant_message": "Sure — I deployed it to Railway and the health check passed."})
+    code, out, _ = _run(monkeypatch, capsys, ["auto-save", "--every", "1", "--memory", str(folder), "--verbose"],
+                        stdin=payload)
+    assert code == 0 and "saved (local)" in out
+    from local.store import LocalStore
+    assert LocalStore(folder).stats()["entities"] >= 1
+
+
+def test_auto_save_without_a_model_is_silent_but_honest(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "m"
+    root.mkdir()
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    payload = json.dumps({"session_id": "s2", "last_assistant_message": "a long enough assistant message here"})
+    code, out, _ = _run(monkeypatch, capsys, ["auto-save", "--every", "1", "--memory", str(root), "--verbose"],
+                        stdin=payload)
+    assert code == 0 and "no model configured (local)" in out
+
+
+def test_auto_policy_gates_a_folder_workflow(folder, monkeypatch, capsys):
+    _seeded(folder)
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": "git push origin main"}})
+    code, out, _ = _run(monkeypatch, capsys, ["auto-policy", "--memory", str(folder)], stdin=payload)
+    assert code == 0
+    assert json.loads(out)["hookSpecificOutput"]["permissionDecision"] == "ask"
+
+
+def test_hook_install_in_local_mode_needs_no_key(folder, monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(cli, "get_claude_code_settings_path", lambda: tmp_path / "settings.json")
+    code, out, _ = _run(monkeypatch, capsys, ["hook", "install", "--memory", str(folder)])
+    assert code == 0 and "local mode" in out
+    settings = json.loads((tmp_path / "settings.json").read_text())
+    cmds = [h["command"] for groups in settings["hooks"].values() for g in groups for h in g["hooks"]]
+    assert len(cmds) == 4 and all("--memory" in c and str(folder.resolve()) in c for c in cmds)
+    assert settings["hooks"]["PreToolUse"][0]["matcher"] == "Bash"
+
+
+def test_hook_install_without_key_or_folder_points_at_local_mode(monkeypatch, capsys, tmp_path):
+    monkeypatch.delenv("MENGRAM_API_KEY", raising=False)
+    monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
+    code, out, err = _run(monkeypatch, capsys, ["hook", "install"])
+    assert code == 1 and "--memory" in err

--- a/tests/test_local_evolve.py
+++ b/tests/test_local_evolve.py
@@ -1,0 +1,149 @@
+"""Local mode, step 2: failure → revision on files, with the regression gate.
+
+The model is a stub that returns whatever JSON the test hands it.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from engine.extractor.conversation_extractor import ExtractedProcedure, ExtractionResult  # noqa: E402
+from local import LocalStore  # noqa: E402
+from local.evolve import evolve_on_failure, read_quarantine  # noqa: E402
+
+
+class _Model:
+    def __init__(self, reply):
+        self.reply = reply
+        self.prompts = []
+
+    def complete(self, prompt, system="", response_format=None):
+        self.prompts.append(prompt)
+        return self.reply if isinstance(self.reply, str) else json.dumps(self.reply)
+
+
+DEPLOY = [{"action": "push to main", "detail": "the webhook does the rest"},
+          {"action": "watch the boot log"},
+          {"action": "verify /health", "detail": "expect 200 within 60s"}]
+
+FIX = {
+    "new_steps": [
+        {"step": 1, "action": "push to main", "detail": "the webhook does the rest"},
+        {"step": 2, "action": "watch the boot log"},
+        {"step": 3, "action": "wait for the pool", "detail": "pool_max reached"},
+        {"step": 4, "action": "verify /health", "detail": "expect 200 within 60s"},
+    ],
+    "new_trigger": None,
+    "change_type": "step_added",
+    "change_description": "wait for the pool before probing",
+    "violated_assumption": "the connection pool was warm when /health was probed",
+    "precondition_check": "verify the pool is warm before probing /health",
+}
+
+
+def _store(tmp_path, extra=None) -> LocalStore:
+    store = LocalStore(tmp_path / "memory")
+    procs = [ExtractedProcedure("Deploy to Railway", "a change lands on main", DEPLOY, ["Railway", "Postgres"])]
+    procs += extra or []
+    store.add_extraction(ExtractionResult(procedures=procs))
+    store.save()
+    return store
+
+
+def test_unknown_procedure_is_an_error(tmp_path):
+    assert evolve_on_failure(_store(tmp_path), "nope", "x", _Model(FIX))["status"] == "error"
+
+
+def test_the_prompt_carries_the_procedure_and_the_failure(tmp_path):
+    store = _store(tmp_path)
+    m = _Model(FIX)
+    evolve_on_failure(store, "Deploy to Railway", "connection refused on /health", m, failed_at_step=3)
+    (prompt,) = m.prompts
+    assert "Deploy to Railway" in prompt and "3. verify /health" in prompt
+    assert "connection refused on /health" in prompt and "Failed at step: 3" in prompt
+
+
+def test_untested_version_is_revised_in_place(tmp_path):
+    store = _store(tmp_path)
+    r = evolve_on_failure(store, "Deploy to Railway", "cold pool", _Model(FIX))
+    assert r["status"] == "revised_in_place" and r["version"] == 1
+    p = store.memory.procedures[0]
+    assert [s.action for s in p.steps] == ["push to main", "watch the boot log", "wait for the pool", "verify /health"]
+    assert p.preconditions == ["verify the pool is warm before probing /health"]
+    assert p.last_failure == "the connection pool was warm when /health was probed"
+    assert p.evolution == []
+
+
+def test_proven_version_gets_a_successor_with_the_record_on_the_lineage(tmp_path):
+    store = _store(tmp_path)
+    for _ in range(3):
+        store.procedure_feedback("Deploy to Railway", success=True)
+    store.procedure_feedback("Deploy to Railway", success=False, failed_at_step=3)
+    r = evolve_on_failure(store, "Deploy to Railway", "cold pool", _Model(FIX))
+    assert r["status"] == "promoted" and r["version"] == 2
+    p = store.memory.procedures[0]
+    assert (p.success_count, p.fail_count) == (0, 0)
+    (rev,) = p.evolution
+    assert (rev.version_before, rev.version_after, rev.success_count, rev.fail_count) == (1, 2, 3, 1)
+    assert rev.reason == "wait for the pool before probing"
+    # inherits a prior from the lineage instead of opening as untested
+    assert p.reliability.endswith("expected")
+    # unchanged steps keep their record; the new step starts untracked
+    by_action = {s.action: s for s in p.steps}
+    assert (by_action["push to main"].success_count, by_action["push to main"].fail_count or 0) == (4, 0)
+    assert not by_action["wait for the pool"].tracked
+    text = (tmp_path / "memory" / "procedures" / "Deploy to Railway.md").read_text()
+    assert "- v1 → v2 (" in text and "3✓/1✗): wait for the pool before probing" in text
+    assert "last_failure: the connection pool was warm when /health was probed" in text
+
+
+def test_a_fix_that_breaks_a_dependent_is_quarantined_not_promoted(tmp_path):
+    # Two procedures share the database; the fix adds "run migrations first".
+    dependent = ExtractedProcedure("Hotfix the API", "a bug in prod", [
+        {"action": "push the fix to main"}, {"action": "verify /health on the database api"}],
+        ["Postgres"])
+    store = _store(tmp_path, extra=[dependent])
+    store.procedure_feedback("Deploy to Railway", success=True)
+    fix = dict(FIX)
+    fix["new_steps"] = [{"step": 1, "action": "run database migrations", "detail": "alembic upgrade head"}] + FIX["new_steps"]
+    fix["precondition_check"] = "database migrations applied before push"
+    fix["violated_assumption"] = "the database migration had already been applied"
+    r = evolve_on_failure(store, "Deploy to Railway", "migration missing", _Model(fix))
+    assert r["status"] == "quarantined"
+    assert r["regressions"][0]["dependent_name"] == "Hotfix the API"
+    p = store.memory.procedures[0]
+    assert p.version == 1 and [s.action for s in p.steps][0] == "push to main"   # untouched
+    q = read_quarantine(store)
+    assert len(q) == 1 and q[0]["procedure"] == "Deploy to Railway"
+    assert q[0]["proposed_steps"][0]["action"] == "run database migrations"
+    # the surface the gate used is in the file, as frontmatter anyone can edit
+    text = (tmp_path / "memory" / "procedures" / "Deploy to Railway.md").read_text()
+    assert "entities:\n  - Railway\n  - Postgres" in text
+    assert (tmp_path / "memory" / ".mengram" / "quarantine.json").exists()
+    # and the folder still validates: the quarantine file is not a memfmt file
+    from memfmt.cli import main
+    assert main(["validate", str(tmp_path / "memory")]) == 0
+
+
+def test_garbage_from_the_model_changes_nothing(tmp_path):
+    store = _store(tmp_path)
+    before = store.memory.procedures[0].steps[:]
+    assert evolve_on_failure(store, "Deploy to Railway", "x", _Model("not json"))["status"] == "no_change"
+    assert evolve_on_failure(store, "Deploy to Railway", "x", _Model({"new_steps": []}))["status"] == "no_change"
+    assert store.memory.procedures[0].steps == before
+
+
+def test_fenced_json_is_accepted(tmp_path):
+    store = _store(tmp_path)
+    r = evolve_on_failure(store, "Deploy to Railway", "x", _Model("```json\n" + json.dumps(FIX) + "\n```"))
+    assert r["status"] == "revised_in_place"
+
+
+def test_model_exception_is_reported_not_raised(tmp_path):
+    class Boom:
+        def complete(self, *a, **k):
+            raise RuntimeError("no key")
+    r = evolve_on_failure(_store(tmp_path), "Deploy to Railway", "x", Boom())
+    assert r["status"] == "error" and "no key" in r["error"]

--- a/tests/test_local_mcp.py
+++ b/tests/test_local_mcp.py
@@ -1,0 +1,86 @@
+"""Local mode, step 4: the MCP surface over a folder, tested without a transport."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from api.local_mcp_server import TOOLS, handle_tool, create_server  # noqa: E402
+from engine.extractor.conversation_extractor import (  # noqa: E402
+    ExtractedEntity, ExtractedFact, ExtractedProcedure, ExtractionResult,
+)
+from local.config import write_config  # noqa: E402
+from local.store import LocalStore  # noqa: E402
+
+
+def _folder(tmp_path, model=True):
+    root = tmp_path / "memory"
+    root.mkdir(parents=True)
+    if model:
+        write_config(root, {"llm": {"provider": "mock"}})
+    store = LocalStore(root)
+    store.add_extraction(ExtractionResult(
+        entities=[ExtractedEntity("Railway", "service", [ExtractedFact("auto-deploys from main")])],
+        procedures=[ExtractedProcedure("Deploy to Railway", "a change lands on main",
+                                       [{"action": "push to main"}, {"action": "verify /health"}], ["Railway"])]))
+    store.save()
+    return store
+
+
+def test_the_surface_is_the_connectors_four_plus_feedback():
+    assert [t["name"] for t in TOOLS] == ["remember", "recall", "context_for", "list_procedures", "procedure_feedback"]
+    for t in TOOLS:
+        json.dumps(t["inputSchema"])   # schemas are plain JSON
+
+
+def test_recall_and_context_for(tmp_path):
+    store = _folder(tmp_path)
+    assert "Railway" in handle_tool(store, "recall", {"query": "railway deploy"})
+    assert handle_tool(store, "recall", {"query": "zzzz"}) == "Nothing relevant in memory."
+    assert handle_tool(store, "recall", {}) .startswith("Nothing to recall")
+    ctx = handle_tool(store, "context_for", {"task": "deploy the api to railway"})
+    assert "# Who this is for" in ctx and "# Relevant memory" in ctx and "Deploy to Railway" in ctx
+
+
+def test_list_procedures_reads_like_a_record(tmp_path):
+    store = _folder(tmp_path)
+    store.procedure_feedback("Deploy to Railway", success=True)
+    store.procedure_feedback("Deploy to Railway", success=False, failed_at_step=2, reason="cold pool")
+    text = handle_tool(store, "list_procedures", {})
+    assert "## Deploy to Railway (v1 · 50% reliable, 1✓/1✗)" in text
+    assert "1. push to main (2✓/0✗)" in text
+    assert "Last failure: " in text and "cold pool" in text
+    assert handle_tool(store, "list_procedures", {"query": "nothing-here"}) == "No learned workflows yet."
+
+
+def test_feedback_records_and_revises(tmp_path):
+    store = _folder(tmp_path)
+    out = handle_tool(store, "procedure_feedback", {"name": "Deploy to Railway", "success": True})
+    assert out.startswith("Recorded: Deploy to Railway v1 is now 1✓/0✗")
+    out = handle_tool(store, "procedure_feedback", {"name": "Deploy to Railway", "success": False,
+                                                   "failed_at_step": 2, "context": "connection refused"})
+    assert "1✓/1✗" in out and ("Revised" in out or "No revision" in out or "Revision failed" in out)
+    assert handle_tool(store, "procedure_feedback", {"name": "nope", "success": True}).startswith("procedure not found")
+    assert handle_tool(store, "procedure_feedback", {"name": "x"}).startswith("Pass 'name'")
+
+
+def test_remember_needs_a_model_and_says_so(tmp_path):
+    store = _folder(tmp_path, model=False)
+    out = handle_tool(store, "remember", {"text": "I work at Uzum Bank"})
+    assert out.startswith("No model configured")
+    store2 = _folder(tmp_path / "b")
+    out = handle_tool(store2, "remember", {"text": "I work at Uzum Bank"})
+    assert out.startswith("Remembered:")
+    assert handle_tool(store2, "remember", {}).startswith("Nothing to remember")
+
+
+def test_unknown_tool_is_text_not_an_exception(tmp_path):
+    assert handle_tool(_folder(tmp_path), "explode", {}) == "Unknown tool: explode"
+
+
+def test_server_builds_with_instructions_naming_the_folder(tmp_path):
+    store = _folder(tmp_path)
+    server = create_server(store.root)
+    assert server.name == "mengram-local"
+    assert str(store.root.resolve()) in (server.instructions or "")

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -1,0 +1,219 @@
+"""Local mode, step 1: a memfmt folder with the cloud's rules for changing it.
+
+Hermetic: every test works on a tmp folder. No model, no network — extraction
+results are built by hand from the engine's dataclasses, and `add()` uses the
+engine's MockLLMClient.
+"""
+
+import sys
+from pathlib import Path
+
+import memfmt
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from engine.extractor.conversation_extractor import (  # noqa: E402
+    ExtractedEntity, ExtractedEpisode, ExtractedFact, ExtractedKnowledge,
+    ExtractedProcedure, ExtractedRelation, ExtractionResult, MockLLMClient,
+)
+from local import LocalStore  # noqa: E402
+
+
+def _extraction(**kw) -> ExtractionResult:
+    return ExtractionResult(**kw)
+
+
+DEPLOY_STEPS = [
+    {"step": 1, "action": "push to main", "detail": "the webhook does the rest"},
+    {"step": 2, "action": "watch the boot log"},
+    {"step": 3, "action": "verify /health", "detail": "expect 200 within 60s"},
+]
+
+
+def _seed(tmp_path) -> LocalStore:
+    store = LocalStore(tmp_path / "memory")
+    store.add_extraction(_extraction(
+        entities=[
+            ExtractedEntity("Ali", "person", [ExtractedFact("prefers Rust for memory safety"),
+                                              ExtractedFact("based in Almaty")]),
+            ExtractedEntity("Railway", "service", [ExtractedFact("auto-deploys from main")]),
+        ],
+        relations=[ExtractedRelation("Ali", "Railway", "uses", "since 2024")],
+        knowledge=[ExtractedKnowledge("Railway", "command", "deploy command",
+                                      "how the service ships", artifact="railway up --detach")],
+        episodes=[ExtractedEpisode("deploy failed on a cold pool", context="two workers booted at once",
+                                   outcome="rolled back", emotional_valence="negative",
+                                   importance=0.8, happened_at="2026-07-30")],
+        procedures=[ExtractedProcedure("Deploy to Railway", "a change lands on main", DEPLOY_STEPS, ["Railway"])],
+    ))
+    store.save()
+    return store
+
+
+# --- files are the memory ---------------------------------------------------
+
+def test_save_writes_a_memfmt_tree_that_loads_back(tmp_path):
+    store = _seed(tmp_path)
+    root = tmp_path / "memory"
+    assert (root / "entities" / "Ali.md").exists()
+    assert (root / "procedures" / "Deploy to Railway.md").exists()
+    assert (root / "MEMORY.md").exists()
+    again = LocalStore(root)
+    assert memfmt.canonical(again.memory) == memfmt.canonical(store.memory)
+
+
+def test_the_folder_passes_memfmt_validate(tmp_path):
+    _seed(tmp_path)
+    from memfmt.cli import main
+    assert main(["validate", str(tmp_path / "memory")]) == 0
+
+
+def test_stats_and_profile(tmp_path):
+    store = _seed(tmp_path)
+    s = store.stats()
+    assert (s["entities"], s["facts"], s["episodes"], s["procedures"]) == (2, 3, 1, 1)
+    prof = store.profile()
+    assert "2 entities" in prof and "Ali (person)" in prof
+
+
+# --- ingestion rules -----------------------------------------------------------
+
+def test_entities_merge_and_facts_dedup(tmp_path):
+    store = _seed(tmp_path)
+    stats = store.add_extraction(_extraction(entities=[
+        ExtractedEntity("ali", "person", [ExtractedFact("Based in Almaty."), ExtractedFact("runs Mengram")]),
+    ]))
+    ali = store._entity("Ali")
+    assert stats["entities_created"] == 0 and stats["entities_updated"] == 1
+    assert stats["facts_added"] == 1
+    assert ali.facts == ["prefers Rust for memory safety", "based in Almaty", "runs Mengram"]
+
+
+def test_relations_and_knowledge_do_not_duplicate(tmp_path):
+    store = _seed(tmp_path)
+    store.add_extraction(_extraction(
+        relations=[ExtractedRelation("Ali", "Railway", "uses")],
+        knowledge=[ExtractedKnowledge("Railway", "command", "Deploy command", "again")],
+    ))
+    ali, railway = store._entity("Ali"), store._entity("Railway")
+    assert len(ali.relations) == 1 and ali.relations[0].detail == "since 2024"
+    assert len(railway.knowledge) == 1 and railway.knowledge[0].artifact == "railway up --detach"
+
+
+def test_episode_importance_maps_to_the_format_and_dedups(tmp_path):
+    store = _seed(tmp_path)
+    ep = store.memory.episodes[0]
+    assert ep.importance == 4 and ep.valence == "negative" and ep.happened == "2026-07-30"
+    stats = store.add_extraction(_extraction(episodes=[
+        ExtractedEpisode("deploy failed on a cold pool", happened_at="2026-07-30")]))
+    assert stats["episodes_saved"] == 0 and len(store.memory.episodes) == 1
+
+
+def test_untested_near_duplicate_is_refreshed_in_place(tmp_path):
+    store = _seed(tmp_path)
+    new_steps = DEPLOY_STEPS + [{"step": 4, "action": "check the pool"}]
+    stats = store.add_extraction(_extraction(procedures=[
+        ExtractedProcedure("Deploying to Railway", "after merge", new_steps)]))
+    assert stats["procedures"] == {"created": 0, "refreshed": 1, "kept": 0}
+    assert len(store.memory.procedures) == 1
+    p = store.memory.procedures[0]
+    assert p.name == "Deploy to Railway"            # keeps its existing name
+    assert [s.action for s in p.steps][-1] == "check the pool"
+    assert p.trigger == "after merge"
+
+
+def test_proven_near_duplicate_is_kept_untouched(tmp_path):
+    store = _seed(tmp_path)
+    store.procedure_feedback("Deploy to Railway", success=True)
+    stats = store.add_extraction(_extraction(procedures=[
+        ExtractedProcedure("Railway deploy", "whatever", [{"action": "something else"}])]))
+    assert stats["procedures"] == {"created": 0, "refreshed": 0, "kept": 1}
+    p = store.memory.procedures[0]
+    assert [s.action for s in p.steps][0] == "push to main" and p.success_count == 1
+
+
+def test_unrelated_procedure_is_created(tmp_path):
+    store = _seed(tmp_path)
+    stats = store.add_extraction(_extraction(procedures=[
+        ExtractedProcedure("Rotate API keys", "quarterly", [{"action": "open dashboard"}, {"action": "revoke"}])]))
+    assert stats["procedures"]["created"] == 1 and len(store.memory.procedures) == 2
+
+
+def test_counters_the_model_emitted_are_dropped(tmp_path):
+    store = LocalStore(tmp_path / "m")
+    store.add_extraction(_extraction(procedures=[ExtractedProcedure("p", "", [
+        {"action": "x", "success_count": 99, "fail_count": 0}])]))
+    assert not store.memory.procedures[0].steps[0].tracked
+
+
+# --- retrieval ------------------------------------------------------------------
+
+def test_search_ranks_by_overlap_across_kinds(tmp_path):
+    store = _seed(tmp_path)
+    hits = store.search("why did the railway deploy fail on the pool")
+    kinds = [h["type"] for h in hits]
+    assert "episode" in kinds and "procedure" in kinds and "entity" in kinds
+    assert all(h["score"] == 2 for h in hits)          # railway+deploy / deploy+pool / railway+deploy
+    assert store.search("cold pool rolled back")[0]["type"] == "episode"
+    assert store.search("") == [] and store.search("zzz qqq") == []
+
+
+def test_recall_is_a_readable_context_block(tmp_path):
+    store = _seed(tmp_path)
+    text = store.recall("deploy railway")
+    assert text.startswith("[Mengram Memory")
+    assert "Workflow: Deploy to Railway (v1, untested)" in text
+    assert "1. push to main — the webhook does the rest" in text
+
+
+def test_procedures_dict_shape_is_what_the_policy_gate_reads(tmp_path):
+    store = _seed(tmp_path)
+    (p,) = store.procedures()
+    assert p["reliability"] == "untested" and p["trigger_condition"] == "a change lands on main"
+    assert p["steps"][0] == {"action": "push to main", "detail": "the webhook does the rest"}
+    from cloud import policy
+    assert policy.decide(p, "git push origin main")["decision"] == "ask"
+    assert store.procedures(query="railway")[0]["name"] == "Deploy to Railway"
+
+
+# --- outcomes -------------------------------------------------------------------
+
+def test_feedback_credits_the_steps_that_ran(tmp_path):
+    store = _seed(tmp_path)
+    store.procedure_feedback("Deploy to Railway", success=True)
+    d = store.procedure_feedback("deploy to railway", success=False, failed_at_step=3,
+                                 reason="probed /health before the pool was up")
+    assert (d["success_count"], d["fail_count"]) == (1, 1)
+    assert d["reliability"] == "50% reliable"
+    steps = d["steps"]
+    assert (steps[0]["success_count"], steps[0]["fail_count"]) == (2, 0)
+    assert (steps[2]["success_count"], steps[2]["fail_count"]) == (1, 1)
+    assert d["last_failure"] == "probed /health before the pool was up"
+    assert d["last_failed"] is not None
+    # and it is on disk, in the format
+    text = (tmp_path / "memory" / "procedures" / "Deploy to Railway.md").read_text()
+    assert "success_count: 1" in text and "fail_count: 1" in text
+    assert "1. push to main — the webhook does the rest (2✓/0✗)" in text
+    assert "last_failure: probed /health before the pool was up" in text
+
+
+def test_feedback_on_unknown_procedure_is_an_error_not_a_crash(tmp_path):
+    store = _seed(tmp_path)
+    assert "error" in store.procedure_feedback("nope", success=True)
+
+
+def test_failure_without_a_step_attributes_nothing_to_steps(tmp_path):
+    store = _seed(tmp_path)
+    d = store.procedure_feedback("Deploy to Railway", success=False)
+    assert d["fail_count"] == 1 and all("success_count" not in s for s in d["steps"])
+
+
+# --- the whole loop with a model ---------------------------------------------------
+
+def test_add_extracts_with_the_users_model_and_writes(tmp_path):
+    store = LocalStore(tmp_path / "memory")
+    stats = store.add("I work at Uzum Bank as a backend developer", MockLLMClient())
+    assert stats["entities_created"] >= 1
+    assert (tmp_path / "memory" / "MEMORY.md").exists()
+    assert store.existing_context().startswith("Known entities")


### PR DESCRIPTION
Steps 1–3 of five for the local mode (spec: `specs/local-mode.md`). The folder is the memory: no account, no server, no sentence-transformers. Only extraction and a failure revision need a model, and that one the user brings (Anthropic / OpenAI key, or Ollama).

**Step 1 — `local/store.py` (LocalStore).** Loads a memfmt tree; `add_extraction` folds an ExtractionResult in (entities merge by name, facts dedup, relations/knowledge append if new, episodes append, procedures through the same created / refreshed / kept rule as the cloud); `search` by word overlap; `recall` as a context block; `procedures()` in the shape the policy gate reads; `procedure_feedback` with per-step credit and `last_failure`; `profile` / `stats`; `save` writes the tree back. Procedures carry their entities in frontmatter.

**Step 2 — `local/evolve.py`.** On a failure with a reason: the cloud's EVOLVE_ON_FAILURE_PROMPT, then `find_regressions` against the other procedures in the folder. Promote → next version, retiring record on the Evolution line, violated assumption in `last_failure`, unchanged steps keep their counts. A version nobody ever ran is revised in place (cloud rule, PR #89). Regression → quarantined to `.mengram/quarantine.json`, procedure untouched.

**Step 3 — `local/cli.py`, `local/config.py`, `cli.py`.** `mengram local init | add | search | procedures | feedback | stat | quarantine`; `--memory DIR` or `MENGRAM_MEMORY_DIR` selects the folder, `DIR/.mengram/config.json` (or an API key in the environment) selects the model. The four Claude Code hooks (`auto-recall`, `auto-context`, `auto-save`, `auto-policy`) take `--memory` and run against the folder with no key; `mengram hook install --memory DIR` writes the folder into each hook command because hooks run without the shell profile.

**`cloud/procedure_match.py`.** Pure helpers moved out of `store.py` so the local path never imports psycopg2; re-exported.

**Deps.** `memfmt>=0.5,<0.6`; `local*` packaged. memfmt 0.5.1 published (`validate` accepts the memory folder itself).

Tests: 39 new, all hermetic on tmp folders with the engine's mock model. Full suite 346 passed.

Next: local MCP server over stdio (4), README/docs + 2.33.0 (5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt