### PR TITLE
2.41.4: put `mengram try` in front of the door instead of behind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.41.4 — 2026-09-11
+
+### Changed
+- **`mengram try` is now the first thing a newcomer is shown.** It reads the
+  Claude Code history already on disk, needs no account and no key, uploads
+  nothing, and prints the projects, the stack and the repeated workflows with
+  counts — in about three seconds. It was the strongest thing in the product
+  and it appeared in exactly one place, the CLI reference, which only people
+  who had already installed and signed up would ever read. The landing page now
+  opens with it, ahead of every install door; the quickstart leads with it as
+  step 0; and `agent-install.txt` instructs the agent to run it and show the
+  output to the user *before* asking for an email.
+
 ## 2.41.3 — 2026-09-11
 
 ### Fixed

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.41.3"
+__version__ = "2.41.4"
 """Mengram — AI memory layer for apps."""

--- a/cloud/agent-install.txt
+++ b/cloud/agent-install.txt
@@ -18,6 +18,15 @@ interactive commands, prefer running `mengram setup` and relay only its
 email/code prompts to the user. Fall back to the manual steps below when it
 is unavailable or fails.
 
+SHOW VALUE FIRST (do this before asking for an email):
+After `pip install mengram-ai`, run `mengram try`. It reads the user's local
+Claude Code history, needs no account and no key, uploads nothing, and prints
+which projects they work in, their stack, and the workflows they have repeated
+with counts. Show that output to the user verbatim before you ask them for
+anything. It takes about three seconds and it is the whole pitch: their agent
+has been relearning all of it from zero every session. If the user has no
+Claude Code history the command says so — skip straight to STEP 2.
+
 CRITICAL RULES:
 - Do not ask the user for confirmation between every step. Just execute.
 - Ask the user ONLY for: (a) their email (once, if no API key exists yet) and
@@ -63,6 +72,9 @@ STEP 1 — DETECT ENVIRONMENT
 ================================================================
 STEP 2 — INSTALL THE PACKAGE
 ================================================================
+
+2.0  Immediately after the install below succeeds and before STEP 3, run
+     `mengram try` and show the user its output. See "SHOW VALUE FIRST" above.
 
 2.1  Run:    python3 -m pip install --user --upgrade mengram-ai
      (On Windows use `python -m pip` if `python3` is not aliased.)

--- a/cloud/landing.html
+++ b/cloud/landing.html
@@ -2013,6 +2013,36 @@
             </div>
         </section>
 
+        <!-- See it before installing anything: the only door that needs no account -->
+        <section class="install-prompt-section reveal" id="try-first">
+            <div class="install-prompt-card">
+                <span class="install-prompt-eyebrow">Start here · No account · Nothing leaves your machine</span>
+                <h2 class="install-prompt-title">See what your agent already knows about you.</h2>
+                <p class="install-prompt-sub">One command reads the Claude Code history already on your disk and tells you which projects you work in, what your stack is, and which workflows you have repeated &mdash; with counts. No key, no signup, no upload.</p>
+                <div class="code-box install-prompt-box">
+                    <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+<pre>pip install mengram-ai
+mengram try</pre>
+                </div>
+                <div class="code-box" style="margin-top:12px;">
+<pre>Scanned 23 sessions across 4 projects (2026-07-31 &rarr; 2026-09-11).
+
+If this were memory, your AI would already know:
+
+  Projects:   mengram (17), po-pilot (4), infra (1)
+  Your stack: railway, python, postgres, stripe, bun
+  Workflow patterns detected:
+    &#9881; debug from logs            (seen in 16 sessions)
+    &#9881; migrate &rarr; verify schema    (seen in 12 sessions)
+    &#9881; branch &rarr; PR &rarr; merge         (seen in 6 sessions)
+    &#9881; test &rarr; fix &rarr; re-test        (seen in 4 sessions)
+
+Right now, every new session starts from zero and relearns all of this.</pre>
+                </div>
+                <p class="install-prompt-fineprint">That output is real, from the author&rsquo;s own history. If the command is not found afterwards, your user-site bin is not on PATH: <code>export PATH="$(python3 -m site --user-base)/bin:$PATH"</code>. Like what you see? Keep it with one of the doors below.</p>
+            </div>
+        </section>
+
         <!-- Add to Claude in one click (remote MCP connector) — the zero-setup door -->
         <section class="install-prompt-section reveal" id="claude-connector">
             <div class="install-prompt-card">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.41.3"
+version = "2.41.4"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
`mengram try` reads the Claude Code history already on disk, needs no account and no key, uploads nothing, and prints the user's own projects, stack and repeated workflows with counts in about three seconds:

```
Scanned 23 sessions across 4 projects (2026-07-31 → 2026-09-11).

If this were memory, your AI would already know:

  Projects:   mengram (17), po-pilot (4), infra (1)
  Your stack: railway, python, postgres, stripe, bun
  Workflow patterns detected:
    debug from logs            (seen in 16 sessions)
    migrate → verify schema    (seen in 12 sessions)
    branch → PR → merge        (seen in 6 sessions)
    test → fix → re-test       (seen in 4 sessions)

Right now, every new session starts from zero and relearns all of this.
```

It shows someone themselves instead of describing a product, and the last line does the work.

### Where it was

In exactly one place: the CLI reference — which only someone who had already installed the package and created an account would ever open. The landing page said `pip install mengram-ai` five times and `mengram setup` once before a visitor saw anything at all. The strongest thing in the product sat behind the gate instead of in front of it.

### Where it is now

- **Landing page**: a new first section, ahead of all three install doors, with the real output above.
- **Quickstart**: step 0, above even the paste-one-prompt path. Page description changed to match.
- **agent-install.txt**: a "SHOW VALUE FIRST" block instructing the agent to run it and show the output verbatim *before* asking the user for an email, plus a 2.0 step pointing back at it.

The PATH caveat is stated in both public places, since `pip install --user` leaves the command off PATH and that is the first thing a newcomer hits.

No code paths touched — `try` already worked. Tests: 491 passed; the 3 `TestParseVault` failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt