### PR TITLE
2.41.5: a timed-out command was being recorded as a success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.41.5 — 2026-09-11
+
+### Fixed
+- **A command that ran out of time was recorded as a success.** 2.38.2 read the
+  arrival of the post-tool event as the verdict, because a failing command
+  fires no event at all. A timed-out command turns out to fire one: measured
+  with a logging hook, it arrives with `interrupted: false`, no exit code, and
+  two extra fields — `timedOutAfterMs` and `backgroundTaskId`. The host moves
+  the command to the background rather than killing it, so it may still be
+  running, may still succeed, and is certainly not evidence of anything yet.
+  Both markers now produce "unknown" and nothing is written. The same
+  survivorship bias as the missing failure event, wearing a different hat.
+
 ## 2.41.4 — 2026-09-11
 
 ### Changed

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.41.4"
+__version__ = "2.41.5"
 """Mengram — AI memory layer for apps."""

--- a/cli.py
+++ b/cli.py
@@ -914,6 +914,16 @@ def _bash_outcome(tool_response) -> bool | None:
         return None
     if tool_response.get("interrupted"):
         return None
+    # A command that ran out of time did not finish, and this host moves it to
+    # the background rather than killing it, so it may yet succeed. Measured
+    # with a logging hook: a timed-out call *does* fire this event, carrying
+    # `timedOutAfterMs` and `backgroundTaskId` and `interrupted: false`. Without
+    # this check the rule below reads that as a success, which is the same
+    # survivorship bias as the missing-failure event, wearing a different hat.
+    if tool_response.get("timedOutAfterMs") is not None:
+        return None
+    if tool_response.get("backgroundTaskId"):
+        return None
     code = tool_response.get("exit_code", tool_response.get("exitCode"))
     if isinstance(code, bool):          # True is not an exit code
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.41.4"
+version = "2.41.5"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_outcome_loop.py
+++ b/tests/test_outcome_loop.py
@@ -133,6 +133,25 @@ def test_the_real_claude_code_payload_means_success():
     assert cli._bash_outcome(real) is True
 
 
+def test_a_timed_out_command_is_not_a_success():
+    """Measured, not assumed: a timed-out call DOES fire this event.
+
+    The host moves the command to the background instead of killing it, so the
+    payload arrives with `interrupted: false` and no exit code — which the
+    arrival-means-success rule would read as a win. It carries `timedOutAfterMs`
+    and a `backgroundTaskId` instead, and the command may still be running.
+    """
+    real = {"stdout": "", "stderr": "", "interrupted": False, "isImage": False,
+            "noOutputExpected": False, "backgroundTaskId": "boiq5n3pk",
+            "timedOutAfterMs": 12000}
+    assert cli._bash_outcome(real) is None
+
+
+def test_either_timeout_marker_alone_is_enough():
+    assert cli._bash_outcome({"stdout": "", "timedOutAfterMs": 1}) is None
+    assert cli._bash_outcome({"stdout": "", "backgroundTaskId": "x"}) is None
+
+
 def test_an_interrupted_command_is_still_no_evidence():
     real = {"stdout": "", "stderr": "", "interrupted": True,
             "isImage": False, "noOutputExpected": False}


### PR DESCRIPTION
2.38.2 made the arrival of the post-tool event the verdict, on the grounds that a failing command fires no event at all. Someone on r/AI_Agents asked whether interrupted or timed-out runs produce a terminal event. I said I did not know and would measure it.

### Measured

A logging hook on PostToolUse, three commands:

| command | event fired | payload |
|---|---|---|
| `echo "MARK-OK"` | yes | `stdout, stderr, interrupted:false, isImage, noOutputExpected` |
| `echo "MARK-FAIL"; exit 9` | **no** | — |
| 120 s loop, 12 s tool timeout | **yes** | the above **plus `timedOutAfterMs`, `backgroundTaskId`**, `interrupted:false` |

So a timed-out command does fire the event. This host moves it to the background rather than killing it, so it may still be running and may still succeed.

Which means the arrival-means-success rule read it as a win. Same survivorship bias as the missing failure event, wearing a different hat: the runs that go badly are exactly the ones that look like nothing happened.

### Change

`timedOutAfterMs` or `backgroundTaskId` present → "unknown", write nothing. Tests pin both markers individually and the full captured payload.

Non-zero exits still fire no event and stay invisible from here. Recording intent at PreToolUse — which fires for every command including the ones that go on to fail — is the real fix, suggested by u/arthaudm in that thread, and is the next change.

Tests: 493 passed, 2 new; the 3 `TestParseVault` failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt