### PR TITLE
anthropic SDK 1.x and Claude 5: no temperature, read text blocks, missing-SDK hint (2.37.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.37.1 — 2026-09-07
+
+### Fixed
+- Anthropic extraction failed on `anthropic>=1.0` with
+  `Messages.create() got an unexpected keyword argument 'temperature'` — the
+  SDK dropped the parameter. Not sent any more. Found on the first real
+  `mengram import claude-code --memory` run.
+- A folder configured for a provider whose SDK is not installed now says
+  `pip install 'mengram-ai[anthropic]'` (or `[openai]`) instead of a
+  traceback, from `local add`, `local feedback` and `import claude-code`.
+
 ## 2.37.0 — 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   `Messages.create() got an unexpected keyword argument 'temperature'` — the
   SDK dropped the parameter. Not sent any more. Found on the first real
   `mengram import claude-code --memory` run.
+- Claude 5 models return a thinking block first; `content[0].text` raised
+  `AttributeError: 'ThinkingBlock' object has no attribute 'text'` and every
+  extraction fell back and failed. The text blocks are read now.
 - A folder configured for a provider whose SDK is not installed now says
   `pip install 'mengram-ai[anthropic]'` (or `[openai]`) instead of a
   traceback, from `local add`, `local feedback` and `import claude-code`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Claude 5 models return a thinking block first; `content[0].text` raised
   `AttributeError: 'ThinkingBlock' object has no attribute 'text'` and every
   extraction fell back and failed. The text blocks are read now.
+- Thinking counts against `max_tokens`; at 4096 the visible JSON was cut
+  mid-object ("Failed to parse JSON from LLM"). The Anthropic client now
+  asks for 16384.
 - A folder configured for a provider whose SDK is not installed now says
   `pip install 'mengram-ai[anthropic]'` (or `[openai]`) instead of a
   traceback, from `local add`, `local feedback` and `import claude-code`.

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.37.0"
+__version__ = "2.37.1"
 """Mengram — AI memory layer for apps."""

--- a/cli.py
+++ b/cli.py
@@ -431,7 +431,11 @@ def _local_import_claude_code(args, local_dir) -> int:
     if not local_dir.is_dir():
         print(f"❌ No memory folder at {local_dir} — run: mengram local init {local_dir}")
         return 1
-    client = llm_client(local_dir)
+    try:
+        client = llm_client(local_dir)
+    except ImportError as e:
+        print(f"❌ {e}")
+        return 2
     if client is None:
         print("❌ No model configured — extraction needs one.\n"
               f"   mengram local init {local_dir} --provider anthropic --api-key sk-ant-...   (or openai / ollama)\n"

--- a/engine/extractor/llm_client.py
+++ b/engine/extractor/llm_client.py
@@ -30,6 +30,14 @@ class LLMClient(ABC):
         return self.complete(last_user, system=system)
 
 
+def _anthropic_text(response) -> str:
+    """The text of a Messages response. Claude 5 models put a ThinkingBlock
+    first, so `content[0].text` raises; join the text blocks instead."""
+    parts = [getattr(b, "text", "") for b in (getattr(response, "content", None) or [])
+             if getattr(b, "type", "") == "text" or (hasattr(b, "text") and not hasattr(b, "thinking"))]
+    return "\n".join(p for p in parts if p)
+
+
 class AnthropicClient(LLMClient):
     """Claude via Anthropic API"""
 
@@ -50,7 +58,7 @@ class AnthropicClient(LLMClient):
             system=system or "You are a knowledge extraction assistant.",
             messages=[{"role": "user", "content": prompt}],
         )
-        return response.content[0].text
+        return _anthropic_text(response)
 
     def chat(self, messages: list[dict], system: str = "") -> str:
         response = self.client.messages.create(
@@ -59,7 +67,7 @@ class AnthropicClient(LLMClient):
             system=system or "You are a helpful assistant.",
             messages=messages,
         )
-        return response.content[0].text
+        return _anthropic_text(response)
 
 
 class OpenAIClient(LLMClient):

--- a/engine/extractor/llm_client.py
+++ b/engine/extractor/llm_client.py
@@ -42,10 +42,11 @@ class AnthropicClient(LLMClient):
         self.model = model
 
     def complete(self, prompt: str, system: str = "", response_format=None) -> str:
+        # No `temperature`: the anthropic SDK dropped it in 1.x (Messages.create()
+        # rejects the keyword), and Claude 5 models ignore it anyway.
         response = self.client.messages.create(
             model=self.model,
             max_tokens=4096,
-            temperature=0.2,
             system=system or "You are a knowledge extraction assistant.",
             messages=[{"role": "user", "content": prompt}],
         )

--- a/engine/extractor/llm_client.py
+++ b/engine/extractor/llm_client.py
@@ -54,7 +54,9 @@ class AnthropicClient(LLMClient):
         # rejects the keyword), and Claude 5 models ignore it anyway.
         response = self.client.messages.create(
             model=self.model,
-            max_tokens=4096,
+            # Claude 5 thinks first and the thinking counts against max_tokens:
+            # at 4096 the visible JSON was cut mid-object. Give it room.
+            max_tokens=16384,
             system=system or "You are a knowledge extraction assistant.",
             messages=[{"role": "user", "content": prompt}],
         )
@@ -63,7 +65,7 @@ class AnthropicClient(LLMClient):
     def chat(self, messages: list[dict], system: str = "") -> str:
         response = self.client.messages.create(
             model=self.model,
-            max_tokens=4096,
+            max_tokens=16384,
             system=system or "You are a helpful assistant.",
             messages=messages,
         )

--- a/local/cli.py
+++ b/local/cli.py
@@ -79,7 +79,11 @@ def cmd_add(args) -> int:
     if not text.strip():
         print("nothing to add (pass text, or --stdin)", file=sys.stderr)
         return 1
-    client = llm_client(store.root)
+    try:
+        client = llm_client(store.root)
+    except ImportError as e:
+        print(str(e), file=sys.stderr)
+        return 2
     if client is None:
         print("no model configured — extraction needs one.\n"
               "  mengram local init --provider anthropic --api-key sk-ant-...   (or openai / ollama)\n"
@@ -151,7 +155,11 @@ def cmd_feedback(args) -> int:
           f"{result['reliability']}")
     if success or not args.context:
         return 0
-    client = llm_client(store.root)
+    try:
+        client = llm_client(store.root)
+    except ImportError as e:
+        print(str(e), file=sys.stderr)
+        return 2
     if client is None:
         print("failure recorded; no model configured, so the workflow was not revised "
               "(set one to let a failure produce a new version)", file=sys.stderr)

--- a/local/config.py
+++ b/local/config.py
@@ -71,7 +71,12 @@ def llm_client(root: Path):
         from engine.extractor.conversation_extractor import MockLLMClient
         return MockLLMClient()
     from engine.extractor.llm_client import create_llm_client
-    return create_llm_client(cfg)
+    try:
+        return create_llm_client(cfg)
+    except ImportError as e:
+        provider = cfg.get("provider", "anthropic")
+        raise ImportError(
+            f"the '{provider}' provider needs its SDK — pip install 'mengram-ai[{provider}]'  ({e})") from e
 
 
 def describe_model(root: Path) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.37.0"
+version = "2.37.1"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_llm_client_anthropic.py
+++ b/tests/test_llm_client_anthropic.py
@@ -1,0 +1,35 @@
+"""AnthropicClient against SDK 1.x response shapes: a ThinkingBlock may come first."""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from engine.extractor.llm_client import _anthropic_text, AnthropicClient  # noqa: E402
+
+
+def test_text_is_taken_from_text_blocks_not_the_thinking_block():
+    resp = SimpleNamespace(content=[
+        SimpleNamespace(type="thinking", thinking="let me think"),
+        SimpleNamespace(type="text", text='{"entities": []}'),
+    ])
+    assert _anthropic_text(resp) == '{"entities": []}'
+
+
+def test_plain_text_only_response_still_works():
+    resp = SimpleNamespace(content=[SimpleNamespace(type="text", text="OK")])
+    assert _anthropic_text(resp) == "OK"
+
+
+def test_complete_does_not_send_temperature(monkeypatch):
+    calls = {}
+
+    class _Messages:
+        def create(self, **kw):
+            calls.update(kw)
+            return SimpleNamespace(content=[SimpleNamespace(type="text", text="hi")])
+
+    c = AnthropicClient.__new__(AnthropicClient)
+    c.client = SimpleNamespace(messages=_Messages())
+    c.model = "claude-sonnet-5"
+    assert c.complete("x") == "hi"
+    assert "temperature" not in calls and calls["model"] == "claude-sonnet-5"

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -248,3 +248,17 @@ def test_import_claude_code_needs_an_initialised_folder(tmp_path, monkeypatch, c
     _fake_sessions(tmp_path, monkeypatch)
     code, out, _ = _run(monkeypatch, capsys, ["import", "claude-code", "--memory", str(tmp_path / "nope"), "--yes"])
     assert code == 1 and "mengram local init" in out
+
+
+def test_missing_provider_sdk_is_a_one_line_hint_not_a_traceback(tmp_path, monkeypatch, capsys):
+    """`local init --provider anthropic` on a bare install: the SDK is an extra."""
+    import engine.extractor.llm_client as llm
+    root = tmp_path / "m"
+    root.mkdir()
+    write_config(root, {"llm": {"provider": "anthropic", "anthropic": {"api_key": "sk-ant-x"}}})
+    monkeypatch.setattr(llm, "create_llm_client", lambda cfg: (_ for _ in ()).throw(ImportError("pip install anthropic")))
+    code, out, err = _run(monkeypatch, capsys, ["local", "add", "hello", "--memory", str(root)])
+    assert code == 2 and "mengram-ai[anthropic]" in err
+    _fake_sessions(tmp_path, monkeypatch)
+    code, out, err = _run(monkeypatch, capsys, ["import", "claude-code", "--memory", str(root), "--yes"])
+    assert code == 2 and "mengram-ai[anthropic]" in out


### PR DESCRIPTION
## What

Found on the first real `mengram import claude-code --memory` run with `claude-sonnet-5` on `anthropic 1.4.0`:

- `Messages.create()` no longer accepts `temperature` — every extraction raised `TypeError`. Not sent any more.
- Claude 5 returns a `ThinkingBlock` first, so `content[0].text` raised `AttributeError` and the structured-output fallback failed the same way. `_anthropic_text` joins the text blocks.
- A folder configured for a provider whose SDK extra is not installed printed a traceback ending in `pip install anthropic`. Now one line: `pip install 'mengram-ai[anthropic]'`, exit 2, from `local add`, `local feedback` and `import claude-code`.

## Tests

`tests/test_llm_client_anthropic.py` (3, SDK 1.x response shapes, no temperature sent) and one case in `tests/test_local_cli.py`. Full suite: 386 passed, 3 pre-existing failures in `tests/test_parser.py::TestParseVault`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt