### PR TITLE
2.38.1: hooks that are installed must actually run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2.38.1 — 2026-09-09
+
+### Fixed
+- **`hook install` writes a command Claude Code can actually run.** It wrote a
+  bare `mengram`, which resolves only when the install happened to land on
+  PATH. A `pip install --user` on macOS does not, and Claude Code runs hooks in
+  a shell that never reads your profile, so the command was not found. Every
+  hook is built to fail silently, so nothing was ever printed: auto-save,
+  auto-recall and the session profile simply never ran. Found on a machine
+  where they had been dead since May. The install now writes the full path of
+  the program that is running, and verifies it can be launched before it
+  finishes.
+- **`hook status` runs the hooks instead of trusting the settings file.** It
+  used to look for the command text in `settings.json` and print "installed".
+  It now executes each one the way Claude Code would, through a plain shell,
+  and names any that cannot run along with the shell's own error.
+- **`doctor` checks the hooks before the cloud.** A round-trip against the API
+  said "OK" while every hook was dead. Hooks that are installed and cannot run
+  now fail `doctor` with the offending command.
+
 ## 2.38.0 — 2026-09-09
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.38.0"
+__version__ = "2.38.1"
 """Mengram — AI memory layer for apps."""

--- a/cli.py
+++ b/cli.py
@@ -984,6 +984,75 @@ def cmd_auto_outcome(args):
         _exit("error")
 
 
+def _resolve_mengram_bin() -> str:
+    """The program to write into a hook command.
+
+    A bare `mengram` is found only when the install put it on PATH, and a
+    user-site install on macOS does not. The hook then runs in a shell that
+    never loads a profile, so it fails — and every hook is built to fail
+    silently, which is how an install can report success and do nothing for
+    months. The most reliable answer is the script that is running right now:
+    it demonstrably launched, so writing its path down cannot be wrong.
+    """
+    candidate = sys.argv[0] or ""
+    try:
+        path = Path(candidate).resolve()
+    except (OSError, ValueError):
+        path = None
+    if (path and path.is_file() and os.access(path, os.X_OK)
+            and path.name.startswith("mengram")):
+        return str(path)
+    return shutil.which("mengram") or "mengram"
+
+
+def _shell_quote(path: str) -> str:
+    return f'"{path}"' if " " in path else path
+
+
+def _broken_hook_commands() -> list[tuple[str, str]]:
+    """Installed Mengram hooks that a shell cannot run: `[(command, why)]`.
+
+    Empty when nothing is installed. Not installed is a choice; installed and
+    unable to launch is the failure worth shouting about.
+    """
+    try:
+        settings_path = get_claude_code_settings_path()
+        settings = json.loads(settings_path.read_text()) if settings_path.exists() else {}
+    except Exception:
+        return []
+    out = []
+    for groups in (settings.get("hooks") or {}).values():
+        for group in groups or []:
+            for hook in group.get("hooks", []) or []:
+                cmd = hook.get("command", "")
+                if "mengram" not in cmd or "auto-" not in cmd:
+                    continue
+                ok, detail = _hook_command_runs(cmd)
+                if not ok:
+                    out.append((cmd, detail))
+    return out
+
+
+def _hook_command_runs(command: str) -> tuple[bool, str]:
+    """Can a shell actually run this hook command? `(ok, detail)`.
+
+    Asked the way Claude Code asks it — through a non-interactive shell, which
+    does not read the profile that makes `mengram` resolvable in a terminal.
+    That gap is the whole bug: a check that only reads settings.json reports a
+    healthy install that has never run once.
+    """
+    import subprocess
+    try:
+        r = subprocess.run(f"{command} --help", shell=True, capture_output=True,
+                           text=True, timeout=20)
+    except Exception as e:
+        return False, type(e).__name__
+    if r.returncode == 0:
+        return True, ""
+    lines = (r.stderr or r.stdout or "").strip().splitlines()
+    return False, (lines[-1][:120] if lines else f"exit {r.returncode}")
+
+
 def cmd_hook(args):
     """Manage Claude Code auto-save hook"""
     action = getattr(args, "hook_action", None)
@@ -1331,6 +1400,17 @@ def cmd_doctor(args):
     import urllib.request
     import urllib.error
     import time
+
+    # Hooks first. A cloud round-trip says nothing about whether the hooks that
+    # actually do the work can launch, and reporting OK while they cannot is
+    # how an install stayed dead for months without anyone noticing.
+    broken = _broken_hook_commands()
+    if broken:
+        print("FAIL: Claude Code hooks are installed but cannot run.", file=sys.stderr)
+        for cmd, detail in broken:
+            print(f"  {cmd}\n    -> {detail}", file=sys.stderr)
+        print("  Run `mengram hook install` again to write the full path.", file=sys.stderr)
+        sys.exit(1)
 
     api_key = _load_cloud_api_key()
     if not api_key:
@@ -1782,11 +1862,14 @@ def cmd_hook_install(args):
     user_id = getattr(args, "user_id", None)
 
     # Build hook commands
-    save_cmd = f"mengram auto-save --every {every}"
-    recall_cmd = "mengram auto-recall"
-    context_cmd = "mengram auto-context"
-    policy_cmd = "mengram auto-policy"
-    outcome_cmd = "mengram auto-outcome"
+    # Absolute path, not a bare name: see _resolve_mengram_bin.
+    mengram_bin = _resolve_mengram_bin()
+    prog = _shell_quote(mengram_bin)
+    save_cmd = f"{prog} auto-save --every {every}"
+    recall_cmd = f"{prog} auto-recall"
+    context_cmd = f"{prog} auto-context"
+    policy_cmd = f"{prog} auto-policy"
+    outcome_cmd = f"{prog} auto-outcome"
     if user_id:
         save_cmd += f" --user-id {user_id}"
         recall_cmd += f" --user-id {user_id}"
@@ -1866,6 +1949,21 @@ def cmd_hook_install(args):
         print(f"  Policy gate:  confirm before running a workflow with a weak record")
     print(f"  Run outcomes: record whether a workflow's step worked")
     print(f"  Settings: {settings_path}")
+
+    # Verify rather than assume. An install that cannot run is the failure
+    # this whole path is here to stop being invisible.
+    ok, detail = _hook_command_runs(save_cmd)
+    if ok:
+        print(f"  Verified: {mengram_bin} runs from a plain shell")
+    else:
+        print(f"\n  WARNING: the hook command does not run: {detail}")
+        print(f"  Claude Code would launch: {save_cmd}")
+        if mengram_bin == "mengram":
+            print("  `mengram` is not on PATH here, so the hooks would do nothing,")
+            print("  silently. Reinstall with the full path, or add the directory")
+            print("  holding the `mengram` script to PATH and run this again.")
+        print("  Nothing else in Claude Code is affected.")
+
     print(f"\nRestart Claude Code for hooks to take effect.")
 
 
@@ -1953,6 +2051,27 @@ def cmd_hook_status(args):
     print(f"  Session context: {'installed' if context_cmd else 'not installed'}")
     print(f"  Policy gate:    {'installed' if policy_cmd else 'not installed'}")
     print(f"  Run outcomes:   {'installed' if outcome_cmd else 'not installed'}")
+
+    # Installed is not the same as working: run what Claude Code would run.
+    broken = []
+    for label, cmd in (("Auto-save", save_cmd), ("Auto-recall", recall_cmd),
+                       ("Session context", context_cmd), ("Policy gate", policy_cmd),
+                       ("Run outcomes", outcome_cmd)):
+        if not cmd:
+            continue
+        ok, detail = _hook_command_runs(cmd)
+        if not ok:
+            broken.append((label, cmd, detail))
+    if broken:
+        print("\n  THESE HOOKS ARE INSTALLED BUT CANNOT RUN:")
+        for label, cmd, detail in broken:
+            print(f"    {label}: {detail}")
+            print(f"      command: {cmd}")
+        print("  Claude Code runs hooks in a plain shell that does not read your")
+        print("  profile, so a command that works in your terminal can still fail")
+        print("  here. Run `mengram hook install` again to write the full path.")
+    elif save_cmd or recall_cmd or context_cmd or policy_cmd or outcome_cmd:
+        print("  Hook commands:  verified, they run from a plain shell")
 
     # Check API key
     api_key = os.environ.get("MENGRAM_API_KEY", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.38.0"
+version = "2.38.1"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_hook_health.py
+++ b/tests/test_hook_health.py
@@ -1,0 +1,157 @@
+"""An install that cannot run must never report success.
+
+Hooks are built to fail silently, which is right: a broken hook must not stop
+you working. The cost is that a hook which never launches looks exactly like a
+hook with nothing to say. `mengram hook install` wrote a bare `mengram` into
+Claude Code's settings, which resolves only when the install happened to land
+on PATH; `hook status` then read that file back and said "installed", and
+`doctor` pinged the cloud and said "OK". All three could be true while nothing
+had run for months. These tests hold that door shut.
+"""
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import cli
+
+
+def _fake_script(tmp_path, name="mengram"):
+    p = tmp_path / name
+    p.write_text("#!/bin/sh\nexit 0\n")
+    p.chmod(p.stat().st_mode | stat.S_IXUSR)
+    return p
+
+
+# --- which program gets written into the settings --------------------------
+
+def test_the_running_script_is_what_gets_written(tmp_path, monkeypatch):
+    script = _fake_script(tmp_path)
+    monkeypatch.setattr(sys, "argv", [str(script), "hook", "install"])
+    assert cli._resolve_mengram_bin() == str(script.resolve())
+
+
+def test_a_module_invocation_falls_back_to_path(tmp_path, monkeypatch):
+    # `python cli.py hook install`: argv[0] is not the console script.
+    monkeypatch.setattr(sys, "argv", ["cli.py", "hook", "install"])
+    monkeypatch.setattr(cli.shutil, "which", lambda n: "/somewhere/bin/mengram")
+    assert cli._resolve_mengram_bin() == "/somewhere/bin/mengram"
+
+
+def test_bare_name_only_as_a_last_resort(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["cli.py"])
+    monkeypatch.setattr(cli.shutil, "which", lambda n: None)
+    assert cli._resolve_mengram_bin() == "mengram"
+
+
+def test_a_non_executable_file_is_not_the_program(tmp_path, monkeypatch):
+    plain = tmp_path / "mengram"
+    plain.write_text("not executable")
+    monkeypatch.setattr(sys, "argv", [str(plain)])
+    monkeypatch.setattr(cli.shutil, "which", lambda n: None)
+    assert cli._resolve_mengram_bin() == "mengram"
+
+
+def test_paths_with_spaces_are_quoted():
+    assert cli._shell_quote("/Users/a b/bin/mengram") == '"/Users/a b/bin/mengram"'
+    assert cli._shell_quote("/usr/bin/mengram") == "/usr/bin/mengram"
+
+
+# --- asking the question the way Claude Code asks it -----------------------
+
+def test_a_command_that_does_not_resolve_is_reported_as_broken():
+    ok, detail = cli._hook_command_runs("definitely-not-a-real-program-9f3a auto-save")
+    assert ok is False and detail
+
+
+def test_a_command_that_resolves_is_reported_as_working():
+    ok, detail = cli._hook_command_runs(sys.executable)
+    assert ok is True and detail == ""
+
+
+def test_the_check_uses_a_plain_shell_not_the_users_profile(tmp_path, monkeypatch):
+    """The bug in one test: on PATH here, still broken where hooks run."""
+    script = _fake_script(tmp_path, "mengram-probe")
+    # Visible to a PATH lookup inside this process...
+    monkeypatch.setenv("PATH", os.defpath)
+    assert cli.shutil.which("mengram-probe") is None
+    # ...and the shell agrees, which is the point: both must be asked.
+    ok, _ = cli._hook_command_runs("mengram-probe auto-save")
+    assert ok is False
+    assert script.exists()
+
+
+# --- what status and doctor read ------------------------------------------
+
+def _settings(tmp_path, command):
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps({"hooks": {"Stop": [
+        {"hooks": [{"type": "command", "command": command}]}]}}))
+    return p
+
+
+def test_a_broken_installed_hook_is_found(tmp_path, monkeypatch):
+    p = _settings(tmp_path, "/nonexistent/bin/mengram auto-save --every 3")
+    monkeypatch.setattr(cli, "get_claude_code_settings_path", lambda: p)
+    broken = cli._broken_hook_commands()
+    assert len(broken) == 1 and "auto-save" in broken[0][0]
+
+
+def test_a_working_installed_hook_is_not_reported(tmp_path, monkeypatch):
+    p = _settings(tmp_path, f"{_fake_script(tmp_path)} auto-save --every 3")
+    monkeypatch.setattr(cli, "get_claude_code_settings_path", lambda: p)
+    assert cli._broken_hook_commands() == []
+
+
+def test_other_peoples_hooks_are_left_alone(tmp_path, monkeypatch):
+    p = _settings(tmp_path, "~/.claude/hooks/block-push-to-main.sh")
+    monkeypatch.setattr(cli, "get_claude_code_settings_path", lambda: p)
+    assert cli._broken_hook_commands() == []
+
+
+def test_no_hooks_installed_is_not_a_failure(tmp_path, monkeypatch):
+    p = tmp_path / "settings.json"
+    p.write_text("{}")
+    monkeypatch.setattr(cli, "get_claude_code_settings_path", lambda: p)
+    assert cli._broken_hook_commands() == []
+
+
+def test_unreadable_settings_do_not_crash(tmp_path, monkeypatch):
+    p = tmp_path / "settings.json"
+    p.write_text("{ not json")
+    monkeypatch.setattr(cli, "get_claude_code_settings_path", lambda: p)
+    assert cli._broken_hook_commands() == []
+
+
+def test_doctor_fails_before_touching_the_cloud(tmp_path, monkeypatch, capsys):
+    """A cloud round-trip says nothing about whether the hooks can launch."""
+    p = _settings(tmp_path, "/nonexistent/bin/mengram auto-save")
+    monkeypatch.setattr(cli, "get_claude_code_settings_path", lambda: p)
+    monkeypatch.setattr(cli, "_load_cloud_api_key",
+                        lambda: (_ for _ in ()).throw(AssertionError("cloud was contacted")))
+    with pytest.raises(SystemExit) as e:
+        cli.cmd_doctor(type("A", (), {})())
+    assert e.value.code == 1
+    assert "cannot run" in capsys.readouterr().err
+
+
+# --- install writes something that works -----------------------------------
+
+def test_install_writes_the_full_path_and_verifies_it(tmp_path, monkeypatch, capsys):
+    folder = tmp_path / "memory"
+    (folder / "procedures").mkdir(parents=True)
+    settings = tmp_path / "settings.json"
+    monkeypatch.setattr(cli, "get_claude_code_settings_path", lambda: settings)
+    script = _fake_script(tmp_path)
+    monkeypatch.setattr(cli, "_resolve_mengram_bin", lambda: str(script))
+    args = type("A", (), {"memory": str(folder), "every": 3, "user_id": None,
+                          "no_policy": False})()
+    cli.cmd_hook_install(args)
+    written = json.loads(settings.read_text())
+    cmds = [h["command"] for gs in written["hooks"].values() for g in gs for h in g["hooks"]]
+    assert cmds and all(c.startswith(str(script)) for c in cmds)
+    assert "Verified" in capsys.readouterr().out


### PR DESCRIPTION
`hook install` wrote a bare `mengram` into Claude Code's settings. That resolves only if the install happened to put the console script on PATH. A `pip install --user` on macOS does not, and Claude Code runs hooks in a shell that never reads a profile, so the command was not found. Every hook is built to exit 0 in silence, which is correct for a hook and fatal for diagnosis: nothing is ever printed.

Meanwhile `hook status` only looked for the command text inside `settings.json` and answered "installed", and `doctor` only pinged the cloud and answered "OK". All three could agree while auto-save, auto-recall and the session profile had not run once.

Found on a real machine where they had been dead since May. It is also why the policy gate had never fired for anyone: it could not have.

### Changes

- **install** writes the full path of the program that is running (argv[0] when it is the console script, then PATH, then the bare name as a last resort), quotes paths with spaces, and verifies the command launches before it finishes.
- **status** executes each installed hook through a plain shell, the way Claude Code would, and names the ones that cannot run along with the shell's own error.
- **doctor** checks hooks before the cloud and fails when an installed hook cannot launch. Not having hooks installed is still fine.

Tests: 439 passed, 15 of them new; the 3 `TestParseVault` failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt