### PR TITLE
2.41.3: a missing folder pointed at creating a second one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.41.3 — 2026-09-11
+
+### Fixed
+- **A missing memory folder no longer sends you off to create a second one.**
+  `local init /somewhere` prints an `export MENGRAM_MEMORY_DIR=...` line that
+  every later command depends on. Forget it and the message used to read "no
+  memory folder at memory — run: mengram local init memory", which creates an
+  empty store in the current directory and strands the real one. The next
+  `search` then returns nothing and the product looks like it lost your data.
+  When the path came from the default rather than from `--memory` or the
+  environment, the error now offers the env var first and creating a new folder
+  second. Found by installing the package from PyPI in a clean container and
+  following the documented steps.
+
 ## 2.41.2 — 2026-09-11
 
 ### Fixed

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.41.2"
+__version__ = "2.41.3"
 """Mengram — AI memory layer for apps."""

--- a/local/cli.py
+++ b/local/cli.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -25,10 +26,24 @@ def _root(args) -> Path:
 
 def _open(args) -> LocalStore:
     root = _root(args)
-    if not root.is_dir():
-        print(f"no memory folder at {root} — run: mengram local init {root}", file=sys.stderr)
-        sys.exit(1)
-    return LocalStore(root)
+    if root.is_dir():
+        return LocalStore(root)
+
+    # Where the folder came from decides what to say. Told explicitly and it is
+    # missing, the answer is to create it. Falling back to the default `memory`
+    # is the interesting case: a folder almost certainly exists somewhere else
+    # and the user forgot the env var `init` printed, so "run init" would
+    # create a *second* store and quietly strand the first one.
+    explicit = bool(getattr(args, "memory", None) or os.environ.get("MENGRAM_MEMORY_DIR", "").strip())
+    print(f"no memory folder at {root}", file=sys.stderr)
+    if explicit:
+        print(f"  create it:  mengram local init {root}", file=sys.stderr)
+    else:
+        print("  if you already have one elsewhere, point at it:", file=sys.stderr)
+        print("    export MENGRAM_MEMORY_DIR=/path/to/memory", file=sys.stderr)
+        print("    (or pass --memory /path/to/memory)", file=sys.stderr)
+        print(f"  to start a new one here:  mengram local init {root}", file=sys.stderr)
+    sys.exit(1)
 
 
 def cmd_init(args) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.41.2"
+version = "2.41.3"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_local_missing_folder.py
+++ b/tests/test_local_missing_folder.py
@@ -1,0 +1,61 @@
+"""A missing folder must not send you off to create a second one.
+
+`mengram local init /somewhere` prints an `export MENGRAM_MEMORY_DIR=...` line,
+and every later command needs it. Forget the export and the old message said
+"no memory folder at memory — run: mengram local init memory", which creates a
+new empty store in the current directory and strands the real one. The user
+then sees an empty memory and concludes the product lost their data.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from local import cli as lcli
+
+
+class _Args:
+    memory = None
+
+
+def _run(monkeypatch, capsys, tmp_path, memory=None, env=None):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
+    if env:
+        monkeypatch.setenv("MENGRAM_MEMORY_DIR", env)
+    args = _Args()
+    args.memory = memory
+    with pytest.raises(SystemExit) as e:
+        lcli._open(args)
+    assert e.value.code == 1
+    return capsys.readouterr().err
+
+
+def test_the_default_path_offers_the_env_var_first(monkeypatch, capsys, tmp_path):
+    err = _run(monkeypatch, capsys, tmp_path)
+    assert "MENGRAM_MEMORY_DIR" in err
+    assert "--memory" in err
+    # Creating a new one is still offered, but as the second option.
+    assert err.index("MENGRAM_MEMORY_DIR") < err.index("local init")
+
+
+def test_an_explicit_path_just_says_create_it(monkeypatch, capsys, tmp_path):
+    """Nothing to point at: the user named a folder and it is not there."""
+    err = _run(monkeypatch, capsys, tmp_path, memory=str(tmp_path / "nope"))
+    assert "local init" in err
+    assert "MENGRAM_MEMORY_DIR" not in err
+
+
+def test_an_env_var_pointing_nowhere_also_just_says_create_it(monkeypatch, capsys, tmp_path):
+    err = _run(monkeypatch, capsys, tmp_path, env=str(tmp_path / "gone"))
+    assert "local init" in err
+    assert "export MENGRAM_MEMORY_DIR" not in err
+
+
+def test_an_existing_folder_opens_without_complaint(monkeypatch, tmp_path):
+    (tmp_path / "memory").mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
+    args = _Args()
+    assert lcli._open(args) is not None


### PR DESCRIPTION
Found by installing `mengram-ai` from PyPI into a clean container and walking the documented install exactly as written, rather than from memory.

`mengram local init /somewhere` prints an `export MENGRAM_MEMORY_DIR=...` line and every later command depends on it. Forget the export and the error read:

```
no memory folder at memory — run: mengram local init memory
```

Following that advice creates an empty store in the current directory and strands the real one. The next `search` returns nothing, and the product looks like it lost your memory.

Where the path came from now decides what the message says. Named explicitly via `--memory` or the environment and missing, the answer is still "create it". Falling back to the default is the interesting case, and there the env var comes first:

```
no memory folder at memory
  if you already have one elsewhere, point at it:
    export MENGRAM_MEMORY_DIR=/path/to/memory
    (or pass --memory /path/to/memory)
  to start a new one here:  mengram local init memory
```

### The rest of the clean-room run passed

For the record, since the point of the exercise was to find out what a stranger gets today:

- `pip install --user` leaves `mengram` off PATH, which the install guide already warns about and which fails loudly.
- `hook install` writes **absolute paths** for all five hooks, zero bare names, and verifies itself: *"Verified: /root/.local/bin/mengram runs from a plain shell"*.
- `hook status` executes each command rather than reading the settings file.
- `local add` without a model gives a precise error naming all three ways to configure one.
- `local search` and `local stat` work with no model and no account.

Tests: 491 passed, 4 new; the 3 `TestParseVault` failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt