### PR TITLE
benchmark: local-extraction kit (exact prompt vs Ollama models, forma…

### DIFF
--- a/benchmark/local-extraction/README.md
+++ b/benchmark/local-extraction/README.md
@@ -1,0 +1,55 @@
+# Local-model extraction benchmark
+
+The exact prompt Mengram uses to turn a Claude Code session into memory
+(entities + facts, episodes, procedures), run against local Ollama models so
+anyone can check JSON reliability and extraction quality on their own hardware.
+
+Prompt: [`engine/extractor/conversation_extractor.py`](../../engine/extractor/conversation_extractor.py)
+(`EXTRACTION_PROMPT`, JSON schema in `EXTRACTION_SCHEMA`). The cloud runs the same
+prompt with a hosted model, so the numbers here are directly comparable.
+
+## Run
+
+```bash
+pip install mengram-ai
+ollama pull llama3.1:8b qwen2.5:14b gemma3:12b     # whatever you want to test
+python bench.py --models llama3.1:8b,qwen2.5:14b,gemma3:12b --runs 3
+```
+
+Flags that change the outcome:
+
+| flag | default | why it matters |
+|---|---|---|
+| `--num-ctx` | 16384 | Ollama's default context (~4k) is smaller than the prompt; without this, models silently truncate and return broken JSON |
+| `--format json\|none` | json | whether to send Ollama's `format: json` grammar constraint; `none` lets you test if it hurts quality |
+| `--think` | off | thinking models (qwen3, deepseek-r1) burn minutes and tokens in thinking; off by default |
+| `--runs N` | 1 | medians over N runs; use ≥3 for anything you want to quote |
+| `--transcript` | `sample-transcript.md` | your own session; `User:` / `Assistant:` paragraphs |
+| `--dump-prompt FILE` | | write the rendered prompt to use with any other runner |
+
+## What gets reported
+
+- **valid JSON 1st try** — whether the raw model output parsed with `json.loads` before any repair.
+  Mengram has fallback parsing, so a `no` here doesn't always mean lost data, but it does mean the model
+  is unreliable.
+- **entities / facts / episodes / procedures** — counts after Mengram's parser. The sample transcript
+  contains, by hand count: 4 entities worth having (the user, the notify-svc project, Marcus, Zed),
+  ~10 facts, 2 episodes (the failed deploy + diagnosis, the constraint decisions), and 1 procedure
+  (the 6-step deploy checklist). A model that returns 0 procedures missed the most valuable part.
+- **seconds** — wall time per session, including any retry call.
+
+## Reference numbers
+
+M1 Pro, 16 GB, Ollama 0.32.5, `num_ctx` 16k, `format: json`, think off, two real 5–6k-char sessions,
+one run each. See [`growth/bench-ollama-2026-09-08.md`](../../growth/bench-ollama-2026-09-08.md).
+
+| model | seconds | valid JSON | entities | episodes | procedures |
+|---|---|---|---|---|---|
+| llama3.1:8b | 30–32 | yes | 2–3 | 0–2 | 0 |
+| qwen2.5:7b | 31–55 | yes | 1–4 | 0–2 | 0–2 |
+| qwen3:8b | 47–104 | yes | 2–3 | 1–4 | 0–2 |
+| qwen3:4b | 42–52 | yes | 4–6 | 1–2 | 1 |
+| claude-sonnet-5 (cloud) | 52 | yes | 8 | 4 | 2 |
+
+If you run this on other hardware or models, open an issue or PR with the table. Larger models
+(14B+) and the gemma family are the gap we most want filled.

--- a/benchmark/local-extraction/bench.py
+++ b/benchmark/local-extraction/bench.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Local-model extraction benchmark for Mengram.
+
+Runs the exact extraction prompt Mengram uses (the one we run with claude-sonnet-5
+in the cloud and in `mengram import claude-code`) against one or more Ollama
+models, and reports JSON validity, latency, and how much each model pulled out.
+
+    pip install mengram-ai
+    python bench.py --models llama3.1:8b,qwen2.5:14b,gemma3:12b
+    python bench.py --models qwen2.5:14b --format none        # no `format: json`
+    python bench.py --models qwen3:8b --think                  # let thinking models think
+    python bench.py --transcript my-session.md --runs 3        # your own transcript, 3 runs each
+    python bench.py --dump-prompt prompt.txt                   # just write the rendered prompt
+
+Transcript format: a text file with "User:" / "Assistant:" paragraphs (see
+sample-transcript.md). Each paragraph that starts with one of those labels is one
+message; everything else continues the previous message.
+
+The script talks to Ollama's /api/chat directly, so it does not depend on the
+Ollama client shipped in the package. Stdlib only, no extra dependencies.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+try:
+    from engine.extractor.conversation_extractor import (
+        EXTRACTION_PROMPT,
+        EXTRACTION_SCHEMA,
+        ConversationExtractor,
+    )
+except ImportError:  # pragma: no cover
+    sys.exit("mengram-ai is not installed: pip install mengram-ai")
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_TRANSCRIPT = HERE / "sample-transcript.md"
+
+
+def parse_transcript(path: Path) -> list[dict]:
+    """'User:' / 'Assistant:' paragraphs → [{role, content}]."""
+    messages: list[dict] = []
+    for block in path.read_text(encoding="utf-8").split("\n\n"):
+        stripped = block.strip()
+        if not stripped:
+            continue
+        for label, role in (("User:", "user"), ("Assistant:", "assistant")):
+            if stripped.startswith(label):
+                messages.append({"role": role, "content": stripped[len(label):].strip()})
+                break
+        else:
+            if messages:
+                messages[-1]["content"] += "\n\n" + stripped
+            else:
+                messages.append({"role": "user", "content": stripped})
+    if not messages:
+        sys.exit(f"no messages found in {path}")
+    return messages
+
+
+class OllamaChat:
+    """Minimal Ollama /api/chat client with the knobs that matter for extraction."""
+
+    def __init__(self, model: str, base_url: str, num_ctx: int, use_format: bool,
+                 think: bool, timeout: float):
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.num_ctx = num_ctx
+        self.use_format = use_format
+        self.think = think
+        self.timeout = timeout
+        self.raw_outputs: list[str] = []
+
+    def complete(self, prompt: str, system: str = "", response_format=None) -> str:
+        messages = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+        body = {
+            "model": self.model,
+            "messages": messages,
+            "stream": False,
+            "think": self.think,
+            "options": {"num_ctx": self.num_ctx, "temperature": 0.2},
+        }
+        if response_format is not None and self.use_format:
+            body["format"] = "json"
+        req = urllib.request.Request(
+            f"{self.base_url}/api/chat",
+            data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            data = json.loads(resp.read())
+        text = data.get("message", {}).get("content", "")
+        self.raw_outputs.append(text)
+        return text
+
+
+def is_valid_json(text: str) -> bool:
+    try:
+        json.loads(text)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def run_one(client: OllamaChat, conversation: list[dict]) -> dict:
+    client.raw_outputs.clear()
+    started = time.time()
+    error = ""
+    try:
+        result = ConversationExtractor(client).extract(conversation, existing_context="")
+        entities, episodes, procedures = len(result.entities), len(result.episodes), len(result.procedures)
+        facts = sum(len(e.facts) for e in result.entities)
+    except Exception as exc:  # noqa: BLE001 - we want the model failure, whatever it is
+        entities = episodes = procedures = facts = 0
+        error = f"{type(exc).__name__}: {str(exc)[:80]}"
+    elapsed = time.time() - started
+    first = client.raw_outputs[0] if client.raw_outputs else ""
+    return {
+        "seconds": round(elapsed, 1),
+        "calls": len(client.raw_outputs),
+        "valid_json_first_try": is_valid_json(first),
+        "raw_chars": len(first),
+        "entities": entities,
+        "facts": facts,
+        "episodes": episodes,
+        "procedures": procedures,
+        "error": error,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--models", default="llama3.1:8b", help="comma-separated Ollama model tags")
+    ap.add_argument("--transcript", type=Path, default=DEFAULT_TRANSCRIPT)
+    ap.add_argument("--runs", type=int, default=1, help="runs per model (report median seconds)")
+    ap.add_argument("--num-ctx", type=int, default=16384)
+    ap.add_argument("--format", choices=["json", "none"], default="json",
+                    help="send Ollama `format: json` (default) or not")
+    ap.add_argument("--think", action="store_true", help="enable thinking for models that support it")
+    ap.add_argument("--base-url", default=os.environ.get("OLLAMA_HOST", "http://localhost:11434"))
+    ap.add_argument("--timeout", type=float, default=900.0)
+    ap.add_argument("--out", type=Path, default=HERE / "results.json")
+    ap.add_argument("--dump-prompt", type=Path, help="write the rendered prompt for the transcript and exit")
+    args = ap.parse_args()
+
+    conversation = parse_transcript(args.transcript)
+    chars = sum(len(m["content"]) for m in conversation)
+
+    if args.dump_prompt:
+        extractor = ConversationExtractor(llm_client=None)
+        rendered = EXTRACTION_PROMPT.format(
+            conversation=extractor._format_conversation(conversation), existing_context="")
+        args.dump_prompt.write_text(rendered, encoding="utf-8")
+        print(f"wrote {args.dump_prompt} ({len(rendered)} chars)")
+        return
+
+    print(f"transcript: {args.transcript.name}, {len(conversation)} messages, {chars} chars; "
+          f"num_ctx={args.num_ctx} format={args.format} think={args.think}", file=sys.stderr)
+
+    rows = []
+    for model in [m.strip() for m in args.models.split(",") if m.strip()]:
+        client = OllamaChat(model, args.base_url, args.num_ctx, args.format == "json", args.think, args.timeout)
+        runs = []
+        for i in range(args.runs):
+            r = run_one(client, conversation)
+            runs.append(r)
+            print(json.dumps({"model": model, "run": i + 1, **r}), file=sys.stderr)
+        rows.append({
+            "model": model,
+            "runs": args.runs,
+            "seconds_median": statistics.median(r["seconds"] for r in runs),
+            "valid_json_first_try": f"{sum(r['valid_json_first_try'] for r in runs)}/{len(runs)}",
+            "entities": statistics.median(r["entities"] for r in runs),
+            "facts": statistics.median(r["facts"] for r in runs),
+            "episodes": statistics.median(r["episodes"] for r in runs),
+            "procedures": statistics.median(r["procedures"] for r in runs),
+            "errors": [r["error"] for r in runs if r["error"]],
+            "details": runs,
+        })
+
+    print(f"\ntranscript {chars} chars · num_ctx {args.num_ctx} · format {args.format} · think {args.think}\n")
+    print("| model | runs | seconds (median) | valid JSON 1st try | entities | facts | episodes | procedures |")
+    print("|---|---|---|---|---|---|---|---|")
+    for r in rows:
+        line = (f"| {r['model']} | {r['runs']} | {r['seconds_median']} | {r['valid_json_first_try']} | "
+                f"{r['entities']:g} | {r['facts']:g} | {r['episodes']:g} | {r['procedures']:g} |")
+        if r["errors"]:
+            line += " " + "; ".join(r["errors"])
+        print(line)
+    args.out.write_text(json.dumps(rows, indent=1), encoding="utf-8")
+    print(f"\nraw results: {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/local-extraction/sample-transcript.md
+++ b/benchmark/local-extraction/sample-transcript.md
@@ -1,0 +1,69 @@
+User: I need to get the notifications service deployed to Railway today. It's a FastAPI app, Postgres on Supabase, and the last deploy failed with "too many connections" during the health check. Repo is ~/work/notify-svc.
+
+Assistant: Let's look at what happened. Can you show me the Railway logs from the failed deploy and your database settings?
+
+User: Here's the tail:
+
+```
+[migrate] applying 0007_add_delivery_log
+psycopg2.OperationalError: FATAL: remaining connection slots are reserved for non-replication superuser connections
+[health] GET /health -> 503 after 30s
+```
+
+We're on the Supabase free tier, pooler is on port 6543 in transaction mode. Gunicorn runs 4 workers, and each worker opens its own pool of 5.
+
+Assistant: That's 20 connections from the app alone, plus the migration step, plus whatever the previous deploy's workers still hold while Railway overlaps the two versions. The free tier pooler caps around 15 client connections for one project. Two things fix this reliably:
+
+1. Run migrations as a separate pre-deploy command, not inside the app startup, so they never compete with workers for slots.
+2. Drop to 2 workers with a pool of 3 each. For a notifications service that's IO-bound, 2 workers with async handlers is plenty.
+
+User: Migrations run in `app/startup.py` right now, on every worker boot. That's dumb, each worker tries to migrate.
+
+Assistant: Yes, and with 4 workers you get 4 concurrent migration attempts. Move it out. In Railway, set the pre-deploy command to `python -m app.migrate`, and remove the call from startup. Here's the change:
+
+```python
+# app/startup.py
+async def on_startup():
+    # migrations now run via `python -m app.migrate` before deploy
+    await init_pool(min_size=1, max_size=3)
+```
+
+And in `railway.json`:
+
+```json
+{
+  "deploy": {
+    "preDeployCommand": "python -m app.migrate",
+    "startCommand": "gunicorn app.main:app -k uvicorn.workers.UvicornWorker -w 2"
+  }
+}
+```
+
+User: Done. Deploying now.
+
+User: Health check passed, but the migration step printed a warning: "0006_backfill_timezones already applied, skipping" and then 0007 applied fine. Is that skipping a problem?
+
+Assistant: No, that's the migration runner being idempotent. 0006 was applied by one of the workers during the previous failed deploy before the pool ran out. The runner tracks applied versions in `schema_migrations`, so it skips it. Nothing to fix.
+
+User: Ok. One more thing, I keep forgetting the order for a Railway deploy on this service. Can you write down the steps so I stop breaking it?
+
+Assistant: Here's the checklist for deploying notify-svc:
+
+1. Run the test suite locally: `pytest -q`. Don't deploy on red.
+2. Check pending migrations: `python -m app.migrate --dry-run`. If a migration touches a big table, run it manually during low traffic instead of via pre-deploy.
+3. Push to `main`. Railway auto-deploys from `main`.
+4. Watch the pre-deploy step in the Railway dashboard until you see "migrations up to date".
+5. Wait for `/health` to return 200 on the new deployment before closing the tab. Railway keeps the old version up until then.
+6. If the health check fails, check pooler connection count in Supabase first. That's been the cause both times.
+
+User: Save that. Also, note for the future: I want to stay on the Supabase free tier until we have paying customers, so any fix that says "upgrade the plan" is a no.
+
+Assistant: Noted. The constraint is: Supabase free tier until first paying customer, so connection budget is hard capped. The 2-worker, pool-of-3 setup leaves headroom for the migration step and one overlapping deploy.
+
+User: Also I switched my editor from VS Code to Zed last week, so if you suggest editor settings, use Zed's config format.
+
+Assistant: Got it, Zed's `settings.json` from now on. Anything else for today?
+
+User: No, that's it. Deploy is green, moving on to the email templates tomorrow with Marcus, he owns the design side.
+
+Assistant: Sounds good. Summary of today: migrations moved to a Railway pre-deploy command, worker count dropped from 4 to 2 with pool size 3, health check passing, deploy checklist written down. Tomorrow: email templates with Marcus.

--- a/growth/bench-ollama-2026-09-08.md
+++ b/growth/bench-ollama-2026-09-08.md
@@ -1,0 +1,19 @@
+| model | session | transcript chars | seconds | valid JSON 1st try | entities | episodes | procedures |
+|---|---|---|---|---|---|---|---|
+| qwen3:8b | 1 | 5859 | 47.2 | yes | 2 | 1 | 0 |
+| qwen3:8b | 2 | 4676 | 104.2 | yes | 3 | 4 | 2 |
+| llama3.1:8b | 1 | 5859 | 31.7 | yes | 2 | 0 | 0 |
+| llama3.1:8b | 2 | 4676 | 29.7 | yes | 3 | 2 | 0 |
+| qwen2.5:7b | 1 | 5859 | 31.0 | yes | 1 | 0 | 0 |
+| qwen2.5:7b | 2 | 4676 | 54.7 | yes | 4 | 2 | 2 |
+| qwen3:4b | 1 | 5859 | 51.6 | yes | 6 | 1 | 1 |
+| qwen3:4b | 2 | 4676 | 41.9 | yes | 4 | 2 | 1 |
+
+## Sample transcript (benchmark/local-extraction/sample-transcript.md, 3984 chars), 2026-09-08, n=1
+
+| model | format | seconds | valid JSON 1st try | entities | facts | episodes | procedures |
+|---|---|---|---|---|---|---|---|
+| qwen3:4b | json | 49.5 | yes | 5 | 10 | 1 | 1 |
+| llama3.1:8b | json | 49.2 | yes | 2 | 5 | 2 | 1 |
+| qwen3:4b | none | 231.3 | no (27k chars of prose) | 0 | 0 | 0 | 0 |
+| llama3.1:8b | none | 55.9 | yes | 3 | 10 | 2 | 1 |


### PR DESCRIPTION
Standalone `benchmark/local-extraction/`: `bench.py` runs the real extraction prompt against Ollama tags with the knobs that matter (`--num-ctx`, `--format json|none`, `--think`, `--runs`), plus a synthetic sample transcript and a README with reference numbers. Made for the r/ollama thread where a user with a 5090 offered to run 7–14B models.

No product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt