### PR TITLE
cloud: procedures.last_succeeded — set by a successful feedback, never by a read (2.37.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.37.0 — 2026-09-07
+
+### Added
+- **Cloud: `procedures.last_succeeded`** (migration v2.23, no backfill). Set
+  only by a successful `PATCH /v1/procedures/{id}/feedback`, never by
+  retrieval. Returned by `/v1/procedures`, procedure search, the connector's
+  `list_procedures`, and written into `mengram export markdown` as
+  `last_succeeded` + `**Last success**`, so the cloud and the folder now carry
+  the same staleness signal.
+
 ## 2.36.0 — 2026-09-07
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.36.0"
+__version__ = "2.37.0"
 """Mengram — AI memory layer for apps."""

--- a/api/cloud_mcp_server.py
+++ b/api/cloud_mcp_server.py
@@ -137,6 +137,8 @@ def create_cloud_mcp_server(
                 lines.append(f"ID: `{p['id']}`")
                 if p.get("trigger_condition"):
                     lines.append(f"**When:** {p['trigger_condition']}")
+                if p.get("last_succeeded"):
+                    lines.append(f"**Last success:** {str(p['last_succeeded'])[:10]}")
                 if total > 0:
                     lines.append(f"**Stats:** {sc} successes, {fc} failures")
                 for s in p.get("steps", []):
@@ -979,6 +981,8 @@ def create_cloud_mcp_server(
                     lines.append(f"ID: `{p['id']}`")
                     if p.get("trigger_condition"):
                         lines.append(f"When: {p['trigger_condition']}")
+                    if p.get("last_succeeded"):
+                        lines.append(f"Last success: {str(p['last_succeeded'])[:10]}")
                     if total > 0:
                         lines.append(f"Stats: {sc} successes, {fc} failures")
                     for s in p.get("steps", []):

--- a/cloud/markdown_export.py
+++ b/cloud/markdown_export.py
@@ -223,6 +223,7 @@ def procedure_file(procedure: dict, evolution: list = None) -> str:
             "fail_count": fail,
             "last_failure": last_failure,
             "last_failed": last_failed,
+            "last_succeeded": _day(procedure.get("last_succeeded")) or None,
         }),
         "",
         f"# {name} (v{version} · {_reliability_estimate(success, fail, _prior(evolution))})",
@@ -240,6 +241,8 @@ def procedure_file(procedure: dict, evolution: list = None) -> str:
     if last_failure:
         when = f"{last_failed}: " if last_failed else ""
         body += ["", f"**Last failure** — {when}{last_failure}"]
+    if _day(procedure.get("last_succeeded")):
+        body += ["", f"**Last success** — {_day(procedure.get('last_succeeded'))}"]
 
     steps = procedure.get("steps") or []
     if steps:

--- a/cloud/policy.py
+++ b/cloud/policy.py
@@ -168,7 +168,7 @@ def _plan(proc: dict, label: str) -> str:
         when = f"{proc['last_failed']}: " if proc.get("last_failed") else ""
         lines.append(f"Last failure: {when}{proc['last_failure']}")
     if proc.get("last_succeeded"):
-        lines.append(f"Last success: {proc['last_succeeded']}")
+        lines.append(f"Last success: {str(proc['last_succeeded'])[:10]}")
     lines.append("The evidence for this workflow is weak, so the user was asked to confirm. "
                  "If they decline, show them the plan and what you would verify first.")
     return "\n".join(lines)

--- a/cloud/store/_core.py
+++ b/cloud/store/_core.py
@@ -970,6 +970,19 @@ class CoreMixin:
             """)
         logger.info("✅ Migration complete (v2.22: memory health tracking)")
 
+        # ---- v2.23: last_succeeded — when a workflow last worked ----
+        # Written only by a successful procedure_feedback, never by retrieval
+        # (last_used is touched by search, so "unverified for N days" cannot
+        # be derived from it). No backfill: NULL means no success was recorded
+        # since the column existed, not that the workflow never worked. Same
+        # field as memfmt 0.5.2 and the local folder (2.36.0).
+        with self._cursor() as cur:
+            cur.execute("""
+                ALTER TABLE procedures
+                ADD COLUMN IF NOT EXISTS last_succeeded TIMESTAMPTZ
+            """)
+        logger.info("✅ Migration complete (v2.23: procedures.last_succeeded)")
+
         with self._cursor() as cur:
             cur.execute("SELECT pg_advisory_unlock(42)")
 

--- a/cloud/store/_procedures.py
+++ b/cloud/store/_procedures.py
@@ -13,6 +13,11 @@ from ._common import (  # noqa: F401
 )
 
 
+def _iso(value):
+    """ISO string for a timestamp column, None for NULL. Dict-cursor rows may lack the key on old fixtures."""
+    return value.isoformat() if hasattr(value, "isoformat") else (value or None)
+
+
 class ProcedureMixin:
     """Procedural memory: versions, feedback, evolution, regression gate."""
 
@@ -209,7 +214,7 @@ class ProcedureMixin:
         with self._cursor(dict_cursor=True) as cur:
             cur.execute(
                 """SELECT id, name, trigger_condition, steps, entity_names,
-                          success_count, fail_count, last_used, version,
+                          success_count, fail_count, last_used, last_succeeded, version,
                           created_at, updated_at, metadata
                    FROM procedures
                    WHERE user_id = %s AND sub_user_id = %s
@@ -236,6 +241,7 @@ class ProcedureMixin:
                                             row["fail_count"] or 0),
                     "version": row["version"] or 1,
                     "last_used": row["last_used"].isoformat() if row["last_used"] else None,
+                    "last_succeeded": _iso(row.get("last_succeeded")),
                     "created_at": row["created_at"].isoformat() if row["created_at"] else None,
                     "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
                     "metadata": row.get("metadata") or {},
@@ -268,7 +274,7 @@ class ProcedureMixin:
             query_text = query_text.replace("\x00", "")
         query = f"""
             SELECT p.id, p.name, p.trigger_condition, p.steps, p.entity_names,
-                   p.success_count, p.fail_count, p.last_used, p.version, p.updated_at, p.metadata,
+                   p.success_count, p.fail_count, p.last_used, p.last_succeeded, p.version, p.updated_at, p.metadata,
                    1 - (pe.{emb_col} <=> %s::vector) AS score
             FROM procedure_embeddings pe
             JOIN procedures p ON p.id = pe.procedure_id
@@ -316,7 +322,7 @@ class ProcedureMixin:
                     if pid not in vec_rows:
                         cur.execute("""
                             SELECT p.id, p.name, p.trigger_condition, p.steps, p.entity_names,
-                                   p.success_count, p.fail_count, p.last_used, p.version, p.updated_at, p.metadata
+                                   p.success_count, p.fail_count, p.last_used, p.last_succeeded, p.version, p.updated_at, p.metadata
                             FROM procedures p WHERE p.id = %s
                         """, (pid,))
                         r = cur.fetchone()
@@ -377,6 +383,7 @@ class ProcedureMixin:
                     "reliability": estimate(s_count, f_count),
                     "version": row.get("version") or 1,
                     "last_used": last_used.isoformat() if last_used else None,
+                    "last_succeeded": _iso(row.get("last_succeeded")),
                     "score": final_score,
                     "updated_at": row["updated_at"].isoformat() if row.get("updated_at") else None,
                     "metadata": row.get("metadata") or {},
@@ -400,7 +407,7 @@ class ProcedureMixin:
             query = query.replace("\x00", "")
         sql = """
             SELECT p.id, p.name, p.trigger_condition, p.steps, p.entity_names,
-                   p.success_count, p.fail_count, p.last_used, p.version, p.updated_at, p.metadata,
+                   p.success_count, p.fail_count, p.last_used, p.last_succeeded, p.version, p.updated_at, p.metadata,
                    ts_rank_cd(pe.tsv, plainto_tsquery('english', %s), 32) AS score
             FROM procedure_embeddings pe
             JOIN procedures p ON p.id = pe.procedure_id
@@ -435,6 +442,7 @@ class ProcedureMixin:
                                             row["fail_count"] or 0),
                     "version": row["version"] or 1,
                     "last_used": row["last_used"].isoformat() if row.get("last_used") else None,
+                    "last_succeeded": _iso(row.get("last_succeeded")),
                     "score": round(float(row["score"]), 4),
                     "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
                     "metadata": row.get("metadata") or {},
@@ -453,6 +461,8 @@ class ProcedureMixin:
                            sub_user_id: str = "default", failed_at_step: int = None) -> dict:
         """Record success/failure feedback for a procedure and for its steps."""
         col = "success_count" if success else "fail_count"
+        # A success is the only thing that moves last_succeeded — never a read.
+        mark = ", last_succeeded = NOW()" if success else ""
         with self._cursor(dict_cursor=True) as cur:
             cur.execute(
                 """SELECT steps FROM procedures
@@ -467,9 +477,9 @@ class ProcedureMixin:
             cur.execute(
                 f"""UPDATE procedures
                     SET {col} = {col} + 1, steps = %s::jsonb,
-                        last_used = NOW(), updated_at = NOW()
+                        last_used = NOW(), updated_at = NOW(){mark}
                     WHERE id = %s AND user_id = %s AND sub_user_id = %s
-                    RETURNING id, name, success_count, fail_count, steps""",
+                    RETURNING id, name, success_count, fail_count, steps, last_succeeded""",
                 (json.dumps(steps), procedure_id, user_id, sub_user_id)
             )
             row = cur.fetchone()
@@ -479,6 +489,7 @@ class ProcedureMixin:
                 "success_count": row["success_count"],
                 "fail_count": row["fail_count"],
                 "steps": row["steps"],
+                "last_succeeded": _iso(row.get("last_succeeded")),
                 "feedback": "success" if success else "failure",
             }
 
@@ -492,7 +503,7 @@ class ProcedureMixin:
             cur.execute(
                 """SELECT id, name, trigger_condition, steps, entity_names,
                           success_count, fail_count, version, parent_version_id,
-                          evolved_from_episode, is_current, last_used,
+                          evolved_from_episode, is_current, last_used, last_succeeded,
                           created_at, updated_at, metadata
                    FROM procedures
                    WHERE id = %s AND user_id = %s AND sub_user_id = %s""",
@@ -514,6 +525,7 @@ class ProcedureMixin:
                 "evolved_from_episode": str(row["evolved_from_episode"]) if row["evolved_from_episode"] else None,
                 "is_current": row["is_current"],
                 "last_used": row["last_used"].isoformat() if row["last_used"] else None,
+                "last_succeeded": _iso(row.get("last_succeeded")),
                 "created_at": row["created_at"].isoformat() if row["created_at"] else None,
                 "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
                 "metadata": row.get("metadata") or {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.36.0"
+version = "2.37.0"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_last_succeeded_cloud.py
+++ b/tests/test_last_succeeded_cloud.py
@@ -1,0 +1,84 @@
+"""procedures.last_succeeded in the cloud store: moved only by a recorded success.
+
+Hermetic: CloudStore is built without __init__ and given a stub cursor, the same
+way the other store tests do it, so the assertions are about the SQL we send.
+"""
+
+import contextlib
+import datetime
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from cloud.store import CloudStore  # noqa: E402
+from cloud.markdown_export import procedure_file  # noqa: E402
+
+
+class _FakeCursor:
+    def __init__(self, fetchone_results=None):
+        self._ones = list(fetchone_results or [])
+        self.sql = []
+
+    def execute(self, sql, params=None):
+        self.sql.append(" ".join(sql.split()))
+
+    def fetchone(self):
+        return self._ones.pop(0) if self._ones else None
+
+    def fetchall(self):
+        return []
+
+
+def _store(cursor):
+    store = CloudStore.__new__(CloudStore)
+
+    @contextlib.contextmanager
+    def _cursor(dict_cursor=False):
+        yield cursor
+
+    store._cursor = _cursor
+    return store
+
+
+NOW = datetime.datetime(2026, 9, 7, 12, 0, tzinfo=datetime.timezone.utc)
+
+
+def test_success_sets_last_succeeded_in_the_same_update():
+    cur = _FakeCursor([{"steps": [{"action": "push"}]},
+                       {"id": "p1", "name": "Deploy", "success_count": 1, "fail_count": 0,
+                        "steps": [], "last_succeeded": NOW}])
+    out = _store(cur).procedure_feedback("u", "p1", True)
+    update = cur.sql[-1]
+    assert "success_count = success_count + 1" in update
+    assert "last_succeeded = NOW()" in update and "RETURNING" in update and "last_succeeded" in update.split("RETURNING")[1]
+    assert out["last_succeeded"] == NOW.isoformat()
+
+
+def test_failure_leaves_last_succeeded_alone():
+    cur = _FakeCursor([{"steps": [{"action": "push"}]},
+                       {"id": "p1", "name": "Deploy", "success_count": 0, "fail_count": 1,
+                        "steps": [], "last_succeeded": None}])
+    out = _store(cur).procedure_feedback("u", "p1", False, failed_at_step=1)
+    update = cur.sql[-1]
+    assert "fail_count = fail_count + 1" in update and "last_succeeded = NOW()" not in update
+    assert out["last_succeeded"] is None
+
+
+def test_migration_adds_the_column_without_a_backfill():
+    src = (Path(__file__).parent.parent / "cloud" / "store" / "_core.py").read_text()
+    block = src.split("v2.23")[1]
+    assert "ADD COLUMN IF NOT EXISTS last_succeeded TIMESTAMPTZ" in block
+    assert "UPDATE procedures SET last_succeeded" not in src  # never derived from last_used
+
+
+def test_export_writes_last_succeeded_as_a_date_and_a_body_line():
+    out = procedure_file({"id": "p1", "name": "Deploy", "success_count": 3, "fail_count": 0,
+                          "version": 1, "steps": [{"action": "push"}],
+                          "last_succeeded": "2026-09-07T12:00:00+00:00"})
+    assert "last_succeeded: 2026-09-07" in out and "**Last success** — 2026-09-07" in out
+
+
+def test_export_stays_silent_without_it():
+    out = procedure_file({"id": "p1", "name": "Deploy", "success_count": 3, "fail_count": 0,
+                          "version": 1, "steps": [{"action": "push"}]})
+    assert "last_succeeded" not in out and "Last success" not in out


### PR DESCRIPTION
## What

The cloud half of `last_succeeded` (folder + memfmt landed in #110).

- **Migration v2.23**: `ALTER TABLE procedures ADD COLUMN IF NOT EXISTS last_succeeded TIMESTAMPTZ`. No backfill: `last_used` is touched by search, so nothing honest can be derived from it. NULL means no success was recorded since the column existed.
- `procedure_feedback(success=True)` sets `last_succeeded = NOW()` in the same UPDATE; a failure leaves it alone.
- Returned by `get_procedures`, both procedure searches, `get_procedure_by_id`, and the feedback response (so `PATCH /v1/procedures/{id}/feedback`, `/v1/procedures`, `/v1/procedures/search` and the MCP tools carry it).
- `mengram export markdown` writes `last_succeeded: <date>` + `**Last success**`, the same shape as memfmt 0.5.2 and the folder.
- Connector `list_procedures` prints `Last success: <date>`; the policy plan trims the timestamp to the date.

## Deploy note

The migration runs at boot under the existing advisory lock, like v2.22. Additive column, idempotent. Existing rows stay NULL until their next successful feedback.

## Tests

`tests/test_last_succeeded_cloud.py`: success sets it in the UPDATE and returns it; failure does not touch it; migration text is additive with no backfill; export writes the date and body line, or stays silent. Full suite: 382 passed, 3 pre-existing failures in `tests/test_parser.py::TestParseVault`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt
