### PR TITLE
last_succeeded: when a workflow last worked — folder, map, policy gate (2.36.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.36.0 — 2026-09-07
+
+### Added
+- **`last_succeeded`** — when a workflow last worked. Set only when a
+  successful run is recorded (`mengram local feedback --success`), never by
+  a read, so "unverified for N days" is a fact about runs. Shown by
+  `mengram local procedures` (with days ago), on the memory map (flagged
+  after 30 days), and in the policy gate's plan. Needs memfmt 0.5.2, which
+  adds the field to the format.
+
 ## 2.35.0 — 2026-09-07
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.35.0"
+__version__ = "2.36.0"
 """Mengram — AI memory layer for apps."""

--- a/cloud/policy.py
+++ b/cloud/policy.py
@@ -167,6 +167,8 @@ def _plan(proc: dict, label: str) -> str:
     if proc.get("last_failure"):
         when = f"{proc['last_failed']}: " if proc.get("last_failed") else ""
         lines.append(f"Last failure: {when}{proc['last_failure']}")
+    if proc.get("last_succeeded"):
+        lines.append(f"Last success: {proc['last_succeeded']}")
     lines.append("The evidence for this workflow is weak, so the user was asked to confirm. "
                  "If they decline, show them the plan and what you would verify first.")
     return "\n".join(lines)
@@ -226,6 +228,7 @@ def memfmt_procedures(root: str) -> list[dict]:
             # memfmt 0.5 fields; absent on an older library, and then absent here.
             "last_failure": getattr(p, "last_failure", None),
             "last_failed": getattr(p, "last_failed", None),
+            "last_succeeded": getattr(p, "last_succeeded", None),
             "steps": [
                 {"action": s.action, "detail": s.detail,
                  "success_count": s.success_count, "fail_count": s.fail_count}

--- a/local/cli.py
+++ b/local/cli.py
@@ -132,6 +132,10 @@ def cmd_procedures(args) -> int:
         if p.get("last_failure"):
             when = f"{p['last_failed']}: " if p.get("last_failed") else ""
             print(f"  last failure: {when}{p['last_failure']}")
+        if p.get("last_succeeded"):
+            days = p.get("days_since_success")
+            ago = f" ({days} days ago)" if isinstance(days, int) and days > 0 else ""
+            print(f"  last success: {p['last_succeeded']}{ago}")
     return 0
 
 

--- a/local/map.py
+++ b/local/map.py
@@ -43,6 +43,15 @@ def write_map(store: LocalStore, quarantine: list | None = None, out: Path | Non
 # ---- data ---------------------------------------------------------------------
 
 
+def _days_since(iso_date: str | None) -> int | None:
+    if not iso_date:
+        return None
+    try:
+        return (_dt.date.today() - _dt.date.fromisoformat(str(iso_date)[:10])).days
+    except ValueError:
+        return None
+
+
 def _reliability_word(p) -> str:
     return getattr(p, "reliability", None) or "untested"
 
@@ -148,9 +157,13 @@ def _procedure_card(p) -> str:
     trigger = f'<div class="trigger">When: {_e(p.trigger)}</div>' if p.trigger else ""
     pre = "".join(f'<span class="chip">{_e(x)}</span>' for x in p.preconditions[:6])
     fail = ""
+    if getattr(p, "last_succeeded", None):
+        days = _days_since(p.last_succeeded)
+        stale = f' <span class="stale">unverified for {days} days</span>' if isinstance(days, int) and days >= 30 else ""
+        fail += f'<div class="fail"><b>Last success:</b> {_e(p.last_succeeded)}{stale}</div>'
     if p.last_failure:
         when = f" · {_e(p.last_failed[:10])}" if p.last_failed else ""
-        fail = f'<div class="fail"><b>Last failure{when}:</b> {_e(p.last_failure)}</div>'
+        fail += f'<div class="fail"><b>Last failure{when}:</b> {_e(p.last_failure)}</div>'
     evo = ""
     if p.evolution:
         items = "".join(
@@ -227,7 +240,7 @@ nav.views input{flex:1 1 200px;min-width:160px;padding:8px 12px;border:1px solid
 .step+.step:before{content:"→";position:absolute;left:-14px;top:2px;color:var(--t3)}
 .step .n{flex:0 0 22px;height:22px;border-radius:50%;background:var(--acd);color:var(--ac);font-size:12px;display:grid;place-items:center;font-weight:600}
 .step .act{font-size:13px}.step .detail{font-size:12px;color:var(--t2)}.tag{display:inline-block;margin-top:4px;font-size:11px;padding:1px 8px;border-radius:999px;background:var(--el);border:1px solid var(--bd);color:var(--green)}.tag.dim{color:var(--t3)}
-.fail{margin-top:8px;font-size:13px;color:var(--t2)}.fail b{color:var(--tx)}
+.fail{margin-top:8px;font-size:13px;color:var(--t2)}.fail b{color:var(--tx)}.stale{color:var(--amber);margin-left:6px}
 details{margin-top:8px;font-size:13px;color:var(--t2)}summary{cursor:pointer}.evo{margin:6px 0 0;padding-left:18px}
 .qh{margin:22px 0 10px;font-size:14px}.qh small{color:var(--t2);font-weight:400;margin-left:8px}.quarantine{border-color:rgba(220,38,38,.35)}
 .empty{color:var(--t2);background:var(--card);border:1px dashed var(--bd);border-radius:12px;padding:18px}

--- a/local/store.py
+++ b/local/store.py
@@ -43,6 +43,16 @@ def _today() -> str:
     return _dt.date.today().isoformat()
 
 
+def _days_since(iso_date: str | None) -> int | None:
+    """Whole days since an ISO date, or None when there is none (or it is malformed)."""
+    if not iso_date:
+        return None
+    try:
+        return (_dt.date.today() - _dt.date.fromisoformat(str(iso_date)[:10])).days
+    except ValueError:
+        return None
+
+
 class LocalStore:
     """A memfmt folder with the cloud's rules for changing it."""
 
@@ -292,6 +302,7 @@ class LocalStore:
             "reliability": p.reliability, "trigger_condition": p.trigger,
             "preconditions": list(p.preconditions), "steps": steps,
             "last_failure": p.last_failure, "last_failed": p.last_failed,
+            "last_succeeded": p.last_succeeded, "days_since_success": _days_since(p.last_succeeded),
             "evolution": [{"version_before": r.version_before, "version_after": r.version_after,
                            "reason": r.reason, "date": r.date,
                            "success_count": r.success_count, "fail_count": r.fail_count}
@@ -314,6 +325,7 @@ class LocalStore:
             return {"error": "procedure not found", "name": name}
         if success:
             p.success_count += 1
+            p.last_succeeded = _today()
         else:
             p.fail_count += 1
             if reason:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.35.0"
+version = "2.36.0"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -38,7 +38,7 @@ dependencies = [
     "numpy>=1.24",
     "certifi>=2024.0",
     "mcp==1.28.1",
-    "memfmt>=0.5,<0.6",
+    "memfmt>=0.5.2,<0.6",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_local_map.py
+++ b/tests/test_local_map.py
@@ -120,3 +120,19 @@ def test_import_ends_with_the_map(tmp_path, monkeypatch, capsys):
     monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
     code, out, _ = _run(monkeypatch, capsys, ["import", "claude-code", "--memory", str(root), "--yes"])
     assert code == 0 and "Map of the folder" in out and (root / MAP_FILE).exists()
+
+
+def test_map_shows_last_success_and_flags_staleness(tmp_path):
+    from local.store import LocalStore
+    store = _seeded(tmp_path / "m")
+    p = store.memory.procedures[0]
+    p.last_succeeded = "2026-01-01"          # months ago
+    store.save()
+    html = render_map(LocalStore(tmp_path / "m"), [])
+    assert "Last success:</b> 2026-01-01" in html and "unverified for" in html
+    p = store.memory.procedures[0]
+    import datetime as dt
+    p.last_succeeded = dt.date.today().isoformat()
+    store.save()
+    html = render_map(LocalStore(tmp_path / "m"), [])
+    assert "unverified for" not in html

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -217,3 +217,26 @@ def test_add_extracts_with_the_users_model_and_writes(tmp_path):
     assert stats["entities_created"] >= 1
     assert (tmp_path / "memory" / "MEMORY.md").exists()
     assert store.existing_context().startswith("Known entities")
+
+
+def test_success_writes_last_succeeded_and_failure_does_not(tmp_path):
+    """`last_succeeded` is a fact about runs: set by a recorded success, never by a read."""
+    import datetime as dt
+    from engine.extractor.conversation_extractor import ExtractedProcedure, ExtractionResult
+    from local.store import LocalStore
+    root = tmp_path / "m"
+    root.mkdir()
+    store = LocalStore(root)
+    store.add_extraction(ExtractionResult(procedures=[ExtractedProcedure(
+        "Deploy", "a change lands", [{"action": "push"}, {"action": "verify"}])]))
+    store.save()
+    assert store.procedures()[0]["last_succeeded"] is None
+    store.procedure_feedback("Deploy", False, failed_at_step=2, reason="cold pool")
+    assert LocalStore(root).procedures()[0]["last_succeeded"] is None
+    d = store.procedure_feedback("Deploy", True)
+    assert d["last_succeeded"] == dt.date.today().isoformat() and d["days_since_success"] == 0
+    text = (root / "procedures" / "Deploy.md").read_text() if (root / "procedures" / "Deploy.md").exists() else \
+        "".join(p.read_text() for p in (root / "procedures").glob("*.md"))
+    assert f"last_succeeded: {dt.date.today().isoformat()}" in text
+    # reading the folder again does not move it
+    assert LocalStore(root).procedures()[0]["last_succeeded"] == dt.date.today().isoformat()

--- a/tests/test_policy_hook.py
+++ b/tests/test_policy_hook.py
@@ -243,3 +243,22 @@ def test_upsert_keeps_existing_matcher_on_update():
                              matcher="Bash")
     assert found
     assert settings["hooks"]["PreToolUse"][0]["matcher"] == "Bash|Edit"
+
+
+def test_plan_mentions_the_last_success_when_the_folder_has_it(tmp_path):
+    """The gate's plan tells the agent when the workflow last worked, so a stale
+    workflow reads differently from a fresh one with the same counts."""
+    memfmt = pytest.importorskip("memfmt")
+    if not hasattr(memfmt, "load"):
+        pytest.skip("memfmt namespace shadow")
+    from cloud.policy import memfmt_procedures, decide
+    from memfmt import Memory, Procedure, Step, serialise, write_dir
+    root = tmp_path / "mem"
+    mem = Memory(procedures=[Procedure("Deploy to Railway", trigger="a change lands on main",
+                                       success_count=2, fail_count=1, last_succeeded="2026-06-01",
+                                       steps=[Step("git push origin main"), Step("verify /health")])])
+    write_dir(serialise(mem, root=""), root)
+    procs = memfmt_procedures(root)
+    assert procs and procs[0]["last_succeeded"] == "2026-06-01"
+    out = decide(procs[0], "git push origin main", min_reliable=70)
+    assert out and "Last success: 2026-06-01" in out["plan"]


### PR DESCRIPTION
## What

`last_succeeded` is the staleness signal the local-mode post called out as missing. It is set only when a successful run is recorded (`mengram local feedback --success`), never by a read, so "unverified for N days" is a fact about runs, not about retrieval.

- `LocalStore.procedure_feedback(success=True)` writes it; `procedures()` exposes it plus `days_since_success`.
- `mengram local procedures` prints `last success: <date> (N days ago)`.
- The memory map shows it and flags a workflow unverified for 30+ days.
- The policy gate's plan carries `Last success: <date>` next to the last failure (`cloud/policy.memfmt_procedures` maps the field).
- memfmt 0.5.2 (published) adds the field to the format: frontmatter is the source of truth, the `**Last success**` body line is derived. Pin bumped to `memfmt>=0.5.2,<0.6`.

## Not in this PR

The cloud: the procedures table has no such column, and `last_used` is touched by retrieval, so nothing is derived from it. A migration is a separate change.

## Tests

New: store (success sets it, failure and reads do not, it lands in the file), map (shows it, flags staleness, no flag when fresh), policy (plan mentions it from a memfmt folder). memfmt: 4 new tests, 47 passing. Full suite here: 377 passed, 3 pre-existing failures in `tests/test_parser.py::TestParseVault`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt
