### PR TITLE
import claude-code --memory: the cold start for a memory folder (2.34.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.34.0 — 2026-09-07
+
+### Added
+- **`mengram import claude-code --memory DIR`** — the cold start for a memory
+  folder. Your local Claude Code sessions (`~/.claude/projects`) are parsed,
+  redacted for secrets, and extracted with the folder's own model; the run ends
+  with what the folder now holds and the workflows it learned, with their
+  record. The folder keeps its own imported-sessions list
+  (`.mengram/claude-code-imported.json`), separate from the cloud account's, so
+  the two never skip each other's sessions. `MENGRAM_MEMORY_DIR` works too.
+
+### Changed
+- `cloud/api.py` and `cloud/store.py` were split by domain (#107): the public
+  site and its content live in `cloud/site.py` + `cloud/content/`, billing in
+  `cloud/billing.py`, and `CloudStore` is assembled from mixins in
+  `cloud/store/`. No behaviour change; every route, page and method verified
+  identical.
+
 ## 2.33.0 — 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Prefer CLI-managed hooks instead of the plugin? `pip install mengram-ai && mengr
 ```bash
 pip install mengram-ai
 mengram local init ./memory --provider anthropic --api-key sk-ant-...   # or openai / ollama
+mengram import claude-code --memory ./memory                             # seed it from your Claude Code sessions
 mengram hook install --memory ./memory                                   # the same four hooks, all local
 mengram server --memory ./memory                                         # MCP for Claude Desktop, Cursor, any client
 ```

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.33.0"
+__version__ = "2.34.0"
 """Mengram — AI memory layer for apps."""

--- a/cli.py
+++ b/cli.py
@@ -421,6 +421,96 @@ def _local_auto_save(args, EVENT, HOOK, local_dir, messages):
     _emit_hook_exit(EVENT, args, HOOK, "saved (local)")
 
 
+def _local_import_claude_code(args, local_dir) -> int:
+    """`mengram import claude-code --memory DIR`: the cold start for a folder.
+    Each session is one extraction with the folder's own model; the folder
+    keeps its own imported-sessions list, separate from the cloud account's."""
+    from importer import import_claude_code, discover_claude_code_sessions
+    from local.config import describe_model, llm_client
+
+    if not local_dir.is_dir():
+        print(f"❌ No memory folder at {local_dir} — run: mengram local init {local_dir}")
+        return 1
+    client = llm_client(local_dir)
+    if client is None:
+        print("❌ No model configured — extraction needs one.\n"
+              f"   mengram local init {local_dir} --provider anthropic --api-key sk-ant-...   (or openai / ollama)\n"
+              "   or export ANTHROPIC_API_KEY / OPENAI_API_KEY")
+        return 2
+
+    available = discover_claude_code_sessions(getattr(args, "project", "") or "")
+    if not available:
+        print("❌ No Claude Code sessions found in ~/.claude/projects/")
+        return 1
+    n = min(getattr(args, "last", 20), len(available))
+    print(f"🧠 Found {len(available)} Claude Code sessions; importing up to {n} most recent into {local_dir}.")
+    print(f"   Each session = 1 extraction with {describe_model(local_dir)}. Nothing leaves your machine")
+    print("   except the calls to that model.")
+    if not getattr(args, "yes", False):
+        answer = input("   Continue? [y/N] ").strip().lower()
+        if answer not in ("y", "yes"):
+            print("Aborted.")
+            return 0
+
+    store = _local_store(local_dir)
+    totals = {"entities_created": 0, "entities_updated": 0, "facts_added": 0, "episodes_saved": 0,
+              "procedures_created": 0, "procedures_refreshed": 0}
+
+    def add_fn(text, session_id):
+        stats = store.add(text, client)
+        for key in ("entities_created", "entities_updated", "facts_added", "episodes_saved"):
+            totals[key] += int(stats.get(key) or 0)
+        procs = stats.get("procedures") or {}
+        totals["procedures_created"] += int(procs.get("created") or 0)
+        totals["procedures_refreshed"] += int(procs.get("refreshed") or 0)
+        return {}
+
+    def progress(current, total, title):
+        pct = int(current / total * 100) if total else 0
+        bar = "█" * (pct // 5) + "░" * (20 - pct // 5)
+        print(f"\r  {bar} {pct}% ({current}/{total}) {title}", end="", flush=True)
+
+    print()
+    result = import_claude_code(
+        add_fn,
+        last=getattr(args, "last", 20),
+        project_filter=getattr(args, "project", "") or "",
+        reimport=getattr(args, "reimport", False),
+        on_progress=progress,
+        state_file=local_dir / ".mengram" / "claude-code-imported.json",
+    )
+
+    print(f"\n\n{'='*50}")
+    print("✅ Import complete!\n")
+    print(f"   Sessions considered: {result.conversations_found}")
+    print(f"   Imported:            {result.chunks_sent}")
+    print(f"   Time:                {result.duration_seconds:.1f}s")
+    if result.errors:
+        print(f"\n   ⚠️  {len(result.errors)} errors:")
+        for err in result.errors[:5]:
+            print(f"      - {err}")
+
+    if result.chunks_sent > 0:
+        s = store.stats()
+        print(f"\n   🧠 Folder now holds: {s['entities']} entities, {s['facts']} facts, "
+              f"{s['episodes']} episodes, {s['procedures']} workflows")
+        print(f"   This run: entities +{totals['entities_created']} (updated {totals['entities_updated']}), "
+              f"facts +{totals['facts_added']}, episodes +{totals['episodes_saved']}, "
+              f"workflows +{totals['procedures_created']} (refreshed {totals['procedures_refreshed']})")
+        procs = store.procedures(limit=3)
+        if procs:
+            print("\n   Learned workflows (these evolve as you succeed or fail):")
+            for p in procs:
+                print(f"      ⚙ {p.get('name', '?')} — {len(p.get('steps') or [])} steps, {p.get('reliability') or 'untested'}")
+    elif result.conversations_found == 0:
+        print("\n   Nothing new — every session is already in the folder (use --reimport to force).")
+
+    print(f"\n   Try: mengram local search \"deploy\" --memory {local_dir}")
+    print(f"   Hooks: mengram hook install --memory {local_dir}")
+    print("   Already-imported sessions are skipped on re-runs (use --reimport to force).")
+    return 0
+
+
 def cmd_auto_recall(args):
     """Hook handler — called by Claude Code on UserPromptSubmit. Searches Mengram for relevant context."""
     HOOK = "auto-recall"
@@ -1898,6 +1988,7 @@ def cmd_import(args):
     if not import_type:
         print("Usage: mengram import {claude-code,chatgpt,obsidian,files} <path>")
         print("  mengram import claude-code            # your local Claude Code sessions")
+        print("  mengram import claude-code --memory ./memory   # ...into a local memory folder, no account")
         print("  mengram import chatgpt ~/Downloads/chatgpt-export.zip")
         print("  mengram import obsidian ~/Documents/MyVault")
         print("  mengram import files notes/*.md")
@@ -1906,6 +1997,10 @@ def cmd_import(args):
     # --- Claude Code local transcripts: cloud-first, self-contained flow ---
     if import_type == "claude-code":
         from importer import import_claude_code, discover_claude_code_sessions, RateLimiter
+
+        local_dir = _local_dir(args)
+        if local_dir:
+            sys.exit(_local_import_claude_code(args, local_dir))
 
         api_key = _load_cloud_api_key()
         if not api_key:
@@ -2180,6 +2275,8 @@ def main():
     p_cc.add_argument("--reimport", action="store_true", help="Re-import sessions that were already imported")
     p_cc.add_argument("--yes", action="store_true", help="Skip the confirmation prompt")
     p_cc.add_argument("--user-id", default=None, dest="user_id")
+    p_cc.add_argument("--memory", default=None, metavar="DIR",
+                      help="Import into a local memory folder instead of the cloud (or set MENGRAM_MEMORY_DIR)")
 
     p_chatgpt = import_sub.add_parser("chatgpt", help="Import ChatGPT export ZIP")
     p_chatgpt.add_argument("path", help="Path to ChatGPT export ZIP file")

--- a/importer.py
+++ b/importer.py
@@ -481,17 +481,18 @@ _CC_MIN_SESSION_CHARS = 200
 _CC_MIN_USER_TURNS = 2
 
 
-def _cc_load_state() -> set:
+def _cc_load_state(state_file: Optional[Path] = None) -> set:
     try:
-        return set(json.loads(_CC_STATE_FILE.read_text()))
+        return set(json.loads((state_file or _CC_STATE_FILE).read_text()))
     except Exception:
         return set()
 
 
-def _cc_save_state(imported: set) -> None:
+def _cc_save_state(imported: set, state_file: Optional[Path] = None) -> None:
+    path = state_file or _CC_STATE_FILE
     try:
-        _CC_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        _CC_STATE_FILE.write_text(json.dumps(sorted(imported)))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(sorted(imported)))
     except Exception:
         pass  # state is an optimization, never a blocker
 
@@ -590,6 +591,7 @@ def import_claude_code(
     project_filter: str = "",
     reimport: bool = False,
     on_progress: Optional[Callable] = None,
+    state_file: Optional[Path] = None,
 ) -> ImportResult:
     """
     Import local Claude Code transcripts into memory.
@@ -600,12 +602,15 @@ def import_claude_code(
         project_filter: Only sessions whose project path contains this substring
         reimport: Ignore the already-imported state file
         on_progress: Optional callback(current, total, title)
+        state_file: Where the already-imported session ids live. Defaults to
+            ~/.mengram/claude-code-imported.json (the cloud account); a memory
+            folder keeps its own so the two never skip each other's sessions.
     """
     start = time.time()
     result = ImportResult()
 
     session_files = discover_claude_code_sessions(project_filter)
-    imported_before = set() if reimport else _cc_load_state()
+    imported_before = set() if reimport else _cc_load_state(state_file)
     candidates = [f for f in session_files if Path(f).stem not in imported_before][:last]
     result.conversations_found = len(candidates)
 
@@ -631,7 +636,7 @@ def import_claude_code(
         except Exception as e:
             result.errors.append(f"{Path(path).name}: {e}")
 
-    _cc_save_state(imported_now)
+    _cc_save_state(imported_now, state_file)
     result.entities_created = list(set(result.entities_created))
     result.duration_seconds = time.time() - start
     return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.33.0"
+version = "2.34.0"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -186,3 +186,65 @@ def test_hook_install_without_key_or_folder_points_at_local_mode(monkeypatch, ca
     monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
     code, out, err = _run(monkeypatch, capsys, ["hook", "install"])
     assert code == 1 and "--memory" in err
+
+
+# --- mengram import claude-code --memory DIR (the folder's cold start) --------------
+
+def _fake_sessions(tmp_path, monkeypatch, n=2):
+    """A fake ~/.claude/projects with `n` sessions that pass the importer's thresholds."""
+    import importer
+    projects = tmp_path / "claude-projects"
+    proj = projects / "-Users-me-Projects-shop"
+    proj.mkdir(parents=True)
+    for i in range(n):
+        rows = []
+        for turn in range(3):
+            rows.append({"type": "user", "timestamp": f"2026-09-0{i + 1}T10:0{turn}:00Z",
+                         "message": {"role": "user", "content": f"Session {i}: I deploy the shop backend to Railway "
+                                                                 f"and verify /health after every push, turn {turn}."}})
+            rows.append({"type": "assistant", "timestamp": f"2026-09-0{i + 1}T10:0{turn}:30Z",
+                         "message": {"role": "assistant", "content": [{"type": "text",
+                                     "text": "Pushed to main; Railway built it; /health returned 200 after the pool warmed up."}]}})
+        (proj / f"session-{i}.jsonl").write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    monkeypatch.setattr(importer, "CLAUDE_PROJECTS_DIR", projects)
+    return projects
+
+
+def test_import_claude_code_into_the_folder(folder, tmp_path, monkeypatch, capsys):
+    _fake_sessions(tmp_path, monkeypatch, n=2)
+    code, out, err = _run(monkeypatch, capsys, ["import", "claude-code", "--memory", str(folder), "--yes"])
+    assert code == 0, err
+    assert "Imported:            2" in out and "Folder now holds" in out
+    from local.store import LocalStore
+    assert LocalStore(folder).stats()["entities"] >= 1
+    # the folder keeps its own imported-list, not the cloud account's ~/.mengram file
+    state = folder / ".mengram" / "claude-code-imported.json"
+    assert state.exists() and set(json.loads(state.read_text())) == {"session-0", "session-1"}
+    # a second run finds nothing new; --reimport forces it
+    code, out, _ = _run(monkeypatch, capsys, ["import", "claude-code", "--memory", str(folder), "--yes"])
+    assert code == 0 and "Nothing new" in out
+    code, out, _ = _run(monkeypatch, capsys, ["import", "claude-code", "--memory", str(folder), "--yes", "--reimport"])
+    assert code == 0 and "Imported:            2" in out
+
+
+def test_import_claude_code_respects_last_and_env_folder(folder, tmp_path, monkeypatch, capsys):
+    _fake_sessions(tmp_path, monkeypatch, n=3)
+    monkeypatch.setenv("MENGRAM_MEMORY_DIR", str(folder))
+    code, out, _ = _run(monkeypatch, capsys, ["import", "claude-code", "--yes", "--last", "1"])
+    assert code == 0 and "Imported:            1" in out
+
+
+def test_import_claude_code_without_a_model_says_so(tmp_path, monkeypatch, capsys):
+    _fake_sessions(tmp_path, monkeypatch)
+    root = tmp_path / "m"
+    root.mkdir()
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    code, out, _ = _run(monkeypatch, capsys, ["import", "claude-code", "--memory", str(root), "--yes"])
+    assert code == 2 and "No model configured" in out
+
+
+def test_import_claude_code_needs_an_initialised_folder(tmp_path, monkeypatch, capsys):
+    _fake_sessions(tmp_path, monkeypatch)
+    code, out, _ = _run(monkeypatch, capsys, ["import", "claude-code", "--memory", str(tmp_path / "nope"), "--yes"])
+    assert code == 1 and "mengram local init" in out


### PR DESCRIPTION
## What

`mengram import claude-code --memory ./memory` (or `MENGRAM_MEMORY_DIR`) seeds a local memory folder from the Claude Code sessions already on disk. An empty folder otherwise takes days to fill through the hooks.

- Reuses the existing importer: same session discovery and thresholds, same secret redaction, `--last`, `--project`, `--reimport`, `--yes`.
- Each session is one extraction with the folder's own model via `LocalStore.add`; nothing leaves the machine except those model calls.
- The run ends with what the folder now holds and the workflows it learned, with their reliability.
- The folder keeps its own imported-sessions list in `.mengram/claude-code-imported.json` (`import_claude_code` grew a `state_file` parameter). The cloud account's `~/.mengram/claude-code-imported.json` is untouched, so importing to one never skips sessions for the other.
- Version 2.34.0; CHANGELOG also records the #107 split. README local section gets the line; docs page updated separately (mintlify-docs 5636887).

## Tests

Four new cases in `tests/test_local_cli.py` on a fake `~/.claude/projects` with the mock model: import + state file, nothing-new on rerun, `--reimport`, `--last 1` with the env folder, no model (exit 2), no folder (exit 1). Full suite: 369 passed, 3 pre-existing failures in `tests/test_parser.py::TestParseVault`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt
