### PR TITLE
2.41.1: retrieval health was averaging two different score scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2.41.1 — 2026-09-10
+
+### Fixed
+- **Retrieval health read two score scales as one, and was about to email
+  everyone about it.** `usage_log.query_score` holds a rerank/cosine similarity
+  in 0..1 for some searches and a raw RRF score for others, and RRF tops out
+  near 0.05 by construction. The aggregation averaged the two and compared the
+  result to a cosine-shaped threshold of 0.4. In production that meant 286 of
+  304 scored searches counted as failures, mean 0.075, and 23 of 26 accounts
+  were marked `critical` — which is what the Monday digest mails about.
+  `_quality_label` in `cloud/api.py` had already been made scale-aware for the
+  per-search label; the aggregation had not, and the two have now been pinned
+  to each other by a test.
+- Status is now the share of searches that found **nothing** (below 0.02, the
+  point where neither scale has a match): 60% or more is critical, 30% or more
+  is degraded. On the same production window this reads 1 critical and 1
+  healthy instead of 2 critical.
+- The recommendation text says what actually happened — "62% of searches (13 of
+  21) found nothing at all" — instead of quoting a threshold on a number that
+  was never a single quantity.
+
 ## 2.41.0 — 2026-09-10
 
 ### Changed

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.41.0"
+__version__ = "2.41.1"
 """Mengram — AI memory layer for apps."""

--- a/cloud/store/_health.py
+++ b/cloud/store/_health.py
@@ -147,10 +147,25 @@ class HealthMixin:
 
     # ---- Memory Health Aggregation (Day 2 of Memory Health Monitor) ----
 
-    # Status thresholds — mean score over recent searches
-    _HEALTH_THRESHOLD_HEALTHY = 0.6   # mean ≥ 0.6 = healthy
-    _HEALTH_THRESHOLD_DEGRADED = 0.4  # mean ≥ 0.4 = degraded; below = critical
-    _LOW_QUALITY_SCORE = 0.4          # individual searches below this = low-quality
+    # `usage_log.query_score` holds two different scales in one column: a
+    # rerank/cosine similarity in 0..1, and a raw RRF score, which tops out
+    # around 0.05 by construction. Averaging them and comparing the result to a
+    # cosine-shaped threshold marks healthy retrieval as broken: production
+    # showed 286 of 304 scored searches "below 0.4" with a mean of 0.075, which
+    # classified 23 of 26 accounts as critical and would have mailed every one
+    # of them that their memory needed attention.
+    #
+    # `_quality_label` in cloud/api.py already solved this for the per-search
+    # label; these are the same cut points, applied per search rather than to
+    # an average, because a mean over two scales is not a quantity.
+    _STRONG_SCORE = 0.30   # at or above: a real match on either scale
+    _WEAK_SCORE = 0.02     # at or above: a match worth showing; below: nothing found
+
+    # Status is now the share of searches that found nothing.
+    _CRITICAL_NO_MATCH_SHARE = 0.60   # most searches return nothing
+    _DEGRADED_NO_MATCH_SHARE = 0.30   # a large minority do
+
+    _LOW_QUALITY_SCORE = _WEAK_SCORE  # individual searches below this found nothing
 
     def aggregate_memory_health(self, window_hours: int = 24) -> dict:
         """Compute per-user retrieval health over the last `window_hours` of
@@ -187,13 +202,16 @@ class HealthMixin:
             for row in per_user:
                 uid = str(row["user_id"])
                 mean = float(row["mean"] or 0)
+                searches = int(row["n"] or 0)
+                no_match = int(row["low_count"] or 0)
+                no_match_share = (no_match / searches) if searches else 0.0
 
-                if mean >= self._HEALTH_THRESHOLD_HEALTHY:
-                    status = "healthy"
-                elif mean >= self._HEALTH_THRESHOLD_DEGRADED:
+                if no_match_share >= self._CRITICAL_NO_MATCH_SHARE:
+                    status = "critical"
+                elif no_match_share >= self._DEGRADED_NO_MATCH_SHARE:
                     status = "degraded"
                 else:
-                    status = "critical"
+                    status = "healthy"
 
                 # Per-language breakdown
                 cur.execute(
@@ -215,16 +233,17 @@ class HealthMixin:
 
                 # Recommendations
                 recs = []
+                pct = round(100 * no_match_share)
                 if status == "critical":
-                    recs.append("Retrieval relevance is below 0.4 — likely silent quality drop. Review recent additions for noise.")
-                if status == "degraded":
-                    recs.append("Mean relevance 0.4–0.6 — some queries returning weak matches. Consider running `dedup` to clean similar entities.")
-                if row["low_count"] >= 5:
-                    recs.append(f"{row['low_count']} searches under 0.4 in window — flag for content audit.")
+                    recs.append(f"{pct}% of searches ({no_match} of {searches}) found nothing at all. "
+                                "Either the memory is missing this material, or recent additions are noise.")
+                elif status == "degraded":
+                    recs.append(f"{pct}% of searches ({no_match} of {searches}) found nothing. "
+                                "Consider running `dedup` to clean up near-identical entities.")
                 if row["lang_count"] and row["lang_count"] >= 2:
                     weakest = min(lang_breakdown, key=lambda x: x["mean_score"])
-                    if weakest["mean_score"] < self._HEALTH_THRESHOLD_DEGRADED:
-                        recs.append(f"Lowest-quality language: {weakest['lang']} ({weakest['mean_score']:.2f} mean). "
+                    if weakest["mean_score"] < self._WEAK_SCORE:
+                        recs.append(f"Lowest-quality language: {weakest['lang']} ({weakest['mean_score']:.3f} mean). "
                                      "May need more content in that language.")
 
                 details = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.41.0"
+version = "2.41.1"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_memory_health_scale.py
+++ b/tests/test_memory_health_scale.py
@@ -1,0 +1,86 @@
+"""Retrieval health must not read two score scales as one.
+
+`usage_log.query_score` holds a rerank/cosine similarity in 0..1 for some
+searches and a raw RRF score for others, and RRF tops out near 0.05 by
+construction. Averaging the two and comparing the result to a cosine-shaped
+threshold called production healthy-or-not at random: 286 of 304 scored
+searches sat "below 0.4" with a mean of 0.075, 23 of 26 accounts were marked
+critical, and the Monday digest was ready to tell every one of them that their
+memory needed attention.
+
+The per-search label in `cloud/api.py` had already been made scale-aware. The
+aggregation had not. These tests pin the cut points to each other.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from cloud.store._health import HealthMixin
+
+
+def _status(searches, no_match):
+    """The status the aggregation would assign for this share of empty results."""
+    share = no_match / searches
+    if share >= HealthMixin._CRITICAL_NO_MATCH_SHARE:
+        return "critical"
+    if share >= HealthMixin._DEGRADED_NO_MATCH_SHARE:
+        return "degraded"
+    return "healthy"
+
+
+def test_the_cut_points_match_the_per_search_label():
+    """Both files decide the same question; they must not drift apart.
+
+    `_quality_label` in cloud/api.py: >= 0.3 strong, >= 0.02 weak, else none.
+    """
+    api = Path(__file__).parent.parent / "cloud" / "api.py"
+    body = api.read_text()
+    assert "if top_score >= 0.3:" in body
+    assert "if top_score >= 0.02:" in body
+    assert HealthMixin._STRONG_SCORE == 0.30
+    assert HealthMixin._WEAK_SCORE == 0.02
+
+
+def test_a_low_score_is_not_by_itself_a_failure():
+    """An RRF score of 0.05 is a good match, not a broken one."""
+    assert HealthMixin._LOW_QUALITY_SCORE == HealthMixin._WEAK_SCORE
+    assert HealthMixin._LOW_QUALITY_SCORE < 0.05
+
+
+def test_healthy_when_searches_find_something():
+    assert _status(20, 0) == "healthy"
+    assert _status(20, 5) == "healthy"      # 25% empty
+
+
+def test_degraded_when_a_large_minority_find_nothing():
+    assert _status(20, 6) == "degraded"     # 30%
+    assert _status(20, 11) == "degraded"    # 55%
+
+
+def test_critical_only_when_most_searches_find_nothing():
+    assert _status(20, 12) == "critical"    # 60%
+    assert _status(20, 20) == "critical"
+
+
+def test_the_production_sample_is_no_longer_uniformly_critical():
+    """The measurement that started this: mean 0.075 over 304 searches.
+
+    Under the old rule every one of those accounts was critical. Under the new
+    one the verdict depends on how many searches came back empty, which is the
+    thing a user would actually recognise as a problem.
+    """
+    # A user whose scores are all RRF-scale but who finds what they look for.
+    assert _status(304, 10) == "healthy"
+    # A user whose searches genuinely return nothing.
+    assert _status(304, 250) == "critical"
+
+
+def test_thresholds_are_ordered_and_are_shares_not_scores():
+    assert 0 < HealthMixin._DEGRADED_NO_MATCH_SHARE < HealthMixin._CRITICAL_NO_MATCH_SHARE <= 1
+    assert HealthMixin._WEAK_SCORE < HealthMixin._STRONG_SCORE < 1
+
+
+def test_the_old_score_thresholds_are_gone():
+    """They classified on a quantity that does not exist: a mean over two scales."""
+    assert not hasattr(HealthMixin, "_HEALTH_THRESHOLD_HEALTHY")
+    assert not hasattr(HealthMixin, "_HEALTH_THRESHOLD_DEGRADED")


### PR DESCRIPTION
`usage_log.query_score` holds a rerank/cosine similarity in 0..1 for some searches and a raw RRF score for others. RRF tops out near 0.05 by construction, so a mean over the two is not a quantity — and it was being compared to a cosine-shaped threshold of 0.4.

### What that did in production

Seven days of scored searches:

| | |
|---|---|
| scored searches | 304 |
| mean query_score | 0.075 |
| counted as "below 0.4" | 286 |
| accounts marked critical | 23 of 26 |

That status is what the Monday 09:00 UTC digest mails about — subject line "Your Mengram memory needs attention this week". Four accounts were inside the digest's seven-day window and would have been told their memory was broken this coming Monday, on a measurement that had no way to say otherwise.

`_quality_label` in `cloud/api.py` already had the scale-aware cut points, and its docstring says exactly why: *"query_score mixes two scales (rerank/cosine 0-1 vs raw RRF topping out ~0.05), so raw thresholds misread healthy RRF results as failures"*. The aggregation never got them.

### The change

Status is now the share of searches that found **nothing** — below 0.02, the point where neither scale has a match — instead of an average:

- 60% or more empty: critical
- 30% or more empty: degraded
- otherwise: healthy

On the same production window that reads **1 critical and 1 healthy** instead of 2 critical. The recommendation text now quotes what was measured ("62% of searches (13 of 21) found nothing at all") rather than a threshold on a number that was never a single quantity.

A test pins the two files' cut points to each other, and asserts the old thresholds are gone, so they cannot drift apart again.

Tests: 480 passed, 8 new; the 3 `TestParseVault` failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt