### PR TITLE
Close the loop: record what a workflow's step actually did

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -862,13 +862,121 @@ def cmd_auto_policy(args):
             mem = CloudMemory(api_key=api_key, base_url=_load_cloud_base_url())
             procs = mem.procedures(query=command[:300], limit=3, user_id=user_id)
 
-        proc = policy.best_match(procs, command)
-        if not proc:
-            _exit("no matching workflow")
+        # The same bar the recorder uses: the command has to *be* a step of
+        # this workflow, not merely share a word with it. Sharing one word was
+        # enough to turn one command in six into a confirmation prompt, which
+        # is the version of this gate nobody would keep installed.
+        hit = policy.best_step_match(procs, command)
+        if hit is None:
+            _exit("no matching workflow step")
+        proc = hit[0]
         verdict = policy.decide(proc, command, min_reliable=min_reliable)
         if verdict is None:
             _exit(f"'{proc.get('name')}' {policy.reliability_of(proc)} — allowed")
         _exit(f"'{verdict['name']}' {verdict['reliability']} — ask", verdict)
+
+    except SystemExit:
+        raise
+    except Exception:
+        _exit("error")
+
+
+def _bash_outcome(tool_response) -> bool | None:
+    """Did this command work? None when the transcript does not actually say.
+
+    Silence is the right answer for anything ambiguous. A guessed success is
+    what makes a track record lie, and the gate downstream believes it.
+    A non-empty stderr is deliberately *not* a failure: plenty of healthy
+    tools write there.
+    """
+    if not isinstance(tool_response, dict):
+        return None
+    if tool_response.get("interrupted"):
+        return None
+    code = tool_response.get("exit_code", tool_response.get("exitCode"))
+    if isinstance(code, bool):          # True is not an exit code
+        return None
+    if isinstance(code, int):
+        return code == 0
+    flag = tool_response.get("is_error", tool_response.get("isError"))
+    if isinstance(flag, bool):
+        return not flag
+    return None
+
+
+def _failure_reason(tool_response) -> str | None:
+    """The shortest honest description of what went wrong."""
+    if not isinstance(tool_response, dict):
+        return None
+    text = (tool_response.get("stderr") or "").strip()
+    if not text:
+        text = (tool_response.get("stdout") or "").strip()
+    if not text:
+        return None
+    line = text.splitlines()[-1].strip()
+    return line[:200] or None
+
+
+def cmd_auto_outcome(args):
+    """Hook handler — Claude Code PostToolUse on Bash.
+
+    The other half of the policy gate. `auto-policy` asks about a workflow
+    whose record is weak; this is what gives a workflow a record at all. When
+    a command is recognisably one step of a learned procedure, its exit code
+    is written back to that step. Without this every procedure stays
+    `untested` forever, and the gate is an opinion with no evidence under it.
+
+    Deliberately quiet and deliberately reluctant: it writes only when the
+    step names the same tool the command ran and shares a word beyond it, and
+    it records nothing at all when the outcome is unclear. It prints nothing
+    and exits 0 whatever happens, because a bookkeeping hook must never
+    disturb the session it is observing.
+    """
+    HOOK = "auto-outcome"
+    EVENT = "PostToolUse"
+    from cloud import policy
+
+    def _exit(status):
+        _emit_hook_exit(EVENT, args, HOOK, status)
+
+    try:
+        try:
+            input_data = json.loads(sys.stdin.read())
+        except Exception:
+            _exit("no input")
+        if input_data.get("tool_name") != "Bash":
+            _exit("skipped (not Bash)")
+        command = (input_data.get("tool_input") or {}).get("command") or ""
+        if not command:
+            _exit("no command")
+        # Cheap check before anything is loaded, and a wider net than the gate
+        # upstream: the gate stays narrow because a false question interrupts a
+        # human, while a recording costs nothing and evidence is what is scarce.
+        # A command naming no known tool cannot match any step, so stop here.
+        if not policy.shell_verbs(command):
+            _exit("skipped (no known tool in the command)")
+        worked = _bash_outcome(input_data.get("tool_response"))
+        if worked is None:
+            _exit("outcome unclear — nothing recorded")
+
+        local_root = _local_dir(args)
+        if not local_root:
+            # The cloud endpoint records whole runs: it always moves the
+            # procedure's own counters. One shell command is not a run, and
+            # writing it there would inflate the very record the gate reads.
+            # Until the API takes a step-scoped write, the folder is where
+            # this loop closes.
+            _exit("cloud mode: step-scoped feedback not available yet")
+
+        procs = policy.memfmt_procedures(str(local_root))
+        hit = policy.best_step_match(procs, command)
+        if hit is None:
+            _exit("no step matched")
+        proc, step_no, _score = hit
+        name = proc.get("name") or "unnamed workflow"
+        reason = None if worked else _failure_reason(input_data.get("tool_response"))
+        _local_store(local_root).step_outcome(name, step_no, success=worked, reason=reason)
+        _exit(f"'{name}' step {step_no} recorded as {'success' if worked else 'failure'}")
 
     except SystemExit:
         raise
@@ -1657,7 +1765,7 @@ def cmd_setup(args):
 
 
 def cmd_hook_install(args):
-    """Install Claude Code memory hooks (auto-save + auto-recall + session context + policy gate)"""
+    """Install Claude Code memory hooks (auto-save + auto-recall + session context + policy gate + run outcomes)"""
     local_dir = _local_dir(args)
     api_key = os.environ.get("MENGRAM_API_KEY", "")
     if not local_dir and not api_key:
@@ -1678,11 +1786,13 @@ def cmd_hook_install(args):
     recall_cmd = "mengram auto-recall"
     context_cmd = "mengram auto-context"
     policy_cmd = "mengram auto-policy"
+    outcome_cmd = "mengram auto-outcome"
     if user_id:
         save_cmd += f" --user-id {user_id}"
         recall_cmd += f" --user-id {user_id}"
         context_cmd += f" --user-id {user_id}"
         policy_cmd += f" --user-id {user_id}"
+        outcome_cmd += f" --user-id {user_id}"
     if local_dir:
         # Hooks run without the user's shell profile, so the folder travels
         # in the command rather than in an env var that may not be there.
@@ -1691,6 +1801,7 @@ def cmd_hook_install(args):
         recall_cmd += mem_arg
         context_cmd += mem_arg
         policy_cmd += mem_arg
+        outcome_cmd += mem_arg
 
     # Read existing settings
     settings_path = get_claude_code_settings_path()
@@ -1734,6 +1845,14 @@ def cmd_hook_install(args):
             "timeout": 10,
         }, matcher="Bash")
 
+    # 5. PostToolUse hook — write back what actually happened, so the gate above
+    #    has a record to judge by instead of an empty one. Observation only.
+    _upsert_hook(settings, "PostToolUse", "mengram auto-outcome", {
+        "type": "command",
+        "command": outcome_cmd,
+        "timeout": 10,
+    }, matcher="Bash")
+
     # Write settings
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     with open(settings_path, "w") as f:
@@ -1745,6 +1864,7 @@ def cmd_hook_install(args):
     print(f"  Session context: load profile on session start")
     if not getattr(args, "no_policy", False):
         print(f"  Policy gate:  confirm before running a workflow with a weak record")
+    print(f"  Run outcomes: record whether a workflow's step worked")
     print(f"  Settings: {settings_path}")
     print(f"\nRestart Claude Code for hooks to take effect.")
 
@@ -1764,12 +1884,13 @@ def cmd_hook_uninstall(args):
         print("Could not read settings file.")
         return
 
-    # Remove all 3 mengram hooks
+    # Remove every mengram hook
     removed = False
     removed |= _remove_hook(settings, "Stop", "mengram auto-save")
     removed |= _remove_hook(settings, "UserPromptSubmit", "mengram auto-recall")
     removed |= _remove_hook(settings, "SessionStart", "mengram auto-context")
     removed |= _remove_hook(settings, "PreToolUse", "mengram auto-policy")
+    removed |= _remove_hook(settings, "PostToolUse", "mengram auto-outcome")
 
     if not removed:
         print("No Mengram hooks found. Nothing to uninstall.")
@@ -1810,11 +1931,12 @@ def cmd_hook_status(args):
                     return hook.get("command", "")
         return None
 
-    # Check all 3 hooks
+    # Check every hook
     save_cmd = _find_hook("Stop", "mengram auto-save")
     recall_cmd = _find_hook("UserPromptSubmit", "mengram auto-recall")
     context_cmd = _find_hook("SessionStart", "mengram auto-context")
     policy_cmd = _find_hook("PreToolUse", "mengram auto-policy")
+    outcome_cmd = _find_hook("PostToolUse", "mengram auto-outcome")
 
     if save_cmd:
         every_n = 3
@@ -1830,6 +1952,7 @@ def cmd_hook_status(args):
     print(f"  Auto-recall:    {'installed' if recall_cmd else 'not installed'}")
     print(f"  Session context: {'installed' if context_cmd else 'not installed'}")
     print(f"  Policy gate:    {'installed' if policy_cmd else 'not installed'}")
+    print(f"  Run outcomes:   {'installed' if outcome_cmd else 'not installed'}")
 
     # Check API key
     api_key = os.environ.get("MENGRAM_API_KEY", "")
@@ -2353,6 +2476,13 @@ def main():
     p_autopolicy.add_argument("--min-reliable", type=int, default=None, dest="min_reliable",
                                help="Percent below which a workflow with a record is confirmed (default 70)")
 
+    # auto-outcome (internal, called by Claude Code PostToolUse hook on Bash)
+    p_autooutcome = sub.add_parser("auto-outcome", help=argparse.SUPPRESS)
+    p_autooutcome.add_argument("--user-id", default=None)
+    p_autooutcome.add_argument("--memory", default=None)
+    p_autooutcome.add_argument("--verbose", action="store_true",
+                                help="Emit a status marker for each hook invocation")
+
     # local — memory in a folder, no account
     from local.cli import add_parser as _add_local_parser
     _add_local_parser(sub)
@@ -2422,6 +2552,8 @@ def main():
         cmd_auto_context(args)
     elif args.command == "auto-policy":
         cmd_auto_policy(args)
+    elif args.command == "auto-outcome":
+        cmd_auto_outcome(args)
     elif args.command == "local":
         from local.cli import run as _run_local
         sys.exit(_run_local(args))

--- a/cloud/policy.py
+++ b/cloud/policy.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import re
 
-from cloud.reliability import estimate
+from cloud.reliability import estimate, from_steps
 
 #: Commands that look like a workflow rather than a lookup. Anything else is
 #: waved through without a search, which keeps the hook cheap: a `ls` should
@@ -87,12 +87,139 @@ def procedure_matches(proc: dict, command: str) -> bool:
     return bool(tokens(_procedure_text(proc)) & tokens(command))
 
 
+#: Tools a step has to name before a shell command can be called that step.
+#: Prose plans ("draft the launch post", "decide the price") never match, which
+#: is the point: they are not things a Bash call can be an instance of.
+SHELL_VERBS = re.compile(
+    r"(?:^|[\s;|&(`$])("
+    r"git|gh|npm|npx|pnpm|yarn|bun|deno|pip|pip3|pipx|python|python3|uv|poetry|"
+    r"docker|docker-compose|kubectl|helm|terraform|pulumi|ansible|vagrant|"
+    r"railway|vercel|netlify|fly|flyctl|heroku|gcloud|aws|az|supabase|"
+    r"psql|mysql|sqlite3|redis-cli|mongosh|pg_dump|alembic|"
+    r"curl|wget|ssh|scp|rsync|systemctl|launchctl|"
+    r"twine|cargo|make|mvn|gradle|pytest|tox|ruff|mypy|eslint"
+    r")\b",
+    re.IGNORECASE,
+)
+
+#: Words a command and a step must share beyond the tool's own name.
+MIN_STEP_OVERLAP = 2
+
+#: And how much of the step those shared words have to account for. Raw
+#: overlap rewards verbose steps: a paragraph-long step collides with almost
+#: any command by chance, which is how `rm -rf dist build` came to look like
+#: "Full Mengram codebase audit". Requiring the command to cover half the
+#: step's words asks the opposite question — is this step *about* this
+#: command — and a step written as a command answers yes easily.
+MIN_STEP_COVERAGE = 0.5
+
+#: A step that names no tool at all ("push to main") is still a real step, and
+#: the command that is it should say so. Without a tool to anchor on, the only
+#: honest evidence is that the command contains nearly the whole step, so the
+#: bar goes up instead of the rule going away.
+MIN_UNANCHORED_COVERAGE = 0.7
+
+
+def shell_verbs(text: str) -> set[str]:
+    """The command-line tools a piece of text names."""
+    return {m.group(1).lower() for m in SHELL_VERBS.finditer(text or "")}
+
+
+def _match_words(text: str) -> set[str]:
+    """Tokens, plus the segments of any path-like one.
+
+    `tests/test_policy_hook.py` and `tests/` share nothing as whole tokens and
+    everything that matters as segments, so a step that says where to look
+    still matches the command that looks there.
+    """
+    words = set()
+    for w in tokens(text):
+        words.add(w)
+        if "/" in w:
+            words.update(part for part in w.split("/") if len(part) > 2)
+    return words
+
+
+def _command_text(command: str) -> str:
+    """The command itself, without the data it carries.
+
+    A heredoc body is an argument, not an instruction: a `cat >> notes.md`
+    that happens to contain the words "pip install" is not a step about
+    installing anything. Everything from the first `<<` is dropped, and the
+    rest is capped, because a 4 kB inline script matches everything.
+    """
+    return (command or "").split("<<", 1)[0][:500]
+
+
+def _step_text(step) -> str:
+    if isinstance(step, dict):
+        return " ".join(p for p in (step.get("action"), step.get("detail")) if p)
+    return str(step or "")
+
+
+def match_step(proc: dict, command: str) -> tuple[int, int] | None:
+    """Which step of this procedure is this command? `(step number, score)`.
+
+    The bar here is deliberately higher than `procedure_matches`. That one
+    guards a question, where a false positive costs the human one keystroke.
+    This one guards a *write*: a wrong match credits or blames a workflow that
+    had nothing to do with the command, and a track record assembled out of
+    those is worse than no record at all, because the gate then trusts it.
+
+    So the step has to name the same tool the command runs, and share a word
+    beyond that tool's name. Steps are numbered from 1, the way a failure is
+    reported.
+    """
+    command = _command_text(command)
+    verbs = shell_verbs(command)
+    if not verbs:
+        return None
+    cmd_words = _match_words(command)
+    best: tuple[int, int] | None = None
+    for i, step in enumerate(proc.get("steps") or [], 1):
+        text = _step_text(step)
+        step_words = _match_words(text)
+        if not step_words:
+            continue
+        score = len(step_words & cmd_words)
+        if score < MIN_STEP_OVERLAP:
+            continue
+        coverage = score / len(step_words)
+        anchored = bool(shell_verbs(text) & verbs)
+        floor = MIN_STEP_COVERAGE if anchored else MIN_UNANCHORED_COVERAGE
+        if coverage < floor:
+            continue
+        if best is None or score > best[1]:
+            best = (i, score)
+    return best
+
+
+def best_step_match(procs: list[dict], command: str) -> tuple[dict, int, int] | None:
+    """The procedure and step this command most plausibly is an instance of.
+
+    Returns `(procedure, step number, score)`, or None when nothing clears the
+    bar — which is the common case, and the right one.
+    """
+    best: tuple[dict, int, int] | None = None
+    for proc in procs or []:
+        m = match_step(proc, command)
+        if m is not None and (best is None or m[1] > best[2]):
+            best = (proc, m[0], m[1])
+    return best
+
+
 def reliability_of(proc: dict) -> str:
     """The record in words, computed here when the source did not include it."""
     label = proc.get("reliability")
     if isinstance(label, str) and label:
         return label
-    return estimate(int(proc.get("success_count") or 0), int(proc.get("fail_count") or 0))
+    success = int(proc.get("success_count") or 0)
+    fail = int(proc.get("fail_count") or 0)
+    if success == 0 and fail == 0:
+        # No whole-run report, which is the normal case. The steps have been
+        # watched one command at a time, and that is the evidence there is.
+        success, fail = from_steps(proc.get("steps") or [])
+    return estimate(success, fail)
 
 
 def parse_reliability(label: str) -> tuple[str, int | None]:

--- a/cloud/reliability.py
+++ b/cloud/reliability.py
@@ -44,6 +44,34 @@ def estimate(success: int, fail: int, prior: tuple = NEUTRAL_PRIOR) -> str:
     return f"{round(100 * value)}% {'reliable' if observed else 'expected'}"
 
 
+def from_steps(steps: list) -> tuple[int, int]:
+    """The whole-run record implied by the steps, for a workflow that has none.
+
+    Nothing increments a workflow's own counters unless someone reports a whole
+    run, and almost nobody ever does. Meanwhile its steps are watched one shell
+    command at a time. A workflow whose every step has been seen working is not
+    "never run" in any sense a human would accept, so the steps stand in.
+
+    The weakest step decides, not the average: a chain is exactly as
+    trustworthy as the link most likely to break, and averaging hides it.
+    Steps nobody measured are ignored rather than counted as zero, because
+    absence of measurement is not evidence of failure.
+    """
+    tracked = [s for s in (steps or [])
+               if isinstance(s, dict)
+               and (s.get("success_count") is not None or s.get("fail_count") is not None)]
+    if not tracked:
+        return (0, 0)
+
+    def _rate(step):
+        ok = int(step.get("success_count") or 0)
+        bad = int(step.get("fail_count") or 0)
+        return (ok + 1) / (ok + bad + 2)
+
+    weakest = min(tracked, key=_rate)
+    return (int(weakest.get("success_count") or 0), int(weakest.get("fail_count") or 0))
+
+
 def prior_from_lineage(evolution: list = None) -> tuple:
     """Beta prior taken from what the previous version retired with.
 

--- a/local/store.py
+++ b/local/store.py
@@ -336,6 +336,36 @@ class LocalStore:
         self.save()
         return self._procedure_dict(p)
 
+    def step_outcome(self, name: str, step: int, success: bool,
+                     reason: str | None = None) -> dict:
+        """Record one step of a procedure, not a whole run of it.
+
+        The hook that calls this watches single shell commands. A command is
+        evidence about the step it *is* and about nothing else: crediting the
+        whole workflow for one command would inflate a record the gate then
+        trusts. So this moves that step's counters and leaves the procedure's
+        own totals alone. A failure still writes `last_failure`, because the
+        workflow really did break somewhere, and that is the first thing the
+        next reader needs to see. Writes.
+        """
+        p = self._procedure(name)
+        if p is None:
+            return {"error": "procedure not found", "name": name}
+        steps = _steps_as_dicts(p.steps, with_counts=True)
+        if not 1 <= step <= len(steps):
+            return {"error": "no such step", "name": name, "step": step}
+        target = dict(steps[step - 1])
+        for key in ("success_count", "fail_count"):
+            target[key] = int(target.get(key) or 0)
+        target["success_count" if success else "fail_count"] += 1
+        steps[step - 1] = target
+        p.steps = _to_steps(steps, keep_counts=True, template=p.steps)
+        if not success and reason:
+            p.last_failure = " ".join(reason.split())
+            p.last_failed = _today()
+        self.save()
+        return self._procedure_dict(p)
+
     # ---- overview ---------------------------------------------------------
 
     def profile(self, max_entities: int = 15) -> str:

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -177,7 +177,9 @@ def test_hook_install_in_local_mode_needs_no_key(folder, monkeypatch, capsys, tm
     assert code == 0 and "local mode" in out
     settings = json.loads((tmp_path / "settings.json").read_text())
     cmds = [h["command"] for groups in settings["hooks"].values() for g in groups for h in g["hooks"]]
-    assert len(cmds) == 4 and all("--memory" in c and str(folder.resolve()) in c for c in cmds)
+    assert len(cmds) == 5 and all("--memory" in c and str(folder.resolve()) in c for c in cmds)
+    # Both halves of the gate: the question before, the record after.
+    assert any("auto-policy" in c for c in cmds) and any("auto-outcome" in c for c in cmds)
     assert settings["hooks"]["PreToolUse"][0]["matcher"] == "Bash"
 
 

--- a/tests/test_outcome_loop.py
+++ b/tests/test_outcome_loop.py
@@ -1,0 +1,270 @@
+"""The other half of the gate: recording what a command actually did.
+
+`auto-policy` asks about a workflow whose record is weak. Nothing gave a
+workflow a record until `auto-outcome`, which is why every procedure in a real
+folder read `untested` forever. These tests pin the two things that make the
+record worth trusting: it is written only when the command really is one step
+of the procedure, and one command is credited to one step rather than to the
+whole workflow.
+"""
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import cli
+from cloud import policy
+from cloud.reliability import from_steps
+
+RELEASE = {
+    "id": "p1", "name": "Release to PyPI", "version": 1,
+    "steps": [
+        {"action": "run the test suite", "detail": "pytest -q tests/"},
+        {"action": "build the artifacts", "detail": "python3 -m build"},
+        {"action": "upload to PyPI", "detail": "twine upload dist/*"},
+        {"action": "write the announcement post"},
+    ],
+}
+
+
+# --- which step is this command? -------------------------------------------
+
+def test_command_matches_the_step_that_names_the_same_tool():
+    assert policy.match_step(RELEASE, "python3 -m twine upload dist/*")[0] == 3
+    assert policy.match_step(RELEASE, "python3 -m build --wheel")[0] == 2
+
+
+def test_path_segments_count_as_shared_words():
+    # "tests/" and "tests/test_policy_hook.py" are not the same token.
+    assert policy.match_step(RELEASE, "pytest -q tests/test_policy_hook.py")[0] == 1
+
+
+def test_prose_steps_never_match_a_command():
+    prose = {"name": "Launch", "steps": [{"action": "write the launch post"},
+                                         {"action": "decide the price"}]}
+    assert policy.match_step(prose, "git push origin main") is None
+
+
+def test_a_shared_tool_alone_is_not_enough():
+    # `git` appears in both, but nothing else does: one word is a coincidence.
+    proc = {"name": "x", "steps": [{"action": "tag the release", "detail": "git tag -a v1"}]}
+    assert policy.match_step(proc, "git status") is None
+
+
+def test_command_without_a_known_tool_matches_nothing():
+    assert policy.match_step(RELEASE, "echo done") is None
+    assert policy.shell_verbs("echo done") == set()
+
+
+def test_best_step_match_prefers_the_stronger_overlap():
+    other = {"name": "Other", "steps": [{"action": "check", "detail": "twine check"}]}
+    proc, step, _ = policy.best_step_match([other, RELEASE], "twine upload dist/*")
+    assert (proc["name"], step) == ("Release to PyPI", 3)
+
+
+def test_best_step_match_returns_none_when_nothing_clears_the_bar():
+    assert policy.best_step_match([RELEASE], "ls -la") is None
+
+
+def test_a_verbose_step_does_not_match_by_chance():
+    """Raw overlap rewards long steps; coverage is what stops that."""
+    wordy = {"name": "Audit", "steps": [{
+        "action": "audit the mengram codebase",
+        "detail": ("walk every module under cloud and local, build the dist, "
+                   "run python3 against each entry point, and write up what "
+                   "the audit found in the projects notes"),
+    }]}
+    assert policy.match_step(wordy, "rm -rf dist build && python3 -m build") is None
+
+
+def test_heredoc_bodies_are_not_part_of_the_command():
+    """`cat >> notes.md <<EOF ... pip install ... EOF` installs nothing."""
+    proc = {"name": "Setup", "steps": [{"action": "install the library",
+                                        "detail": "pip install mengram-ai"}]}
+    carrier = "cat >> notes.md <<'EOF'\npip install mengram-ai is how you start\nEOF"
+    assert policy.match_step(proc, carrier) is None
+    assert policy._command_text(carrier) == "cat >> notes.md "
+
+
+def test_enormous_inline_scripts_are_capped():
+    assert len(policy._command_text("python3 - " + "x" * 5000)) == 500
+
+
+def test_a_step_naming_no_tool_needs_to_be_nearly_all_there():
+    """"push to main" is a real step, and `git push origin main` is it."""
+    plain = {"name": "Deploy", "steps": [{"action": "push to main"}]}
+    assert policy.match_step(plain, "git push origin main")[0] == 1
+    # Same step, now diluted by commentary the command says nothing about.
+    diluted = {"name": "Deploy", "steps": [{
+        "action": "push to main",
+        "detail": "the webhook picks it up and rebuilds the container image"}]}
+    assert policy.match_step(diluted, "git push origin main") is None
+
+
+# --- did it work? ----------------------------------------------------------
+
+@pytest.mark.parametrize("response,expected", [
+    ({"exit_code": 0}, True),
+    ({"exit_code": 1}, False),
+    ({"exitCode": 2}, False),
+    ({"is_error": True}, False),
+    ({"isError": False}, True),
+    ({"stdout": "fine"}, None),          # no verdict in the transcript
+    ({"exit_code": 0, "interrupted": True}, None),
+    ({"exit_code": True}, None),         # a bool is not an exit code
+    ("not a dict", None),
+])
+def test_bash_outcome(response, expected):
+    assert cli._bash_outcome(response) is expected
+
+
+def test_stderr_alone_is_not_a_failure():
+    # Plenty of healthy tools write to stderr.
+    assert cli._bash_outcome({"exit_code": 0, "stderr": "warning: deprecated"}) is True
+
+
+def test_failure_reason_is_the_last_line_and_bounded():
+    assert cli._failure_reason({"stderr": "trace\n  more\nboom: it broke"}) == "boom: it broke"
+    assert cli._failure_reason({"stderr": "", "stdout": "fallback"}) == "fallback"
+    assert cli._failure_reason({"stderr": "x" * 500}).__len__() == 200
+    assert cli._failure_reason({}) is None
+
+
+# --- one command credits one step ------------------------------------------
+
+def _read(tmp_path):
+    """A fresh view of the folder — the hook wrote to disk, not to our object."""
+    from local.store import LocalStore
+    return LocalStore(str(tmp_path)).procedures()
+
+
+def _folder(tmp_path):
+    from local.store import LocalStore
+    store = LocalStore(str(tmp_path))
+    store.save_extracted_procedure("Release to PyPI", "shipping a version",
+                                   [dict(s) for s in RELEASE["steps"]])
+    store.save()
+    return store
+
+
+def test_step_outcome_moves_the_step_and_not_the_workflow(tmp_path):
+    store = _folder(tmp_path)
+    store.step_outcome("Release to PyPI", 3, success=True)
+    proc = store.procedures()[0]
+    assert proc["success_count"] == 0 and proc["fail_count"] == 0
+    steps = proc["steps"]
+    assert steps[2]["success_count"] == 1
+    # Steps nobody watched stay unmeasured rather than counted as zero runs.
+    assert steps[3].get("success_count") in (None, 0)
+    assert steps[0].get("fail_count") in (None, 0)
+
+
+def test_step_failure_records_why(tmp_path):
+    store = _folder(tmp_path)
+    store.step_outcome("Release to PyPI", 1, success=False, reason="3 failed, 12 passed")
+    proc = store.procedures()[0]
+    assert proc["steps"][0]["fail_count"] == 1
+    assert proc["last_failure"] == "3 failed, 12 passed"
+    assert proc["last_failed"]
+
+
+def test_step_outcome_rejects_nonsense(tmp_path):
+    store = _folder(tmp_path)
+    assert "error" in store.step_outcome("Release to PyPI", 99, success=True)
+    assert "error" in store.step_outcome("Release to PyPI", 0, success=True)
+    assert "error" in store.step_outcome("no such workflow", 1, success=True)
+
+
+# --- the record the gate then reads ----------------------------------------
+
+def test_reliability_falls_back_to_the_weakest_watched_step():
+    proc = {"name": "x", "steps": [{"action": "a", "success_count": 9, "fail_count": 0},
+                                   {"action": "b", "success_count": 1, "fail_count": 2}]}
+    assert from_steps(proc["steps"]) == (1, 2)
+    assert policy.reliability_of(proc) == "40% reliable"
+
+
+def test_unwatched_steps_are_ignored_not_counted_as_failures():
+    assert from_steps([{"action": "a"}, {"action": "b"}]) == (0, 0)
+    assert policy.reliability_of({"name": "x", "steps": [{"action": "a"}]}) == "untested"
+
+
+def test_a_real_whole_run_record_still_wins():
+    proc = {"name": "x", "success_count": 4, "fail_count": 0,
+            "steps": [{"action": "a", "success_count": 0, "fail_count": 9}]}
+    assert policy.reliability_of(proc) == "83% reliable"
+
+
+def test_step_evidence_can_make_the_gate_ask(tmp_path):
+    store = _folder(tmp_path)
+    store.step_outcome("Release to PyPI", 1, success=False, reason="boom")
+    proc = policy.memfmt_procedures(str(tmp_path))[0]
+    verdict = policy.decide(proc, "pytest -q tests/")
+    assert verdict and verdict["decision"] == "ask"
+
+
+# --- the hook end to end ---------------------------------------------------
+
+def _run(monkeypatch, capsys, payload, memory):
+    monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(sys, "argv",
+                        ["mengram", "auto-outcome", "--memory", str(memory), "--verbose"])
+    with pytest.raises(SystemExit) as e:
+        cli.main()
+    assert e.value.code == 0
+    return json.loads(capsys.readouterr().out.strip())["systemMessage"]
+
+
+def _bash(command, response):
+    return {"hook_event_name": "PostToolUse", "tool_name": "Bash",
+            "tool_input": {"command": command}, "tool_response": response}
+
+
+def test_hook_records_a_success(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    msg = _run(monkeypatch, capsys, _bash("twine upload dist/*", {"exit_code": 0}), tmp_path)
+    assert "step 3 recorded as success" in msg
+    assert _read(tmp_path)[0]["steps"][2]["success_count"] == 1
+
+
+def test_hook_records_a_failure_with_its_reason(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    payload = _bash("pytest -q tests/", {"exit_code": 1, "stderr": "2 failed"})
+    assert "step 1 recorded as failure" in _run(monkeypatch, capsys, payload, tmp_path)
+    proc = _read(tmp_path)[0]
+    assert proc["steps"][0]["fail_count"] == 1
+    assert proc["last_failure"] == "2 failed"
+
+
+def test_hook_writes_nothing_when_the_outcome_is_unclear(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    msg = _run(monkeypatch, capsys, _bash("twine upload dist/*", {"stdout": "?"}), tmp_path)
+    assert "outcome unclear" in msg
+    assert _read(tmp_path)[0]["steps"][2].get("success_count") in (None, 0)
+
+
+def test_hook_ignores_unrelated_commands_and_other_tools(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    assert "no known tool" in _run(
+        monkeypatch, capsys, _bash("ls -la /tmp", {"exit_code": 0}), tmp_path)
+    assert "no step matched" in _run(
+        monkeypatch, capsys, _bash("git status", {"exit_code": 0}), tmp_path)
+    other = {"hook_event_name": "PostToolUse", "tool_name": "Read",
+             "tool_input": {"file_path": "x"}, "tool_response": {"exit_code": 0}}
+    assert "not Bash" in _run(monkeypatch, capsys, other, tmp_path)
+
+
+def test_hook_stays_silent_without_verbose(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
+    monkeypatch.setattr(sys, "stdin",
+                        io.StringIO(json.dumps(_bash("twine upload dist/*", {"exit_code": 0}))))
+    monkeypatch.setattr(sys, "argv", ["mengram", "auto-outcome", "--memory", str(tmp_path)])
+    with pytest.raises(SystemExit) as e:
+        cli.main()
+    assert e.value.code == 0
+    assert "systemMessage" not in capsys.readouterr().out

--- a/tests/test_policy_hook.py
+++ b/tests/test_policy_hook.py
@@ -15,7 +15,7 @@ DEPLOY = {
     "id": "p1", "name": "deploy to Railway", "version": 3,
     "trigger_condition": "a change lands on main",
     "steps": [
-        {"action": "push to main", "detail": "the webhook does the rest"},
+        {"action": "push to main", "detail": "git push origin main"},
         {"action": "watch the boot log"},
         {"action": "verify /health", "detail": "expect 200 within 60s"},
     ],
@@ -116,7 +116,7 @@ def test_plan_carries_the_last_failure_when_known():
 def test_plan_carries_steps_and_preconditions():
     proc = _with((0, 0), metadata={"preconditions": ["migrations applied"]})
     v = policy.decide(proc, "git push origin main")
-    assert "1. push to main — the webhook does the rest" in v["plan"]
+    assert "1. push to main — git push origin main" in v["plan"]
     assert "Preconditions: migrations applied" in v["plan"]
 
 


### PR DESCRIPTION
The policy gate has never fired for anyone, and the reason was not its logic: **nothing ever wrote a run down**. `procedure_feedback` existed only as a command a human had to type, so 34 of the 37 procedures in a real folder read `untested` forever and the gate was an opinion with no evidence under it.

### What this adds

- **`auto-outcome`** — a PostToolUse hook on Bash. It recognises a command as one step of a learned procedure and records its exit code against that step. Prints nothing, exits 0 whatever happens.
- **`LocalStore.step_outcome`** — writes step counts only. One command is evidence about one step; crediting the whole workflow for it would inflate the record the gate then trusts.
- **`reliability.from_steps`** — a workflow with watched steps stops reading `untested`. The weakest watched step sets the number; unwatched steps are ignored rather than counted as failures.
- **`policy.match_step` / `best_step_match`** — decide whether a command *is* a step: the same tool named and half the step's words covered, or nearly all of them when the step names no tool. Heredoc bodies and huge inline scripts are stripped first.
- The gate now asks on the same bar it records on.

### Measured, not assumed

Replaying **3456 real Bash commands** from local Claude Code history against a real 37-procedure folder:

| | fires |
|---|---|
| gate as shipped (one shared word) | 795 — one command in six |
| gate with step matching | 8 |

The shipped version matched `rm -rf dist build` to "Full Mengram codebase audit" and `git push` to "MVP video-pitch lead outreach pipeline". Both of the distinct matches that survive are the right ones, e.g. a command searching for the Railway binary against the step "Locate Railway CLI — find CLI binary if not in PATH".

### Known limit

Cloud stays on whole-run feedback. Its endpoint always moves the procedure's own counters, so writing a single command there would inflate it. A step-scoped API write is the follow-up.

Tests: 424 passed; the 3 `TestParseVault` failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt