### PR TITLE
2.38.0: run outcomes recorded, gate asks on the same bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 2.38.0 — 2026-09-09
+
+### Added
+- **Run outcomes are recorded.** A new `PostToolUse` hook, `mengram auto-outcome`,
+  recognises a Bash command as one step of a learned workflow and writes that
+  command's exit code against that step. Until now nothing produced a track
+  record at all: `procedure_feedback` existed only as a command a human had to
+  type, so procedures stayed `untested` forever and the policy gate had no
+  evidence to judge by. `mengram hook install` installs it; folder mode only
+  for now (the cloud endpoint records whole runs, and a single command written
+  there would inflate the record).
+- `mengram local` gained `step_outcome` underneath: one command credits one
+  step, never the whole workflow.
+- A workflow whose steps have been watched working no longer reads `untested`.
+  The weakest watched step sets the number; steps nobody measured are ignored
+  rather than counted as failures.
+
+### Changed
+- **The policy gate asks far less, and about the right things.** It used to
+  fire when a command shared a single word with a procedure. Replaying 3456
+  real Bash commands against a real 37-procedure folder, that was 795
+  confirmation prompts — one command in six — on matches like `rm -rf dist
+  build` against "Full Mengram codebase audit". A command must now *be* a
+  step: the same tool named and half the step's words covered, or nearly all
+  of them when the step names no tool. The same replay now fires 8 times.
+  Heredoc bodies and huge inline scripts are stripped before matching, so a
+  `cat >> notes.md` whose text mentions `pip install` no longer matches an
+  install step.
+
 ## 2.37.2 — 2026-09-07
 
 ### Fixed

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.37.2"
+__version__ = "2.38.0"
 """Mengram — AI memory layer for apps."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.37.2"
+version = "2.38.0"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump and changelog for #116.

Tests: 424 passed; the 3 `TestParseVault` failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt