### PR TITLE
2.38.2: the outcome hook recorded nothing, because the docs are wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.38.2 — 2026-09-09
+
+### Fixed
+- **The run-outcome hook recorded nothing.** It looked for an `exit_code` in
+  the PostToolUse payload, following the documented schema. A real Claude Code
+  sends no exit code for Bash: the payload carries `stdout`, `stderr`,
+  `interrupted`, `isImage` and `noOutputExpected`, and — measured with a
+  logging hook — the event fires *only after a command that succeeded*. A
+  failing command produces no PostToolUse at all. So the arrival of the event
+  is the signal, and 2.38.0 treated it as "no verdict" and wrote nothing.
+
+### Known limit
+- Failures cannot be seen from this hook, because it does not fire for them.
+  The loop records successes and never guesses a failure; a failure still has
+  to come from `mengram local feedback`, or from a host that does send an exit
+  code. Reading them out of the session transcript is the obvious next step.
+
 ## 2.38.1 — 2026-09-09
 
 ### Fixed

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.38.1"
+__version__ = "2.38.2"
 """Mengram — AI memory layer for apps."""

--- a/cli.py
+++ b/cli.py
@@ -882,12 +882,20 @@ def cmd_auto_policy(args):
 
 
 def _bash_outcome(tool_response) -> bool | None:
-    """Did this command work? None when the transcript does not actually say.
+    """Did this command work? None when the event does not say.
 
-    Silence is the right answer for anything ambiguous. A guessed success is
-    what makes a track record lie, and the gate downstream believes it.
-    A non-empty stderr is deliberately *not* a failure: plenty of healthy
-    tools write there.
+    Measured against a real payload rather than the documentation, which
+    describes an `exit_code` this host does not send. What actually arrives for
+    Bash is `stdout`, `stderr`, `interrupted`, `isImage`, `noOutputExpected` —
+    and, decisively, the event arrives *only when the command succeeded*. A
+    command that exits non-zero fires no PostToolUse at all (verified: a
+    logging hook recorded the successful marker command and never the failing
+    one). So the arrival of the event is itself the signal.
+
+    That makes failures unobservable from here. They are not guessed at: this
+    returns True or None, never False, unless a host does send an exit code.
+    A non-empty stderr is deliberately not a failure — plenty of healthy tools
+    write there — and an interrupted command is not evidence of anything.
     """
     if not isinstance(tool_response, dict):
         return None
@@ -901,7 +909,8 @@ def _bash_outcome(tool_response) -> bool | None:
     flag = tool_response.get("is_error", tool_response.get("isError"))
     if isinstance(flag, bool):
         return not flag
-    return None
+    # No verdict in the payload, and this event only fires after a success.
+    return True
 
 
 def _failure_reason(tool_response) -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.38.1"
+version = "2.38.2"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_outcome_loop.py
+++ b/tests/test_outcome_loop.py
@@ -112,17 +112,39 @@ def test_a_step_naming_no_tool_needs_to_be_nearly_all_there():
     ({"exitCode": 2}, False),
     ({"is_error": True}, False),
     ({"isError": False}, True),
-    ({"stdout": "fine"}, None),          # no verdict in the transcript
     ({"exit_code": 0, "interrupted": True}, None),
     ({"exit_code": True}, None),         # a bool is not an exit code
     ("not a dict", None),
 ])
-def test_bash_outcome(response, expected):
+def test_bash_outcome_when_a_host_reports_one(response, expected):
     assert cli._bash_outcome(response) is expected
 
 
-def test_stderr_alone_is_not_a_failure():
-    # Plenty of healthy tools write to stderr.
+def test_the_real_claude_code_payload_means_success():
+    """The event carries no exit code, and only arrives when the command worked.
+
+    This is the actual shape, captured from a running Claude Code, not the
+    shape the docs describe. Getting it wrong is not a small error: reading it
+    as "no verdict" makes the whole loop record nothing at all, which is what
+    2.38.0 shipped.
+    """
+    real = {"stdout": "ok", "stderr": "", "interrupted": False,
+            "isImage": False, "noOutputExpected": False}
+    assert cli._bash_outcome(real) is True
+
+
+def test_an_interrupted_command_is_still_no_evidence():
+    real = {"stdout": "", "stderr": "", "interrupted": True,
+            "isImage": False, "noOutputExpected": False}
+    assert cli._bash_outcome(real) is None
+
+
+def test_stderr_without_an_exit_code_is_not_a_failure():
+    real = {"stdout": "", "stderr": "warning: deprecated", "interrupted": False}
+    assert cli._bash_outcome(real) is True
+
+
+def test_stderr_alongside_a_zero_exit_is_not_a_failure():
     assert cli._bash_outcome({"exit_code": 0, "stderr": "warning: deprecated"}) is True
 
 
@@ -240,11 +262,21 @@ def test_hook_records_a_failure_with_its_reason(monkeypatch, capsys, tmp_path):
     assert proc["last_failure"] == "2 failed"
 
 
-def test_hook_writes_nothing_when_the_outcome_is_unclear(monkeypatch, capsys, tmp_path):
+def test_hook_writes_nothing_when_the_command_was_interrupted(monkeypatch, capsys, tmp_path):
     _folder(tmp_path)
-    msg = _run(monkeypatch, capsys, _bash("twine upload dist/*", {"stdout": "?"}), tmp_path)
-    assert "outcome unclear" in msg
+    payload = _bash("twine upload dist/*", {"stdout": "", "interrupted": True})
+    assert "outcome unclear" in _run(monkeypatch, capsys, payload, tmp_path)
     assert _read(tmp_path)[0]["steps"][2].get("success_count") in (None, 0)
+
+
+def test_hook_records_from_the_real_payload_shape(monkeypatch, capsys, tmp_path):
+    """End to end on what Claude Code actually sends."""
+    _folder(tmp_path)
+    real = {"stdout": "uploaded", "stderr": "", "interrupted": False,
+            "isImage": False, "noOutputExpected": False}
+    msg = _run(monkeypatch, capsys, _bash("twine upload dist/*", real), tmp_path)
+    assert "step 3 recorded as success" in msg
+    assert _read(tmp_path)[0]["steps"][2]["success_count"] == 1
 
 
 def test_hook_ignores_unrelated_commands_and_other_tools(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
`_bash_outcome` looked for an `exit_code` in the PostToolUse payload, which is what the hook reference documents. A running Claude Code sends no such field for Bash.

Captured from a live session, the Bash payload is:

```json
{"stdout": "...", "stderr": "", "interrupted": false, "isImage": false, "noOutputExpected": false}
```

And a logging hook showed something more important: **the event fires only after a command that succeeded.** A marker command exiting 7 produced no PostToolUse at all, while the marker command before it was logged.

So the arrival of the event is itself the verdict. 2.38.0 read the missing field as "outcome unclear" and, correctly by its own rules, wrote nothing — which made the entire loop a no-op on the only host it ships for. Verified by running a real matching command through the real hook: the gate fired and asked, and nothing was recorded afterwards.

### Known limit, stated rather than papered over

Failures cannot be seen from this hook, because it does not fire for them. The loop records successes and never guesses a failure: `_bash_outcome` returns True or None, never False, unless a host actually sends an exit code. Failures still have to come from `mengram local feedback`. Reading them out of the session transcript is the obvious next step.

Tests: 442 passed, including the real payload shape; the 3 `TestParseVault` failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt