### PR TITLE
2.41.0: stop building HNSW indexes nothing can use, and drop them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2.41.0 — 2026-09-10
+
+### Changed
+- **Stopped building four HNSW indexes that no query could use, and dropped
+  them (migration v2.24).** An HNSW index answers `ORDER BY column <=> query
+  LIMIT n` and nothing else. The searches over `embeddings` and
+  `chunk_embeddings` are written as a filter — `WHERE 1 - (col <=> q) >
+  threshold`, ordered by id — so Postgres computes the distance for every row
+  and the index is never read. Production statistics over 275 days: 0 scans on
+  all four, against thousands on the episode and procedure indexes, whose
+  queries do order by distance. On the production database they held 929 MB of
+  3.4 GB, plus a 313 MB exact duplicate (`idx_embeddings_vector`) that had been
+  created by hand at some point.
+- Dropping them by hand was not enough: the migration rebuilt them on the next
+  boot and the database was back to its old size within the hour. Hence the
+  drop lives in the migration itself.
+
+### Fixed
+- **HNSW indexes now build in small containers.** A parallel build allocates a
+  shared memory segment; where `/dev/shm` is small (62 MB on Railway) it fails
+  with "could not resize shared memory segment", and both `pg_restore` and our
+  own `try/except` swallow it — so the index silently never exists and search
+  degrades to a sequential scan with nothing in the logs to say why. The
+  migration now sets `max_parallel_maintenance_workers = 0` first. Measured at
+  4 to 9 seconds per index, serially, on 23k and 12k vectors.
+
 ## 2.40.0 — 2026-09-09
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.40.0"
+__version__ = "2.41.0"
 """Mengram — AI memory layer for apps."""

--- a/cloud/store/_core.py
+++ b/cloud/store/_core.py
@@ -158,16 +158,10 @@ class CoreMixin:
                 ON embeddings USING gin(tsv)
             """)
 
-            # --- v1.5 HNSW index for vector search ---
-            # Drop old index if wrong dimensions, recreate
-            try:
-                cur.execute("""
-                    CREATE INDEX IF NOT EXISTS idx_embeddings_hnsw 
-                    ON embeddings USING hnsw (embedding vector_cosine_ops)
-                    WITH (m = 16, ef_construction = 64)
-                """)
-            except Exception:
-                pass  # Index may already exist or dimensions mismatch
+            # --- v1.5 HNSW index for vector search: deliberately NOT created ---
+            # See v2.24 below. `hybrid_search` filters by distance rather than
+            # ordering by it, so an HNSW index on this table cannot be used and
+            # never was: 0 scans in 275 days of production statistics.
 
         logger.info("✅ Migration complete (v1.5: HNSW + tsvector)")
 
@@ -289,6 +283,14 @@ class CoreMixin:
                 CREATE INDEX IF NOT EXISTS idx_ep_emb_episode
                 ON episode_embeddings (episode_id)
             """)
+            # A parallel HNSW build allocates a shared memory segment, and a
+            # container with a small /dev/shm (62 MB on Railway) fails it with
+            # "could not resize shared memory segment". pg_restore and the
+            # try/except below both swallow that, so the index silently never
+            # exists and the search quietly degrades to a sequential scan.
+            # Building serially avoids the segment entirely; measured at 4 to
+            # 9 seconds per index on this data.
+            cur.execute("SET max_parallel_maintenance_workers = 0")
             cur.execute("""
                 CREATE INDEX IF NOT EXISTS idx_ep_emb_hnsw
                 ON episode_embeddings USING hnsw (embedding vector_cosine_ops)
@@ -636,10 +638,6 @@ class CoreMixin:
                 )
             """)
             cur.execute("""
-                CREATE INDEX IF NOT EXISTS idx_chunk_emb_hnsw ON chunk_embeddings
-                    USING hnsw (embedding vector_cosine_ops) WITH (m=16, ef_construction=64)
-            """)
-            cur.execute("""
                 CREATE INDEX IF NOT EXISTS idx_chunk_emb_tsv ON chunk_embeddings USING gin(tsv)
             """)
 
@@ -901,24 +899,17 @@ class CoreMixin:
             cur.execute("ALTER TABLE procedure_embeddings ADD COLUMN IF NOT EXISTS embedding_v2 vector(1024)")
         logger.info("✅ Migration complete (v2.20: embedding_v2 column for Cohere multilingual)")
 
-        # --- v2.21: HNSW indexes on embedding_v2 (idempotent CREATE INDEX IF NOT EXISTS) ---
+        # --- v2.21: HNSW indexes on embedding_v2 for the tables that use them ---
+        # Only episodes and procedures: those queries end in ORDER BY distance
+        # LIMIT n, which is the only shape an HNSW index can serve. See v2.24.
         # Postgres skips index creation when the column has only NULLs — but the
         # statement is safe to run repeatedly. After backfill these become active.
         with self._cursor() as cur:
             try:
-                cur.execute("""
-                    CREATE INDEX IF NOT EXISTS idx_embeddings_v2_hnsw
-                    ON embeddings USING hnsw (embedding_v2 vector_cosine_ops)
-                    WITH (m = 16, ef_construction = 64)
-                """)
+                cur.execute("SET max_parallel_maintenance_workers = 0")   # see v1.5
                 cur.execute("""
                     CREATE INDEX IF NOT EXISTS idx_ep_emb_v2_hnsw
                     ON episode_embeddings USING hnsw (embedding_v2 vector_cosine_ops)
-                    WITH (m = 16, ef_construction = 64)
-                """)
-                cur.execute("""
-                    CREATE INDEX IF NOT EXISTS idx_chunk_emb_v2_hnsw
-                    ON chunk_embeddings USING hnsw (embedding_v2 vector_cosine_ops)
                     WITH (m = 16, ef_construction = 64)
                 """)
                 cur.execute("""
@@ -982,6 +973,34 @@ class CoreMixin:
                 ADD COLUMN IF NOT EXISTS last_succeeded TIMESTAMPTZ
             """)
         logger.info("✅ Migration complete (v2.23: procedures.last_succeeded)")
+
+        # ---- v2.24: drop the HNSW indexes nothing could ever use ----
+        # An HNSW index answers `ORDER BY column <=> query LIMIT n` and nothing
+        # else. The searches over `embeddings` and `chunk_embeddings` are
+        # written as a filter — `WHERE 1 - (col <=> q) > threshold` ordered by
+        # id — so Postgres has to compute the distance for every row and the
+        # index sits unread. Production statistics over 275 days: 0 scans on
+        # all four, against thousands on the episode and procedure indexes,
+        # whose queries do order by distance. Together they held 929 MB of a
+        # 3.4 GB database, and `idx_embeddings_vector` was an exact duplicate
+        # of `idx_embeddings_hnsw` on top of that.
+        #
+        # Dropped here rather than by hand because the CREATE statements above
+        # used to rebuild them on the next boot: a one-off DROP in production
+        # was undone within the hour, which is how this was found.
+        #
+        # If a query on these tables is ever rewritten to order by distance,
+        # delete this block and restore the CREATE statements — the index will
+        # then be earning its size. Recreate CONCURRENTLY on a live database.
+        with self._cursor() as cur:
+            for index in ("idx_embeddings_hnsw", "idx_embeddings_v2_hnsw",
+                          "idx_embeddings_vector",
+                          "idx_chunk_emb_hnsw", "idx_chunk_emb_v2_hnsw"):
+                try:
+                    cur.execute(f"DROP INDEX IF EXISTS {index}")
+                except Exception as e:
+                    logger.warning(f"v2.24: could not drop {index}: {e}")
+        logger.info("✅ Migration complete (v2.24: dropped 4 unused HNSW indexes)")
 
         with self._cursor() as cur:
             cur.execute("SELECT pg_advisory_unlock(42)")

--- a/growth/bench-schema-2026-09-10.json
+++ b/growth/bench-schema-2026-09-10.json
@@ -1,0 +1,68 @@
+[
+ {
+  "model": "llama3.1:8b",
+  "mode": "format: json",
+  "s": 50.7,
+  "valid": true,
+  "entities": 2,
+  "facts": 6,
+  "episodes": 2,
+  "procedures": 1,
+  "err": ""
+ },
+ {
+  "model": "llama3.1:8b",
+  "mode": "strict schema",
+  "s": 28.2,
+  "valid": true,
+  "entities": 2,
+  "facts": 5,
+  "episodes": 2,
+  "procedures": 1,
+  "err": ""
+ },
+ {
+  "model": "qwen2.5:7b",
+  "mode": "format: json",
+  "s": 73.4,
+  "valid": true,
+  "entities": 6,
+  "facts": 11,
+  "episodes": 2,
+  "procedures": 1,
+  "err": ""
+ },
+ {
+  "model": "qwen2.5:7b",
+  "mode": "strict schema",
+  "s": 70.4,
+  "valid": true,
+  "entities": 8,
+  "facts": 16,
+  "episodes": 2,
+  "procedures": 1,
+  "err": ""
+ },
+ {
+  "model": "qwen3:4b",
+  "mode": "format: json",
+  "s": 45.5,
+  "valid": true,
+  "entities": 4,
+  "facts": 9,
+  "episodes": 1,
+  "procedures": 1,
+  "err": ""
+ },
+ {
+  "model": "qwen3:4b",
+  "mode": "strict schema",
+  "s": 45.3,
+  "valid": true,
+  "entities": 5,
+  "facts": 17,
+  "episodes": 1,
+  "procedures": 1,
+  "err": ""
+ }
+]

--- a/growth/bench-schema-2026-09-10.md
+++ b/growth/bench-schema-2026-09-10.md
@@ -1,0 +1,21 @@
+# format: json vs строгая JSON-схема в Ollama (2026-09-10)
+
+Гипотеза Sweet-Transition-787 (r/ollama): передавать Ollama не общий `format: "json"`, а саму JSON-схему,
+с `procedures` в required — тогда 8B-модели перестают пропускать ключ.
+
+Один и тот же промпт (EXTRACTION_PROMPT) и один транскрипт (benchmark/local-extraction/sample-transcript.md,
+3984 символа), num_ctx 16384, think off, temperature 0.2, M1 Pro 16 ГБ, n=1 на ячейку.
+
+| model | mode | s | valid JSON | entities | facts | episodes | procedures |
+|---|---|---|---|---|---|---|---|
+| llama3.1:8b | format: json | 50.7 | yes | 2 | 6 | 2 | 1 |
+| llama3.1:8b | strict schema | 28.2 | yes | 2 | 5 | 2 | 1 |
+| qwen2.5:7b | format: json | 73.4 | yes | 6 | 11 | 2 | 1 |
+| qwen2.5:7b | strict schema | 70.4 | yes | 8 | 16 | 2 | 1 |
+| qwen3:4b | format: json | 45.5 | yes | 4 | 9 | 1 | 1 |
+| qwen3:4b | strict schema | 45.3 | yes | 5 | 17 | 1 | 1 |
+
+Вывод: схема не хуже нигде и лучше в двух из трёх по богатству (факты 11→16 и 9→17), плюс llama3.1
+ускорилась почти вдвое. Пропуска ключа `procedures` на этом транскрипте не было ни в одном режиме,
+так что конкретная механика из совета здесь не воспроизвелась — выигрыш в другом.
+Схема берётся как `EXTRACTION_SCHEMA["json_schema"]["schema"]`.

--- a/growth/post-rag-relevance-2026-09-09.md
+++ b/growth/post-rag-relevance-2026-09-09.md
@@ -1,0 +1,47 @@
+# r/Rag — пост про «молчание» в векторном поиске — ОПУБЛИКОВАН 2026-09-09
+https://www.reddit.com/r/Rag/comments/1wbm46c/ (флер Discussion, обязателен в этом сабе)
+
+Статистика аккаунта на момент выбора площадки (100 постов):
+r/AI_Agents 12 постов avg 3,7 / 11,4 коммента | r/ClaudeCode 9 постов avg 0,6 (мертво, не постить)
+r/mcp 7 avg 2,3 | r/LangChain 6 avg 5,3 | r/LLMDevs 4 avg 5,3 | r/Rag 3 avg 14,3 лучший 31 — ВЫБРАН
+
+
+Выбор площадки по данным аккаунта: r/Rag — 3 поста, средний счёт 14,3, лучший 31, последний 16 дней назад.
+Жанр совпадает с их сработавшим постом («мониторинг врал, потому что две метрики лежали в одной колонке»).
+Из таблицы вычищены имя работодателя и названия внутренних сервисов.
+
+**Title:** Vector search has no way to say "nothing here is relevant" — I measured what that costs
+
+**Body:**
+
+I run a memory layer that injects relevant past context into an agent's prompt automatically, every turn. Yesterday I stopped assuming it worked and looked at what it actually injected, across seven consecutive prompts of a real working session.
+
+| prompt | what got injected | related? |
+|---|---|---|
+| "check reddit" | a websocket note, a competitor, a GitHub repo | no |
+| "why specifically with claude code" | Claude Desktop, a person, an internal service | partly |
+| "what if they don't have claude code" | Claude Desktop, Mem0, an internal service | partly |
+| "what is the value of our product" | an internal service, Redis, another project of mine | no |
+| "restart it and check" | Spring Boot, a former employer, another project | no |
+| "so now?" | sentence-transformers, a former employer, a person | no |
+| "what do you mean, relevance" | SQLite, another project, a GitHub repo | no |
+
+Five of seven had nothing to do with what was asked. A question about hook payloads came back with facts about a Java backend at a bank, stored in February for a completely different project.
+
+The cause is not the ranking. It is that "nearest" is defined for every query, so the search always has an answer. Silence is not in its output set. There was a floor — `min_score = 0.2` cosine — but 0.2 is noise. Two unrelated sentences clear it routinely, because they are both sentences.
+
+The same system has a plain-files mode that retrieves by word overlap, and it never does this: zero overlap means nothing is injected. That property was lost the moment retrieval moved to embeddings, and nobody noticed, because this failure looks like a feature. There is always something in the context.
+
+The fix only removes, never adds: before injecting, require the memory to share at least one content word with the prompt. I already had exactly that guard in another part of the system, where a learned workflow has to share a word with a shell command before it is allowed to interrupt the user with a confirmation. It never occurred to me that retrieval needed the same thing.
+
+Two mistakes I made while fixing it, both instructive:
+
+1. My first version passed everything through when the prompt had no content words at all, reasoning that if you cannot read the query you should not silence recall. Exactly backwards. The shortest prompts are where the search has least to go on, so the "safe" default left the worst cases untouched. "so now?" pulled three entities out of the store as confidently as a detailed question would.
+
+2. I reused a tokenizer from elsewhere in the codebase that only matched ASCII letters. Plenty of my prompts are not in English. It found zero words in them, which would have silenced recall completely instead of filtering it — a much worse bug, and one that ships silently.
+
+After the change: silent on 5 of 7, and the 2 that kept anything kept only the entity the question was actually about.
+
+I did not touch the 0.2 floor. Picking a real number needs the actual score distribution from production, which is a separate measurement I have not earned yet.
+
+So: does anyone here run an explicit "return nothing" path in production RAG? And what do you gate it on — an absolute score floor, the margin between top-1 and top-2, a lexical check like this one, or a reranker with a reject option?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.40.0"
+version = "2.41.0"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/specs/drop-unused-vector-indexes-2026-09-10.sql
+++ b/specs/drop-unused-vector-indexes-2026-09-10.sql
@@ -1,0 +1,20 @@
+-- Drop five HNSW indexes that have served 0 scans in 275 days (1242 MB).
+-- Rollback: specs/rollback-dropped-indexes-2026-09-10.sql
+-- CONCURRENTLY takes a SHARE UPDATE EXCLUSIVE lock: reads and writes keep working.
+-- Each statement must run outside a transaction, so run this file as-is, not inside BEGIN.
+
+\timing on
+SELECT pg_size_pretty(pg_database_size(current_database())) AS size_before;
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_embeddings_vector;    -- 313 MB, duplicate
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_embeddings_hnsw;      -- 313 MB, legacy 1536 column
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_embeddings_v2_hnsw;   -- 415 MB, live column, unusable by the query shape
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_chunk_emb_hnsw;       --  98 MB
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_chunk_emb_v2_hnsw;    -- 103 MB
+
+SELECT pg_size_pretty(pg_database_size(current_database())) AS size_after;
+
+SELECT indexrelname, pg_size_pretty(pg_relation_size(indexrelid)) AS size, idx_scan
+  FROM pg_stat_user_indexes
+ WHERE relname IN ('embeddings','chunk_embeddings')
+ ORDER BY pg_relation_size(indexrelid) DESC;

--- a/specs/rollback-dropped-indexes-2026-09-10.sql
+++ b/specs/rollback-dropped-indexes-2026-09-10.sql
@@ -1,0 +1,34 @@
+-- Rollback for the vector indexes dropped on 2026-09-10.
+--
+-- Why they were dropped: 0 index scans in 275 days of collected statistics,
+-- 1242 MB between them. Every query touching `embeddings` and `chunk_embeddings`
+-- filters by distance (WHERE 1 - (col <=> q) > threshold) instead of ordering by
+-- it, and only `ORDER BY col <=> q LIMIT n` can use an HNSW index. The same
+-- indexes on episode_embeddings and procedure_embeddings are heavily used,
+-- because those queries do order by distance — which is how we know the
+-- statistics are trustworthy and pgvector is not the problem.
+--
+-- `idx_embeddings_vector` was an exact duplicate of `idx_embeddings_hnsw`:
+-- same table, same column, same opclass, same parameters.
+--
+-- Recreate any of these the moment a query on those tables is rewritten to
+-- order by distance with a LIMIT. Build CONCURRENTLY: on this data each takes
+-- minutes and would otherwise lock writes.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_hnsw
+    ON public.embeddings USING hnsw (embedding vector_cosine_ops)
+    WITH (m='16', ef_construction='64');
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_v2_hnsw
+    ON public.embeddings USING hnsw (embedding_v2 vector_cosine_ops)
+    WITH (m='16', ef_construction='64');
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chunk_emb_hnsw
+    ON public.chunk_embeddings USING hnsw (embedding vector_cosine_ops)
+    WITH (m='16', ef_construction='64');
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chunk_emb_v2_hnsw
+    ON public.chunk_embeddings USING hnsw (embedding_v2 vector_cosine_ops)
+    WITH (m='16', ef_construction='64');
+
+-- Deliberately NOT recreated: idx_embeddings_vector, the duplicate.


### PR DESCRIPTION
An HNSW index answers `ORDER BY column <=> query LIMIT n` and nothing else. The searches over `embeddings` and `chunk_embeddings` are written as a filter — `WHERE 1 - (col <=> q) > threshold`, ordered by id — so Postgres computes the distance for every row and the index sits unread.

### The evidence

Production statistics, 275 days:

| index | size | scans |
|---|---|---|
| idx_embeddings_v2_hnsw | 415 MB | 0 |
| idx_embeddings_hnsw | 313 MB | 0 |
| idx_embeddings_vector | 313 MB | 0 |
| idx_chunk_emb_v2_hnsw | 103 MB | 0 |
| idx_chunk_emb_hnsw | 98 MB | 0 |
| idx_ep_emb_hnsw | 163 MB | 11159 |
| idx_proc_emb_hnsw | 93 MB | 15463 |

The contrast is what makes the zeroes trustworthy. Episode and procedure searches end in `ORDER BY ... LIMIT` and their indexes are used constantly; pgvector is fine, the query shape is wrong. `idx_embeddings_vector` was an exact duplicate of `idx_embeddings_hnsw` — same table, column, opclass and parameters — created by hand at some point and never in the schema code.

Meanwhile `embeddings` shows 54 million rows read sequentially over the same period, which is the same fact from the other side.

### Why the drop is in the migration and not a runbook

Because dropping them by hand did not hold. `_migrate()` ran `CREATE INDEX IF NOT EXISTS ... USING hnsw` on the next boot and the database was back from 2147 MB to 2971 MB within the hour. That is how this was found.

### The failure that hides itself

A parallel HNSW build allocates a shared memory segment. In a container with a small `/dev/shm` (62 MB on Railway) it fails with `could not resize shared memory segment` — and `pg_restore` ignores it and exits 0, while our own `try/except` logs a warning nobody reads. The index then does not exist and search quietly degrades to a sequential scan, with nothing in the logs to say why. Found while rehearsing a database migration: all 8 vector indexes failed to build and the restore reported success.

The migration now sets `max_parallel_maintenance_workers = 0` before building. Measured serially: 9.3 s and 8.1 s for the two episode indexes, 4.2 s and 3.7 s for the two procedure ones.

### Reversing it

If a query on those tables is ever rewritten to order by distance, delete the v2.24 block and restore the CREATE statements; the index will be earning its size then. `specs/rollback-dropped-indexes-2026-09-10.sql` has the definitions.

Verified against a full copy of the production database: the drop list removes exactly the five named indexes and leaves the four working ones untouched.

Tests: 472 passed; the 3 `TestParseVault` failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt