### PR TITLE
feat(extractor): add opt-in slim prompt and small-model eval gates

### DIFF
--- a/engine/extractor/conversation_extractor.py
+++ b/engine/extractor/conversation_extractor.py
@@ -355,6 +355,29 @@ CONVERSATION:
 Extract knowledge (return ONLY JSON):"""
 
 
+EXTRACTION_PROMPT_SLIM = """Extract durable memories supported by the conversation, from the User's perspective.
+Return only one complete JSON object, no markdown fences or commentary, with all five arrays: entities, relations, knowledge, episodes, procedures. Use empty arrays when unsupported. Never copy instruction examples or invent missing details.
+
+Attribute personal statements to their speaker, not mentioned third parties. Use the User's stated name, otherwise User. Never infer identity from URLs, repositories or usernames. Keep each person's facts separate and project facts on projects. Extract stated work activities and tools even without an explicit "I" pronoun. Ignore assistant explanations, searches and tool outputs unless the User confirms personal relevance. Ignore greetings, filler, requests without personal information, and transient moods.
+
+Preserve every supported claim, including established facts, tools used at work, reasons, specific names, quantities and dates. Split independent clauses into separate entity facts, including incidental tool use; do not store facts only in episodes. A topic change does not cancel earlier facts. Reuse existing entity names and casing; skip facts already stored. Record explicit changes: mark replaced tools as "no longer used" wherever mentioned, including episode summaries, and keep the new state current. Choosing one tool over another does not imply prior use. Resolve relative dates only with sufficient date context; otherwise use null. Treat shared image descriptions as evidence with the surrounding conversation.
+{existing_context}
+Use these exact field names and types (this is a type contract, not memories):
+entities: [{{name: string, type: string, facts: [{{fact: string, when: string|null}}]}}]
+relations: [{{from: string, to: string, type: string, description: string}}]
+knowledge: [{{entity: string, type: string, title: string, content: string, artifact: string|null}}]
+episodes: [{{summary: string, context: string, outcome: string, participants: [string], emotional_valence: string, importance: number, happened_at: string|null}}]
+procedures: [{{name: string, trigger: string, steps: [{{step: integer, action: string, detail: string}}], entities: [string]}}]
+Knowledge captures useful confirmed solutions and exact code/commands; type is solution, formula, command, insight, decision, recipe or reference.
+Episodes capture real events, never introductions or information sharing in this chat. Emotional_valence is positive, negative, neutral or mixed; importance is 0 to 1.
+Procedures require at least two explicitly described concrete actions in a repeatable sequence. Read the entire conversation and combine steps across messages into one ordered workflow. Keep every step, including implicit sequences. Do not invent steps from occupations, hobbies or equipment. Do not omit workflows to shorten output.
+Keep output concise without dropping supported memory types; finish every JSON array and object.
+
+CONVERSATION:
+{conversation}
+"""
+
+
 EXISTING_CONTEXT_BLOCK = """
 EXISTING ENTITIES FOR THIS USER (use same names, avoid duplicate facts):
 {context}
@@ -693,7 +716,8 @@ class ConversationExtractor:
             context_block = ""
 
         version = prompt_version or EXTRACTION_PROMPT_VERSION
-        prompt_template = EXTRACTION_PROMPT_V2 if version == "v2" else EXTRACTION_PROMPT
+        prompt_template = {"v1": EXTRACTION_PROMPT, "v2": EXTRACTION_PROMPT_V2,
+                           "slim": EXTRACTION_PROMPT_SLIM}.get(version, EXTRACTION_PROMPT)
         prompt = prompt_template.format(
             conversation=conv_text,
             existing_context=context_block

--- a/evals/extraction_cases.yaml
+++ b/evals/extraction_cases.yaml
@@ -1,7 +1,9 @@
 # Golden extraction cases — every real bug or user complaint becomes a case here, forever.
 #
 # Contract per case:
-#   conversation:      [{role, content}] fed to ConversationExtractor.extract (prompt v2)
+#   conversation:      [{role, content}] fed to ConversationExtractor.extract (selected prompt)
+#   require_complete_json: raw response must validate against EXTRACTION_SCHEMA (no parser recovery)
+#   expect_nonempty_types: output collections that must contain memories
 #   must_extract:      keywords that MUST appear in extracted facts (case-insensitive, all required)
 #   must_not_extract:  keywords that must NOT appear in any fact/episode/procedure
 #   expect_procedure:  name-keyword + min_steps when a workflow must be captured
@@ -10,6 +12,45 @@
 # Sources: #54 reflection pollution, supersession bug (Apr 2026), capture-boundary
 # churn case (mark@mb3, Jul 2026), v2 prompt spec (assistant-noise filtering),
 # ExtractedProcedure.steps list[dict] regression.
+
+- id: small-model-example-bleed-through
+  note: "#7: ten-message conversation must not inherit deployment-example memories from the prompt"
+  conversation:
+    - {role: user, content: "My name is Nora Bell. I am a ceramicist."}
+    - {role: assistant, content: "What are you working on?"}
+    - {role: user, content: "A series of cobalt blue bowls."}
+    - {role: assistant, content: "Where do you make them?"}
+    - {role: user, content: "At Cedar Studio in Bristol."}
+    - {role: assistant, content: "Do you teach there?"}
+    - {role: user, content: "Yes, I teach pottery every Saturday."}
+    - {role: assistant, content: "What equipment do you use?"}
+    - {role: user, content: "An electric kiln. My next exhibition opens on 2026-10-12."}
+    - {role: assistant, content: "Good luck with the exhibition."}
+  must_extract: ["cobalt", "cedar", "bristol", "saturday"]
+  must_not_extract: ["railway", "supabase", "postgresql", "deployed mengram"]
+  expect_attribution:
+    - entity_keyword: "Nora"
+      must_have: ["cobalt", "saturday"]
+  require_complete_json: true
+
+- id: small-model-complete-json-with-workflow
+  note: "#7: require complete raw JSON and all five types; silently returning an empty parse must fail. Run on a small model to measure truncation, not just on a large model."
+  conversation:
+    - {role: user, content: "I am Nora Bell, release engineer for the Cedar project."}
+    - {role: assistant, content: "What happened during the release?"}
+    - {role: user, content: "On 2026-09-01 the Cedar deploy failed because its migrations were missing."}
+    - {role: assistant, content: "How did you resolve it?"}
+    - {role: user, content: "I restored service by running the migration command cedar migrate before retrying. That is our confirmed solution for this failure."}
+    - {role: assistant, content: "What is your release workflow now?"}
+    - {role: user, content: "For every Cedar release, first run cedar migrate --check, then back up the database, then run cedar migrate."}
+    - {role: assistant, content: "What follows the migration?"}
+    - {role: user, content: "Then deploy to staging, run smoke tests, and promote to production only if they pass. I own this release workflow."}
+    - {role: assistant, content: "Understood."}
+  must_extract: ["cedar", "migrat", "smoke"]
+  expect_episode_keyword: "cedar"
+  expect_procedure: {name_keyword: "release", min_steps: 6}
+  expect_nonempty_types: [entities, relations, knowledge, episodes, procedures]
+  require_complete_json: true
 
 - id: assistant-noise-filtered
   note: "v2 prompt spec: assistant chatter must not become user facts"

--- a/evals/run_extraction_evals.py
+++ b/evals/run_extraction_evals.py
@@ -2,7 +2,7 @@
 """Extraction quality evals — the boring moat.
 
 Runs golden cases from extraction_cases.yaml through the real
-ConversationExtractor (same construction path as cloud/api.py) and checks
+ConversationExtractor and provider clients, with eval-specific model settings, and checks
 expectations. Every real user complaint becomes a case; this suite must pass
 before any change to extraction prompts ships.
 
@@ -13,26 +13,31 @@ Usage:
 Exit code 0 = all pass.
 """
 import argparse
+import json
 import os
 import sys
+from dataclasses import asdict
 from pathlib import Path
 
 import yaml
+from jsonschema import ValidationError, validate
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from engine.extractor.llm_client import create_llm_client
-from engine.extractor.conversation_extractor import ConversationExtractor
+from engine.extractor.conversation_extractor import ConversationExtractor, EXTRACTION_SCHEMA
 
 
 def build_extractor() -> ConversationExtractor:
-    """Mirror cloud/api.py's construction exactly — evals must test prod's path."""
+    """Use the production factory; model/endpoint selection belongs to this harness."""
     llm_model = os.environ.get("LLM_MODEL", "")
     config = {
         "provider": os.environ.get("LLM_PROVIDER", "openai"),
         "anthropic": {"api_key": os.environ.get("ANTHROPIC_API_KEY", ""),
                       **({"model": llm_model} if llm_model else {})},
         "openai": {"api_key": os.environ.get("OPENAI_API_KEY", ""),
+                   **({"model": llm_model} if llm_model else {})},
+        "ollama": {"base_url": os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434"),
                    **({"model": llm_model} if llm_model else {})},
     }
     return ConversationExtractor(create_llm_client(config))
@@ -60,22 +65,37 @@ def everything_text(result) -> str:
     return " \n ".join(parts)
 
 
-def run_case(extractor, case, verbose=False):
+def run_case(extractor, case, verbose=False, prompt_version="v2"):
     failures = []
     result = extractor.extract(
         case["conversation"],
         existing_context=case.get("existing_context", ""),
-        prompt_version="v2",
+        prompt_version=prompt_version,
     )
     facts = all_fact_text(result)
     everything = everything_text(result)
+    extracted_text = json.dumps({k: v for k, v in asdict(result).items()
+                                 if k != "raw_response"}, ensure_ascii=False).lower()
+    if case.get("require_complete_json"):
+        try:
+            raw = json.loads(result.raw_response)
+            validate(raw, EXTRACTION_SCHEMA["json_schema"]["schema"])
+        except (ValueError, TypeError):
+            failures.append("incomplete or invalid JSON response")
+        except ValidationError as e:
+            failures.append(f"JSON schema violation: {e.message}")
+    for key in case.get("expect_nonempty_types", []):
+        if not getattr(result, key):
+            failures.append(f"missing output type: {key}")
 
     if verbose:
         print(f"    entities={[(e.name, len(e.facts)) for e in result.entities]}")
         print(f"    episodes={len(result.episodes)} procedures={len(result.procedures)}")
+        print(f"    raw_response={result.raw_response!r}")
 
     if case.get("expect_no_output"):
-        n = sum(len(e.facts) for e in result.entities) + len(result.knowledge) + len(result.procedures)
+        n = sum(len(getattr(result, key)) for key in
+                ("entities", "relations", "knowledge", "episodes", "procedures"))
         if n > 0:
             failures.append(f"expected nothing, extracted {n} items: {facts[:150]}")
 
@@ -84,7 +104,7 @@ def run_case(extractor, case, verbose=False):
             failures.append(f"missing required keyword: {kw!r}")
 
     for kw in case.get("must_not_extract", []):
-        if kw.lower() in everything:
+        if kw.lower() in extracted_text:
             failures.append(f"forbidden keyword present: {kw!r}")
 
     for kw in case.get("must_not_extract_as_current", []):
@@ -168,6 +188,7 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--case", help="run a single case id")
     ap.add_argument("--verbose", action="store_true")
+    ap.add_argument("--prompt-version", choices=("v1", "v2", "slim"), default="v2")
     args = ap.parse_args()
 
     cases = yaml.safe_load(open(Path(__file__).parent / "extraction_cases.yaml"))
@@ -177,11 +198,13 @@ def main():
             print(f"no case {args.case!r}"); sys.exit(2)
 
     extractor = build_extractor()
+    print(f"provider={os.environ.get('LLM_PROVIDER', 'openai')} "
+          f"model={getattr(extractor.llm, 'model', 'unknown')} prompt_version={args.prompt_version}")
     passed = failed = advisory = known = 0
     for case in cases:
         print(f"  {case['id']} ...", flush=True)
         try:
-            failures = run_case(extractor, case, verbose=args.verbose)
+            failures = run_case(extractor, case, verbose=args.verbose, prompt_version=args.prompt_version)
         except Exception as e:
             failures = [f"CRASH: {e}"]
         hard = [f for f in failures if not f.startswith("ADVISORY")]

--- a/evals/slim-results.md
+++ b/evals/slim-results.md
@@ -1,0 +1,97 @@
+# Slim extraction evaluation — 2026-09-08
+
+**Not ready for merge: the prompt-only candidate does not clear the small-model bar.**
+Related: #7. No README model-support claim has been changed.
+
+## Scope and method
+
+Production changes are a new `EXTRACTION_PROMPT_SLIM` constant and an explicit
+lookup entry. All five output collections remain; v1/v2, the schema, parsing,
+provider clients and local configuration are unchanged.
+
+The current slim template is 571 `cl100k_base` tokens when rendered with empty
+conversation/context. This is not a total request budget or an Ollama tokenizer
+measurement: conversation, existing context, provider framing, schema handling
+and generation capacity must be accounted for separately.
+
+The original ten cases retain their expectations. Two new ten-message cases
+check example contamination and complete JSON with a six-step workflow and all
+five output types. Their raw responses must validate against `EXTRACTION_SCHEMA`;
+parser recovery cannot turn truncated or malformed JSON into a pass. Forbidden
+terms are checked across all extracted fields, including relations. Empty-output
+cases now count episodes and relations too. These stricter checks apply to both
+v1 and slim. A pass count is not proof of losslessness outside this fixture set.
+
+## Final-candidate results
+
+One full run per row, using the same final candidate and cases. Ollama baseline
+and slim share model weights, a 4096-token context, 2048-token output cap,
+temperature 0 and seed 7. These are harness settings via local model aliases,
+not a change to the production Ollama client. Claude uses the existing
+Anthropic client (16384-token output cap, no temperature override).
+
+| Model | Prompt | Original ten | New two | Total |
+| --- | --- | ---: | ---: | ---: |
+| Claude Sonnet 4.6 | slim | 10/10 | 2/2 | 12/12 |
+| Claude Sonnet 5 | slim | 9/10 | 2/2 | 11/12 |
+| phi4-mini:3.8b Q4_K_M | v1 | 6/10 | 0/2 | 6/12 |
+| phi4-mini:3.8b Q4_K_M | slim | 7/10 | 0/2 | 7/12 |
+| llama3.1:8b Q4_K_M | v1 | 7/10 | 0/2 | 7/12 |
+| llama3.1:8b Q4_K_M | slim | 4/10 | 0/2 | 4/12 |
+
+Sonnet 4.6 passes the large-model regression gate. Sonnet 5 produced malformed
+JSON for the existing workflow case; that failure is retained, not rerun away.
+Neither target small model passes either new case. phi4 improves its overall
+count slightly, while llama3.1 regresses. These results do **not** justify
+advertising either small model as supported by slim.
+
+Small-model failures include wrong nested field types, missing required fields,
+incomplete workflow retention, assistant/example contamination and lost facts.
+The new complete-JSON case detects malformed output, but these runs do not
+establish a general reduction in output truncation frequency. There is no
+unconditional claim that a shorter prompt solves the capacity/quality problem.
+
+## Reproduce
+
+Install the project's `dev` and chosen provider extras (the eval schema check
+uses `jsonschema`, a dev-only dependency). Run from the repository root:
+
+```sh
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_extraction_slim.py tests/test_llm_client_anthropic.py -q
+LLM_PROVIDER=anthropic LLM_MODEL=claude-sonnet-4-6 python3 evals/run_extraction_evals.py --prompt-version slim --verbose
+```
+
+Seven offline checks passed (four slim/eval checks and three existing client
+checks). They verify wiring and gate behavior, not model quality.
+
+For each of `phi4-mini:3.8b` and `llama3.1:8b`, pull the model and create a local
+eval alias from a Modelfile with this content (substitute the model in `FROM`):
+
+```text
+FROM phi4-mini:3.8b
+PARAMETER num_ctx 4096
+PARAMETER num_predict 2048
+PARAMETER temperature 0
+PARAMETER seed 7
+```
+
+```sh
+ollama create mengram-eval-phi4-4k -f /path/to/Modelfile
+LLM_PROVIDER=ollama LLM_MODEL=mengram-eval-phi4-4k python3 evals/run_extraction_evals.py --prompt-version v1 --verbose
+LLM_PROVIDER=ollama LLM_MODEL=mengram-eval-phi4-4k python3 evals/run_extraction_evals.py --prompt-version slim --verbose
+```
+
+Repeat with a separate llama alias. The existing Ollama client requests JSON
+mode, not full JSON-schema enforcement; slim therefore retains a compact field
+contract. `OLLAMA_BASE_URL` selects the eval endpoint (default localhost:11434).
+The default eval prompt remains v2. `--case ID` selects one case.
+
+Recorded Ollama base-model digests:
+
+- phi4-mini:3.8b: `78fad5d182a7c33065e153a5f8ba210754207ba9d91973f57dffa7f487363753`
+- llama3.1:8b: `46e0c10c039e019119339687c3c1757cc81b9da49709a3b3924863ba87ca666e`
+
+Earlier development runs were not acceptance evidence: the initial OpenAI
+attempt returned 401, an unavailable Claude identifier returned 404, and earlier
+prompt candidates failed multiple cases. Those failures led to the current
+field contract and stricter gate; no reduced-output variant was introduced.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ all = [
     "crewai>=0.80",
     "httpx>=0.25",
 ]
-dev = ["pytest>=7.0", "pytest-asyncio>=0.21"]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "jsonschema>=4.0"]
 
 [project.urls]
 Homepage = "https://github.com/alibaizhanov/mengram"

--- a/tests/test_extraction_slim.py
+++ b/tests/test_extraction_slim.py
@@ -1,0 +1,66 @@
+"""Offline checks for #7; real model quality is gated by the extraction evals."""
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+from engine.extractor import conversation_extractor as ce
+from evals.run_extraction_evals import build_extractor, run_case
+
+
+class SlimTests(unittest.TestCase):
+    def test_selection_and_unchanged_schema(self):
+        empty = {key: [] for key in ("entities", "relations", "knowledge", "episodes", "procedures")}
+        client = Mock()
+        client.complete.return_value = json.dumps(empty)
+        extractor = ce.ConversationExtractor(client)
+        for version, template in [("v1", ce.EXTRACTION_PROMPT), ("v2", ce.EXTRACTION_PROMPT_V2),
+                                  ("slim", ce.EXTRACTION_PROMPT_SLIM), ("unknown", ce.EXTRACTION_PROMPT)]:
+            extractor.extract([{"role": "user", "content": "hello"}], prompt_version=version)
+            client.complete.assert_called_with(
+                template.format(existing_context="", conversation="User: hello"),
+                response_format=ce.EXTRACTION_SCHEMA,
+            )
+        with patch.object(ce, "EXTRACTION_PROMPT_VERSION", "slim"):
+            extractor.extract_from_text("hello")
+            self.assertIn("all five arrays", client.complete.call_args.args[0])
+        client.complete.side_effect = [RuntimeError("no structured output"), json.dumps(empty)]
+        extractor.extract([{"role": "user", "content": "hello"}], prompt_version="slim")
+        self.assertEqual(client.complete.call_args.kwargs, {})
+        self.assertIn("Procedures require", client.complete.call_args.args[0])
+
+    def test_truncated_output_cannot_pass_as_empty(self):
+        client = Mock()
+        extractor = ce.ConversationExtractor(client)
+        case = {"conversation": [], "require_complete_json": True, "expect_no_output": True}
+        for raw in ['{"entities": [', '{}']:
+            client.complete.return_value = raw
+            self.assertTrue(run_case(extractor, case, prompt_version="slim"))
+        client.complete.return_value = json.dumps({key: [] for key in
+            ("entities", "relations", "knowledge", "episodes", "procedures")})
+        self.assertEqual(run_case(extractor, case, prompt_version="slim"), [])
+        malformed = json.loads(client.complete.return_value)
+        malformed["entities"] = [{"name": "User", "type": "person", "facts": ["wrong type"]}]
+        client.complete.return_value = json.dumps(malformed)
+        self.assertTrue(any("schema violation" in f for f in run_case(
+            extractor, {"conversation": [], "require_complete_json": True}, prompt_version="slim")))
+        client.complete.return_value = '{"episodes": [{"summary": "fabricated"}]}'
+        self.assertTrue(run_case(extractor, {"conversation": [], "expect_no_output": True}))
+
+    def test_bleed_through_in_relations_is_rejected(self):
+        client = Mock()
+        client.complete.return_value = json.dumps({"relations": [{
+            "from": "User", "to": "Railway", "type": "uses", "description": "invented"
+        }]})
+        failures = run_case(ce.ConversationExtractor(client), {
+            "conversation": [], "must_not_extract": ["railway"]})
+        self.assertTrue(any("forbidden keyword" in f for f in failures))
+
+    def test_ollama_model_reaches_existing_client(self):
+        with patch.dict("os.environ", {"LLM_PROVIDER": "ollama", "LLM_MODEL": "phi4-mini:3.8b",
+                                      "OLLAMA_BASE_URL": "http://localhost:11434"}):
+            extractor = build_extractor()
+        self.assertEqual(extractor.llm.model, "phi4-mini:3.8b")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Status: draft — the small-model gate is still failing

Related to #7. This is the Phase 1 implementation and its measured results, not a claim that #7 is fixed. Please do not merge it as a small-model compatibility improvement yet.

The prompt is now 571 tokens with `cl100k_base` (empty conversation/context), keeps all five output types, and has no worked input/output example. Selection is explicit through `EXTRACTION_PROMPT_VERSION=slim` or `prompt_version="slim"`. Existing v1/v2 prompts, default/unknown-version fallback, output schema, provider clients, parser and local configuration remain unchanged. Production changes are limited to the new constant and the lookup.

I kept a short field/type contract: the current Ollama client requests JSON mode but does not forward `EXTRACTION_SCHEMA` to the model. Removing all field guidance would therefore rely on enforcement that this path does not have. The token figure is not the total request budget; provider framing, context and output still count.

## Evaluation changes

- `--prompt-version {v1,v2,slim}` on the existing runner, defaulting to v2.
- Eval-only Ollama model and endpoint settings via `LLM_MODEL` and `OLLAMA_BASE_URL`.
- Two ten-message cases: prompt-example contamination, and complete JSON retaining a six-step workflow plus all five types.
- The new cases validate the raw response against the existing schema, so truncated or malformed JSON cannot pass through parser recovery. This uses `jsonschema` in the dev extra rather than a new hand-written validator.
- Forbidden terms are checked in every extracted field, including relations; empty-output checks include episodes and relations. The same gates apply to baseline and slim.
- Verbose output includes the raw response for diagnosis.

## Actual results

Each small-model pair uses identical weights and settings: Q4_K_M, context 4096, output cap 2048, temperature 0, seed 7. All rows below use the final candidate and the same 12 cases.

| Model | v1 | slim |
| --- | ---: | ---: |
| Claude Sonnet 4.6 | not run | **12/12** |
| Claude Sonnet 5 | not run | 11/12 |
| phi4-mini:3.8b | 6/12 | 7/12 |
| llama3.1:8b | 7/12 | 4/12 |

Sonnet 4.6 passes the original ten cases and both additions. Sonnet 5 emitted malformed JSON for the existing release-workflow case. Neither small model passes either new case: schema errors and incomplete workflows remain, and llama3.1's aggregate result regresses. Those failures are not waived. I have left the README support table unchanged and have not introduced a facts-only variant.

Seven offline checks pass (four new checks and three existing Anthropic-client checks); `git diff --check` passes. These verify wiring and the eval gates, not extraction quality.

`evals/slim-results.md` contains the split results, model digests, settings and reproduction commands. The initial API 401 and unavailable-model 404 were resolved by using an accessible Anthropic model; they are not counted as model-quality results.

This shows the current prompt-only cut does not clear the requested small-model bar. I am keeping it in draft rather than silently dropping procedures, changing the provider contract, or treating a passing large-model run as a resolution of the issue.
