### PR TITLE
2.40.0: read failures out of the transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.40.0 — 2026-09-09
+
+### Added
+- **Failures are recorded.** The PostToolUse hook never fires for a command
+  that failed, so until now a workflow's record could only climb: every step
+  you actually ran collected successes, crossed the reliability bar, and the
+  gate went quiet — for a workflow that might have been breaking all week.
+  Half the evidence is worse than none, because it is confidently wrong.
+  `auto-outcome` now reads failures out of the session transcript, where a
+  failed Bash call is written down with its error, matches each to a step with
+  the same bar it uses for successes, and records it with the last line of the
+  error as the reason.
+- The first run on a folder records no history: it marks the current end of the
+  transcript and moves on. Charging steps for failures from days ago would be a
+  surprise, and a loud one.
+- Each failure is charged once. Ids already counted are remembered, so a
+  re-read, a replaced transcript, or the lookback that resolves a command
+  split across the cursor cannot double-charge a step.
+
 ## 2.39.0 — 2026-09-09
 
 ### Changed

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.39.0"
+__version__ = "2.40.0"
 """Mengram — AI memory layer for apps."""

--- a/cli.py
+++ b/cli.py
@@ -939,6 +939,34 @@ def _failure_reason(tool_response) -> str | None:
     return line[:200] or None
 
 
+def _record_transcript_failures(transcript_path, local_root, procs, store) -> str:
+    """Charge the steps whose commands failed, from the session transcript.
+
+    Returns a fragment for the verbose marker, empty when nothing was found —
+    which is the usual case, and the quiet one.
+    """
+    if not transcript_path:
+        return ""
+    from cloud import policy
+    from local import transcript as tr
+    try:
+        cursor = tr.read_cursor(local_root)
+        failures, cursor = tr.new_failures(transcript_path, cursor)
+        recorded = 0
+        for command, reason in failures:
+            hit = policy.best_step_match(procs, command)
+            if hit is None:
+                continue
+            proc, step_no, _score = hit
+            store.step_outcome(proc.get("name") or "unnamed workflow", step_no,
+                               success=False, reason=reason)
+            recorded += 1
+        tr.write_cursor(local_root, cursor)
+    except Exception:
+        return ""        # bookkeeping must never disturb the session
+    return f"; {recorded} failure(s) from the transcript" if recorded else ""
+
+
 def cmd_auto_outcome(args):
     """Hook handler — Claude Code PostToolUse on Bash.
 
@@ -971,16 +999,6 @@ def cmd_auto_outcome(args):
         command = (input_data.get("tool_input") or {}).get("command") or ""
         if not command:
             _exit("no command")
-        # Cheap check before anything is loaded, and a wider net than the gate
-        # upstream: the gate stays narrow because a false question interrupts a
-        # human, while a recording costs nothing and evidence is what is scarce.
-        # A command naming no known tool cannot match any step, so stop here.
-        if not policy.shell_verbs(command):
-            _exit("skipped (no known tool in the command)")
-        worked = _bash_outcome(input_data.get("tool_response"))
-        if worked is None:
-            _exit("outcome unclear — nothing recorded")
-
         local_root = _local_dir(args)
         if not local_root:
             # The cloud endpoint records whole runs: it always moves the
@@ -991,14 +1009,37 @@ def cmd_auto_outcome(args):
             _exit("cloud mode: step-scoped feedback not available yet")
 
         procs = policy.memfmt_procedures(str(local_root))
+        store = _local_store(local_root)
+
+        # Failures never arrive as an event — this hook does not fire for them —
+        # so they are read out of the session transcript instead. Done before
+        # anything about *this* command is decided, because a failure is not
+        # about this command: skipping it whenever the current call happens to
+        # be an `ls` would leave failures unrecorded for as long as the session
+        # stayed quiet. Reading the folder costs ~20 ms, and only the new tail
+        # of the transcript is parsed.
+        failed = _record_transcript_failures(
+            input_data.get("transcript_path"), local_root, procs, store)
+
+        # Now this command. A wider net than the gate upstream: the gate stays
+        # narrow because a false question interrupts a human, while a recording
+        # costs nothing and evidence is what is scarce. A command naming no
+        # known tool cannot match any step.
+        if not policy.shell_verbs(command):
+            _exit(f"skipped (no known tool in the command){failed}")
+        worked = _bash_outcome(input_data.get("tool_response"))
+        if worked is None:
+            _exit(f"outcome unclear — nothing recorded{failed}")
+
         hit = policy.best_step_match(procs, command)
         if hit is None:
-            _exit("no step matched")
+            _exit(f"no step matched{failed}")
         proc, step_no, _score = hit
         name = proc.get("name") or "unnamed workflow"
         reason = None if worked else _failure_reason(input_data.get("tool_response"))
-        _local_store(local_root).step_outcome(name, step_no, success=worked, reason=reason)
-        _exit(f"'{name}' step {step_no} recorded as {'success' if worked else 'failure'}")
+        store.step_outcome(name, step_no, success=worked, reason=reason)
+        _exit(f"'{name}' step {step_no} recorded as "
+              f"{'success' if worked else 'failure'}{failed}")
 
     except SystemExit:
         raise

--- a/local/transcript.py
+++ b/local/transcript.py
@@ -1,0 +1,136 @@
+"""Failures, read out of the session transcript.
+
+PostToolUse does not fire when a Bash command fails. The event arrives only
+after a command that succeeded, verified with a logging hook: a marker command
+exiting 7 produced no event at all. That leaves the transcript as the only
+place a failure is written down.
+
+It matters more than it sounds. A workflow's trust is computed from its
+weakest watched step, so a record built only out of successes climbs steadily
+until the gate falls silent — for a workflow that may have been breaking all
+week. Half the evidence is worse than none, because it is confidently wrong.
+
+The transcript is append-only JSON lines. A failed Bash call appears as a
+`tool_result` carrying `is_error` and a body that starts with `Exit code N`,
+pointing back by id at the `tool_use` that holds the command.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+CURSOR_FILE = "outcome-cursor.json"
+
+#: Ids kept to stop a re-read from charging the same step twice. Bash failures
+#: are rare — three in a twelve-thousand-line session — so this never fills.
+MAX_SEEN = 1000
+
+#: How far back to start reading before the stored offset. A `tool_use` and its
+#: result sit within a few lines of each other, but a cursor can land between
+#: them, and a failure whose command cannot be resolved is a failure lost.
+LOOKBACK_BYTES = 64 * 1024
+
+_EXIT_CODE = re.compile(r"^Exit code (\d+)\s*", re.DOTALL)
+
+
+def cursor_path(root) -> Path:
+    return Path(root) / ".mengram" / CURSOR_FILE
+
+
+def read_cursor(root) -> dict:
+    """`{"offset": int, "seen": [tool_use_id]}` — empty when there is none."""
+    try:
+        return json.loads(cursor_path(root).read_text())
+    except Exception:
+        return {}
+
+
+def write_cursor(root, cursor: dict) -> None:
+    p = cursor_path(root)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    cursor = dict(cursor)
+    cursor["seen"] = list(cursor.get("seen") or [])[-MAX_SEEN:]
+    p.write_text(json.dumps(cursor, indent=2) + "\n", encoding="utf-8")
+
+
+def _reason(body: str) -> str | None:
+    """The shortest honest description of what went wrong."""
+    text = _EXIT_CODE.sub("", (body or "").strip()).strip()
+    if not text:
+        return None
+    return text.splitlines()[-1].strip()[:200] or None
+
+
+def _scan(transcript_path, start: int):
+    """`({tool_use_id: command}, [(tool_use_id, body)])` for failures from `start`."""
+    commands: dict[str, str] = {}
+    errors: list[tuple[str, str]] = []
+    try:
+        with open(transcript_path, "r", errors="ignore") as fh:
+            fh.seek(start)
+            if start:
+                fh.readline()            # the seek landed mid-line
+            for line in fh:
+                try:
+                    entry = json.loads(line)
+                except Exception:
+                    continue
+                content = (entry.get("message") or {}).get("content")
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") == "tool_use" and block.get("name") == "Bash":
+                        cmd = (block.get("input") or {}).get("command")
+                        if cmd:
+                            commands[block.get("id")] = cmd
+                    elif block.get("type") == "tool_result" and block.get("is_error"):
+                        errors.append((block.get("tool_use_id"),
+                                       str(block.get("content") or "")))
+    except OSError:
+        return {}, []
+    return commands, errors
+
+
+def new_failures(transcript_path, cursor: dict) -> tuple[list[tuple[str, str | None]], dict]:
+    """Bash commands that failed since the cursor: `([(command, reason)], cursor)`.
+
+    A first run records nothing and marks the current end of the file. Reaching
+    back through a session's history to charge steps for failures from days ago
+    would be a surprise, and a loud one.
+
+    It also has to mark what is already within reach of the lookback as seen.
+    Without that, the very next read reaches back past the cursor and charges
+    for exactly the history the first run refused to touch.
+    """
+    try:
+        size = os.path.getsize(transcript_path)
+    except OSError:
+        return [], cursor
+
+    seen = list(cursor.get("seen") or [])
+
+    if "offset" not in cursor:
+        _, errors = _scan(transcript_path, max(0, size - LOOKBACK_BYTES))
+        seen.extend(tid for tid, _ in errors if tid)
+        return [], {"offset": size, "seen": seen}
+
+    start = cursor["offset"]
+    if start > size:                     # the file was replaced, not appended to
+        start = 0
+    commands, errors = _scan(transcript_path, max(0, start - LOOKBACK_BYTES))
+
+    seen_set = set(seen)
+    failures: list[tuple[str, str | None]] = []
+    for tid, body in errors:
+        if not tid or tid in seen_set or tid not in commands:
+            continue
+        seen_set.add(tid)
+        seen.append(tid)
+        failures.append((commands[tid], _reason(body)))
+
+    return failures, {"offset": size, "seen": seen}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.39.0"
+version = "2.40.0"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_transcript_failures.py
+++ b/tests/test_transcript_failures.py
@@ -1,0 +1,227 @@
+"""Failures come out of the transcript, because they arrive nowhere else.
+
+PostToolUse fires only after a command that succeeded, so a track record built
+from events alone can only climb. Left that way, a workflow that had been
+breaking all week would cross the reliability bar and the gate would fall
+silent about it — confidently, on half the evidence.
+"""
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import cli
+from local import transcript as tr
+
+
+def _use(tid, command):
+    return {"message": {"content": [
+        {"type": "tool_use", "name": "Bash", "id": tid, "input": {"command": command}}]}}
+
+
+def _result(tid, body, error=True):
+    return {"message": {"content": [
+        {"type": "tool_result", "tool_use_id": tid, "is_error": error, "content": body}]}}
+
+
+def _write(path, entries, mode="w"):
+    with open(path, mode) as fh:
+        for e in entries:
+            fh.write(json.dumps(e) + "\n")
+
+
+# --- what went wrong -------------------------------------------------------
+
+def test_reason_strips_the_exit_code_and_keeps_the_last_line():
+    assert tr._reason("Exit code 1\nTraceback\nAssertionError: nope") == "AssertionError: nope"
+
+
+def test_reason_is_none_when_there_is_nothing_to_say():
+    assert tr._reason("Exit code 7") is None
+    assert tr._reason("") is None
+
+
+def test_reason_is_bounded():
+    assert len(tr._reason("Exit code 1\n" + "x" * 900)) == 200
+
+
+# --- reading forward -------------------------------------------------------
+
+def test_a_first_run_records_no_history(tmp_path):
+    """Charging steps for failures from days ago would be a loud surprise."""
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "pytest -q"), _result("a", "Exit code 1\nboom")])
+    failures, cursor = tr.new_failures(str(t), {})
+    assert failures == []
+    assert cursor["offset"] == t.stat().st_size
+
+
+def test_failures_appended_after_the_cursor_are_found(tmp_path):
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "pytest -q"), _result("a", "Exit code 1\nold")])
+    _, cursor = tr.new_failures(str(t), {})
+    _write(t, [_use("b", "twine upload dist/*"), _result("b", "Exit code 1\n403 Forbidden")], mode="a")
+    failures, cursor = tr.new_failures(str(t), cursor)
+    assert failures == [("twine upload dist/*", "403 Forbidden")]
+
+
+def test_the_same_failure_is_never_charged_twice(tmp_path):
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "x")])
+    _, cursor = tr.new_failures(str(t), {})
+    _write(t, [_use("b", "pytest -q"), _result("b", "Exit code 1\nboom")], mode="a")
+    first, cursor = tr.new_failures(str(t), cursor)
+    assert len(first) == 1
+    # Rewind the cursor the way a replaced file would, and read it all again.
+    again, _ = tr.new_failures(str(t), {"offset": 0, "seen": cursor["seen"]})
+    assert again == []
+
+
+def test_history_within_the_lookback_is_marked_seen_on_the_first_run(tmp_path):
+    """Otherwise the next read reaches back past the cursor and charges for it."""
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "pytest -q"), _result("a", "Exit code 1\nold failure")])
+    _, cursor = tr.new_failures(str(t), {})
+    assert "a" in cursor["seen"]
+    _write(t, [_use("b", "ls")], mode="a")
+    assert tr.new_failures(str(t), cursor)[0] == []
+
+
+def test_a_tool_use_before_the_cursor_is_still_resolved(tmp_path):
+    """The cursor can land between a call and its result; the lookback covers it."""
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "pytest -q tests/")])
+    _, cursor = tr.new_failures(str(t), {})          # cursor now sits after the call
+    _write(t, [_result("a", "Exit code 1\n2 failed")], mode="a")
+    failures, _ = tr.new_failures(str(t), cursor)
+    assert failures == [("pytest -q tests/", "2 failed")]
+
+
+def test_a_replaced_shorter_file_does_not_crash(tmp_path):
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "x" * 400), _result("a", "Exit code 1\nboom")])
+    _, cursor = tr.new_failures(str(t), {})
+    _write(t, [_use("b", "pytest -q"), _result("b", "Exit code 1\nfresh")])   # truncates
+    failures, _ = tr.new_failures(str(t), cursor)
+    assert failures == [("pytest -q", "fresh")]
+
+
+def test_successes_and_other_tools_are_ignored(tmp_path):
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "x")])
+    _, cursor = tr.new_failures(str(t), {})
+    _write(t, [
+        _use("b", "pytest -q"), _result("b", "all good", error=False),
+        {"message": {"content": [{"type": "tool_result", "tool_use_id": "zzz",
+                                  "is_error": True, "content": "a browser tool failed"}]}},
+    ], mode="a")
+    assert tr.new_failures(str(t), cursor)[0] == []
+
+
+def test_broken_lines_and_missing_files_are_survivable(tmp_path):
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "x")])
+    _, cursor = tr.new_failures(str(t), {})
+    with open(t, "a") as fh:
+        fh.write("{ not json\n")
+    _write(t, [_use("b", "pytest -q"), _result("b", "Exit code 1\nboom")], mode="a")
+    assert len(tr.new_failures(str(t), cursor)[0]) == 1
+    assert tr.new_failures(str(tmp_path / "gone.jsonl"), {}) == ([], {})
+
+
+def test_the_seen_list_cannot_grow_without_bound(tmp_path):
+    tr.write_cursor(tmp_path, {"offset": 5, "seen": [str(i) for i in range(tr.MAX_SEEN + 50)]})
+    assert len(tr.read_cursor(tmp_path)["seen"]) == tr.MAX_SEEN
+    assert tr.read_cursor(tmp_path)["offset"] == 5
+
+
+def test_no_cursor_file_reads_as_empty(tmp_path):
+    assert tr.read_cursor(tmp_path) == {}
+
+
+# --- through the hook ------------------------------------------------------
+
+def _folder(tmp_path):
+    from local.store import LocalStore
+    store = LocalStore(str(tmp_path))
+    store.save_extracted_procedure("Release to PyPI", "shipping a version", [
+        {"action": "run the test suite", "detail": "pytest -q tests/"},
+        {"action": "upload to PyPI", "detail": "twine upload dist/*"}])
+    store.save()
+    return store
+
+
+def _run(monkeypatch, capsys, tmp_path, transcript, command="echo hi"):
+    payload = {"hook_event_name": "PostToolUse", "tool_name": "Bash",
+               "tool_input": {"command": command},
+               "tool_response": {"stdout": "", "interrupted": False},
+               "transcript_path": str(transcript)}
+    monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(sys, "argv",
+                        ["mengram", "auto-outcome", "--memory", str(tmp_path), "--verbose"])
+    with pytest.raises(SystemExit) as e:
+        cli.main()
+    assert e.value.code == 0
+    return json.loads(capsys.readouterr().out.strip())["systemMessage"]
+
+
+def _read(tmp_path):
+    from local.store import LocalStore
+    return LocalStore(str(tmp_path)).procedures()[0]
+
+
+def test_the_hook_charges_a_step_for_a_transcript_failure(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "ls")])
+    _run(monkeypatch, capsys, tmp_path, t)                       # sets the cursor
+    _write(t, [_use("b", "pytest -q tests/"),
+               _result("b", "Exit code 1\n3 failed, 12 passed")], mode="a")
+    assert "1 failure(s) from the transcript" in _run(monkeypatch, capsys, tmp_path, t)
+    proc = _read(tmp_path)
+    assert proc["steps"][0]["fail_count"] == 1
+    assert proc["last_failure"] == "3 failed, 12 passed"
+    # The workflow's own totals are untouched: one step failed, not a whole run.
+    assert proc["success_count"] == 0 and proc["fail_count"] == 0
+
+
+def test_the_hook_does_not_charge_the_same_failure_twice(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "ls")])
+    _run(monkeypatch, capsys, tmp_path, t)
+    _write(t, [_use("b", "pytest -q tests/"), _result("b", "Exit code 1\nboom")], mode="a")
+    _run(monkeypatch, capsys, tmp_path, t)
+    msg = _run(monkeypatch, capsys, tmp_path, t)
+    assert "failure(s)" not in msg
+    assert _read(tmp_path)["steps"][0]["fail_count"] == 1
+
+
+def test_failures_are_harvested_even_when_this_command_is_not_a_workflow(monkeypatch, capsys, tmp_path):
+    """A failure is not about the command that happens to run after it."""
+    _folder(tmp_path)
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "ls")])
+    _run(monkeypatch, capsys, tmp_path, t, command="cat README.md")
+    _write(t, [_use("b", "twine upload dist/*"), _result("b", "Exit code 1\n403")], mode="a")
+    msg = _run(monkeypatch, capsys, tmp_path, t, command="cat README.md")
+    assert "no known tool" in msg and "1 failure(s)" in msg
+    assert _read(tmp_path)["steps"][1]["fail_count"] == 1
+
+
+def test_a_missing_transcript_path_is_not_an_error(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    payload = {"tool_name": "Bash", "tool_input": {"command": "twine upload dist/*"},
+               "tool_response": {"stdout": "ok", "interrupted": False}}
+    monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(sys, "argv",
+                        ["mengram", "auto-outcome", "--memory", str(tmp_path), "--verbose"])
+    with pytest.raises(SystemExit) as e:
+        cli.main()
+    assert e.value.code == 0
+    assert "recorded as success" in capsys.readouterr().out


### PR DESCRIPTION
PostToolUse fires only after a command that **succeeded**, so the loop shipped in 2.38 could only ever add successes.

That is not a gap, it is a slow corruption. Reliability is computed from the weakest watched step, so every step you actually run collects successes, crosses the 70% bar, and the gate falls silent — about a workflow that may have been failing all week. Half the evidence is worse than none, because it is confidently wrong. Left alone it would have quietly emptied the two-week dogfood that starts today.

The transcript is the only place a failure is written down. A failed Bash call appears as a `tool_result` carrying `is_error` and a body starting with `Exit code N`, pointing back by id at the `tool_use` that holds the command.

### What this adds

- **`local/transcript.py`** reads forward from a stored cursor, resolves each failed result to its command, and returns the error's last line as the reason.
- **The hook harvests before it decides anything about the current command.** A failure is not about whatever happened to run after it, and gating the harvest on the current call being workflow-shaped would strand failures for as long as the session stayed quiet. Loading the folder costs ~20 ms, and only the new tail of the transcript is parsed.
- **A first run records no history.** Charging steps for failures from days ago would be a surprise, and a loud one.
- **Each failure is charged once**, across re-reads, a replaced transcript, and the 64 KB lookback that exists so a call split across the cursor can still be resolved.

### The bug the tests caught

The first run marked the end of the file but did not mark the failures already within reach of the lookback. The next read reached back past the cursor and charged for exactly the history the first run had refused to touch. Found by a test, not by reasoning about it.

### Verified end to end

Against a folder and a real transcript: a fresh failure lands on the right step, the workflow's own totals stay untouched (one step failed, not a whole run), `last_failure` carries the error text and date, reliability drops from `untested` to 33%, and a third run records nothing.

Still invisible, and not guessed at: a command that exits 0 having done the wrong thing, and a command the user interrupted.

Tests: 472 passed, 17 new; the 3 `TestParseVault` failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt