### PR TITLE
2.37.2: resumable import, Anthropic timeout, Ollama num_ctx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.37.2 — 2026-09-07
+
+### Fixed
+- `import claude-code` saves the imported-sessions list after every session,
+  not at the end: a killed or timed-out import resumes instead of extracting
+  everything twice (episodes are appended, so a re-run duplicated them).
+- The Anthropic client has a 5-minute request timeout and one retry (the SDK
+  default was 10 minutes × 3); one session that never answered no longer
+  stalls the whole import. Seen on a real import with claude-sonnet-5.
+
 ## 2.37.1 — 2026-09-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - The Anthropic client has a 5-minute request timeout and one retry (the SDK
   default was 10 minutes × 3); one session that never answered no longer
   stalls the whole import. Seen on a real import with claude-sonnet-5.
+- The Ollama client now sends a 16k context window (`num_ctx`, overridable
+  in the folder config), disables model "thinking", and has a 10-minute
+  timeout. Ollama's default context is ~4k, which silently truncated the
+  ~3.6k-token extraction prompt plus the transcript.
 
 ## 2.37.1 — 2026-09-07
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.37.1"
+__version__ = "2.37.2"
 """Mengram — AI memory layer for apps."""

--- a/engine/extractor/llm_client.py
+++ b/engine/extractor/llm_client.py
@@ -46,7 +46,9 @@ class AnthropicClient(LLMClient):
             import anthropic
         except ImportError:
             raise ImportError("pip install anthropic")
-        self.client = anthropic.Anthropic(api_key=api_key)
+        # A stalled request must fail, not hang an import: the SDK default is
+        # 10 min × 3 attempts. One extraction of a 16k-char session takes ~80s.
+        self.client = anthropic.Anthropic(api_key=api_key, timeout=300.0, max_retries=1)
         self.model = model
 
     def complete(self, prompt: str, system: str = "", response_format=None) -> str:

--- a/engine/extractor/llm_client.py
+++ b/engine/extractor/llm_client.py
@@ -120,20 +120,33 @@ class OpenAIClient(LLMClient):
 class OllamaClient(LLMClient):
     """Ollama — fully local LLM (free)"""
 
-    def __init__(self, base_url: str = "http://localhost:11434", model: str = "llama3.2"):
+    # Ollama's default context window is small (4k on most models); the
+    # extraction prompt alone is ~3.6k tokens plus the transcript, so the
+    # default would silently truncate the input. 16k fits an 8B model on
+    # a 16 GB machine; override with `num_ctx` in the folder config.
+    DEFAULT_NUM_CTX = 16384
+
+    def __init__(self, base_url: str = "http://localhost:11434", model: str = "llama3.2",
+                 num_ctx: int = None, timeout: float = 600.0):
         self.base_url = base_url.rstrip("/")
         self.model = model
+        self.num_ctx = int(num_ctx or self.DEFAULT_NUM_CTX)
+        self.timeout = timeout
+
+    def _payload(self, **fields) -> dict:
+        """Common request fields: context size, and no "thinking" — qwen3-style
+        models otherwise spend the budget reasoning and return truncated JSON."""
+        return {"model": self.model, "stream": False, "think": False,
+                "options": {"num_ctx": self.num_ctx, "temperature": 0.2}, **fields}
 
     def complete(self, prompt: str, system: str = "", response_format=None) -> str:
         import urllib.request
         import json
 
-        req_data = {
-            "model": self.model,
-            "prompt": prompt,
-            "system": system or "You are a knowledge extraction assistant.",
-            "stream": False,
-        }
+        req_data = self._payload(
+            prompt=prompt,
+            system=system or "You are a knowledge extraction assistant.",
+        )
         if response_format:
             req_data["format"] = "json"
         data = json.dumps(req_data).encode()
@@ -143,7 +156,7 @@ class OllamaClient(LLMClient):
             data=data,
             headers={"Content-Type": "application/json"},
         )
-        with urllib.request.urlopen(req) as resp:
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
             result = json.loads(resp.read())
             return result["response"]
 
@@ -153,18 +166,14 @@ class OllamaClient(LLMClient):
 
         msgs = [{"role": "system", "content": system or "You are a helpful assistant."}]
         msgs.extend(messages)
-        data = json.dumps({
-            "model": self.model,
-            "messages": msgs,
-            "stream": False,
-        }).encode()
+        data = json.dumps(self._payload(messages=msgs)).encode()
 
         req = urllib.request.Request(
             f"{self.base_url}/api/chat",
             data=data,
             headers={"Content-Type": "application/json"},
         )
-        with urllib.request.urlopen(req) as resp:
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
             result = json.loads(resp.read())
             return result["message"]["content"]
 
@@ -190,6 +199,7 @@ def create_llm_client(config: dict) -> LLMClient:
         return OllamaClient(
             base_url=settings.get("base_url", "http://localhost:11434"),
             model=settings.get("model", "llama3.2"),
+            num_ctx=settings.get("num_ctx"),
         )
     else:
         raise ValueError(f"Unknown LLM provider: {provider}")

--- a/importer.py
+++ b/importer.py
@@ -628,6 +628,10 @@ def import_claude_code(
             resp = add_fn(session["text"], session["session_id"])
             result.chunks_sent += 1
             imported_now.add(session["session_id"])
+            # Save after every session, not at the end: a killed or timed-out
+            # import must resume from where it stopped, not extract everything
+            # twice (episodes are appended, so a re-run duplicates them).
+            _cc_save_state(imported_now, state_file)
             for key in ("entities_created", "entities_updated"):
                 if isinstance(resp, dict) and key in resp:
                     result.entities_created.extend(resp[key])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.37.1"
+version = "2.37.2"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_llm_client_ollama.py
+++ b/tests/test_llm_client_ollama.py
@@ -1,0 +1,48 @@
+"""OllamaClient sends a real context window, no thinking, and json format when asked."""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import engine.extractor.llm_client as llm  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, body): self._b = json.dumps(body).encode()
+    def read(self): return self._b
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+
+def _capture(monkeypatch):
+    sent = {}
+    def fake_urlopen(req, timeout=None):
+        sent["url"] = req.full_url; sent["body"] = json.loads(req.data.decode()); sent["timeout"] = timeout
+        return _Resp({"response": '{"entities": []}', "message": {"content": "hi"}})
+    import urllib.request
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    return sent
+
+
+def test_generate_carries_num_ctx_no_think_and_json_format(monkeypatch):
+    sent = _capture(monkeypatch)
+    c = llm.OllamaClient(model="llama3.1:8b")
+    out = c.complete("extract", response_format={"type": "object"})
+    assert out == '{"entities": []}'
+    b = sent["body"]
+    assert b["model"] == "llama3.1:8b" and b["think"] is False and b["format"] == "json"
+    assert b["options"]["num_ctx"] == llm.OllamaClient.DEFAULT_NUM_CTX == 16384
+    assert sent["timeout"] == 600.0 and sent["url"].endswith("/api/generate")
+
+
+def test_num_ctx_comes_from_the_folder_config(monkeypatch):
+    sent = _capture(monkeypatch)
+    c = llm.create_llm_client({"provider": "ollama", "ollama": {"model": "qwen2.5:7b", "num_ctx": 8192}})
+    c.complete("x")
+    assert sent["body"]["options"]["num_ctx"] == 8192 and "format" not in sent["body"]
+
+
+def test_chat_uses_the_same_payload(monkeypatch):
+    sent = _capture(monkeypatch)
+    llm.OllamaClient(model="m").chat([{"role": "user", "content": "hi"}])
+    assert sent["body"]["think"] is False and sent["body"]["options"]["num_ctx"] == 16384 and sent["url"].endswith("/api/chat")

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -262,3 +262,21 @@ def test_missing_provider_sdk_is_a_one_line_hint_not_a_traceback(tmp_path, monke
     _fake_sessions(tmp_path, monkeypatch)
     code, out, err = _run(monkeypatch, capsys, ["import", "claude-code", "--memory", str(root), "--yes"])
     assert code == 2 and "mengram-ai[anthropic]" in out
+
+
+def test_import_state_is_saved_after_every_session(folder, tmp_path, monkeypatch, capsys):
+    """A killed import must resume, not re-extract: the state file grows per session."""
+    import importer
+    _fake_sessions(tmp_path, monkeypatch, n=3)
+    seen = []
+    from local.store import LocalStore
+    real_add = LocalStore.add
+
+    def add_and_check(self, text, client):
+        out = real_add(self, text, client)
+        state = folder / ".mengram" / "claude-code-imported.json"
+        seen.append(len(json.loads(state.read_text())) if state.exists() else 0)
+        return out
+    monkeypatch.setattr(LocalStore, "add", add_and_check)
+    code, out, _ = _run(monkeypatch, capsys, ["import", "claude-code", "--memory", str(folder), "--yes"])
+    assert code == 0 and seen == [0, 1, 2]   # before the 1st save: 0; then 1, then 2 already on disk


### PR DESCRIPTION
Three fixes found by running a real import and the r/ollama benchmark.

- **Import is resumable.** State is written after every successful session, not only at the end, so a killed or timed-out import no longer re-extracts everything.
- **Anthropic client gets a timeout.** `timeout=300`, `max_retries=1`. One session previously hung for 12 minutes with no ceiling.
- **Ollama client sends `num_ctx` (16384), `think: false` and a 600 s timeout.** The default context (~4k) is smaller than the extraction prompt, so input was silently truncated and the model returned cut JSON. This was the root cause of local models "not handling structured output", and it is what people in the r/ollama thread are hitting.

Tests: 390 passed; the 3 `TestParseVault` failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt