### PR TITLE
Intent at PreToolUse, outcome by call id; refused commands are not failures (2.42.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 2.42.0 — 2026-09-11
+
+### Fixed
+- **A command that never ran was being counted as a failed step.** The
+  transcript sweep charged a step for every error result attached to a Bash
+  call — including a permission the classifier refused, a push a branch rule
+  blocked, and the user declining at the prompt. On one real project that was
+  26 non-runs against 7 genuine failures. Only a result that begins
+  `Exit code N` now counts; everything else is a command that did not run and
+  says nothing about the step.
+
+### Added
+- **The gate writes its judgement down before the command runs.** At
+  PreToolUse, a command that is a step of a workflow on record is noted in
+  `.mengram/intents.json` under the host's call id. PostToolUse closes that
+  record by id and credits the step it names — no second text match. A
+  command that failed never sends a PostToolUse; its intent is resolved from
+  the transcript by the same id on the next event, in this session or a later
+  one, and charged only for a genuine non-zero exit. Successes found this way
+  are closed without being counted, so a call whose own event is still on the
+  way is never credited twice.
+- 27 regression checks: what an error result means, lookup by call id, the
+  intent file's bounds, and the two hooks end to end.
+
 ## 2.41.6 — 2026-09-11
 
 ### Fixed

--- a/cli.py
+++ b/cli.py
@@ -852,6 +852,17 @@ def cmd_auto_policy(args):
         if input_data.get("tool_name") != "Bash":
             _exit("skipped (not Bash)")
         command = (input_data.get("tool_input") or {}).get("command") or ""
+
+        # Local memfmt folder first: no account, no network, no quota. Loaded
+        # before the workflow filter because the intent is noted for every
+        # command that is a step, gate or no gate: the outcome half needs the
+        # judgement written down for exactly the commands it will later record.
+        local_root = _local_dir(args)
+        procs = None
+        if local_root:
+            procs = policy.memfmt_procedures(str(local_root))
+            _note_intent(input_data, local_root, procs, command)
+
         if not policy.looks_like_workflow(command, os.environ.get("MENGRAM_POLICY_PATTERN")):
             _exit("skipped (not a workflow command)")
 
@@ -862,11 +873,7 @@ def cmd_auto_policy(args):
             except ValueError:
                 min_reliable = policy.DEFAULT_MIN_RELIABLE
 
-        # Local memfmt folder first: no account, no network, no quota.
-        local_root = _local_dir(args)
-        if local_root:
-            procs = policy.memfmt_procedures(str(local_root))
-        else:
+        if not local_root:
             api_key = _load_cloud_api_key()
             if not api_key:
                 _exit("no API key")
@@ -892,6 +899,84 @@ def cmd_auto_policy(args):
         raise
     except Exception:
         _exit("error")
+
+
+def _note_intent(input_data, local_root, procs, command) -> None:
+    """PreToolUse: write down which step this command is, before it runs.
+
+    Keyed by the id the host gives the call, so the outcome half can close
+    exactly this record instead of matching the command text a second time.
+    Same net as the recorder: the command has to name a known tool and be a
+    step of a workflow on record. Never raises — it is bookkeeping inside a
+    hook that must not stop a command.
+    """
+    try:
+        from cloud import policy
+        from local import intents
+        tool_use_id = input_data.get("tool_use_id")
+        if not tool_use_id or not command or not policy.shell_verbs(command):
+            return
+        hit = policy.best_step_match(procs, command)
+        if hit is None:
+            return
+        proc, step_no, _score = hit
+        transcript_path = input_data.get("transcript_path")
+        try:
+            offset = os.path.getsize(transcript_path) if transcript_path else 0
+        except OSError:
+            offset = 0
+        intents.open_intent(local_root, tool_use_id=tool_use_id,
+                            procedure=proc.get("name") or "unnamed workflow",
+                            step=step_no, command=command,
+                            session_id=input_data.get("session_id"),
+                            transcript_path=transcript_path, offset=offset)
+    except Exception:
+        return
+
+
+#: An intent with no result in its transcript after this long is a command
+#: that never finished where anyone could see it; it is dropped, not charged.
+_INTENT_UNRESOLVED_SECONDS = 24 * 3600
+
+
+def _settle_open_intents(local_root, store, current_tool_use_id, seen: list) -> str:
+    """Resolve earlier intents against their transcripts, by id.
+
+    A command that exited non-zero never sends a PostToolUse, so its intent is
+    still open when the next event comes round; the transcript holds its
+    `Exit code N` and that is charged to the step it was noted as. A declined
+    or refused command is closed and charged nothing: it never ran. A result
+    that reads as a success is closed without recording — its own PostToolUse
+    may still be on its way, and one success must not be counted twice.
+
+    Adds every charged id to `seen`, so the transcript sweep that follows does
+    not charge it again. Returns a fragment for the verbose marker.
+    """
+    from local import intents
+    from local import transcript as tr
+    import time
+    charged = 0
+    for intent in intents.open_intents(local_root):
+        tid = intent.get("tool_use_id")
+        if not tid or tid == current_tool_use_id:
+            continue
+        transcript_path = intent.get("transcript_path")
+        result = (tr.result_for(transcript_path, tid, intent.get("offset") or 0)
+                  if transcript_path else None)
+        if result is None:
+            age = time.time() - float(intent.get("opened_at") or 0)
+            if age > _INTENT_UNRESOLVED_SECONDS:
+                intents.close_intent(local_root, tid)
+            continue
+        kind, body = result
+        intents.close_intent(local_root, tid)
+        if kind == "failed":
+            store.step_outcome(intent.get("procedure") or "unnamed workflow",
+                               int(intent.get("step") or 0),
+                               success=False, reason=tr._reason(body))
+            seen.append(tid)
+            charged += 1
+    return f"; {charged} failure(s) from open intents" if charged else ""
 
 
 def _bash_outcome(tool_response) -> bool | None:
@@ -1020,32 +1105,47 @@ def cmd_auto_outcome(args):
 
         procs = policy.memfmt_procedures(str(local_root))
         store = _local_store(local_root)
+        tool_use_id = input_data.get("tool_use_id")
 
-        # Failures never arrive as an event — this hook does not fire for them —
-        # so they are read out of the session transcript instead. Done before
-        # anything about *this* command is decided, because a failure is not
-        # about this command: skipping it whenever the current call happens to
-        # be an `ls` would leave failures unrecorded for as long as the session
-        # stayed quiet. Reading the folder costs ~20 ms, and only the new tail
-        # of the transcript is parsed.
+        # Failures never arrive as an event — this hook does not fire for them.
+        # Two readers find them, in order. First the intents the gate noted at
+        # PreToolUse, resolved by id against their transcripts: exact, and it
+        # works across sessions. Then the transcript sweep, for commands that
+        # ran without an intent on record. Both before anything about *this*
+        # command is decided, because a failure is not about this command:
+        # skipping it whenever the current call happens to be an `ls` would
+        # leave failures unrecorded for as long as the session stayed quiet.
+        from local import intents
+        from local import transcript as tr
+        cursor = tr.read_cursor(local_root)
+        seen = list(cursor.get("seen") or [])
+        settled = _settle_open_intents(local_root, store, tool_use_id, seen)
+        if settled:
+            cursor["seen"] = seen
+            tr.write_cursor(local_root, cursor)
         failed = _record_transcript_failures(
-            input_data.get("transcript_path"), local_root, procs, store)
+            input_data.get("transcript_path"), local_root, procs, store) + settled
 
-        # Now this command. A wider net than the gate upstream: the gate stays
-        # narrow because a false question interrupts a human, while a recording
-        # costs nothing and evidence is what is scarce. A command naming no
-        # known tool cannot match any step.
-        if not policy.shell_verbs(command):
+        # Now this command. Its intent, if the gate noted one, names the step;
+        # no second match. Otherwise a wider net than the gate upstream: the
+        # gate stays narrow because a false question interrupts a human, while
+        # a recording costs nothing and evidence is what is scarce. A command
+        # naming no known tool cannot match any step.
+        intent = intents.close_intent(local_root, tool_use_id) if tool_use_id else None
+        if intent is None and not policy.shell_verbs(command):
             _exit(f"skipped (no known tool in the command){failed}")
         worked = _bash_outcome(input_data.get("tool_response"))
         if worked is None:
             _exit(f"outcome unclear — nothing recorded{failed}")
 
-        hit = policy.best_step_match(procs, command)
-        if hit is None:
-            _exit(f"no step matched{failed}")
-        proc, step_no, _score = hit
-        name = proc.get("name") or "unnamed workflow"
+        if intent is not None:
+            name, step_no = intent.get("procedure") or "unnamed workflow", int(intent.get("step") or 0)
+        else:
+            hit = policy.best_step_match(procs, command)
+            if hit is None:
+                _exit(f"no step matched{failed}")
+            proc, step_no, _score = hit
+            name = proc.get("name") or "unnamed workflow"
         reason = None if worked else _failure_reason(input_data.get("tool_response"))
         store.step_outcome(name, step_no, success=worked, reason=reason)
         _exit(f"'{name}' step {step_no} recorded as "

--- a/local/intents.py
+++ b/local/intents.py
@@ -1,0 +1,101 @@
+"""What the agent was about to do, written down before it does it.
+
+The post-tool event arrives only for commands that succeeded. Everything else
+— a command that exited non-zero, one the user declined, one the host refused
+to run — leaves nothing but a line in the transcript. Reading failures back
+out of that transcript meant matching command text to workflow steps a second
+time, after the fact, with a cursor that could skip past the evidence.
+
+So the gate writes its judgement down at PreToolUse, keyed by the id the host
+gives the tool call: *this* command is step N of *this* workflow. The outcome
+half closes exactly that record, by id, never by guessing again. An intent
+still open when the next event comes round is resolved against the transcript
+by the same id — and only a result that begins `Exit code N` counts against
+the step. A declined or refused command never ran, and says nothing.
+
+Kept in `.mengram/intents.json`, small and bounded: intents are opened only
+for commands that matched a step, which is a few in a hundred.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+FILE = "intents.json"
+
+#: More open intents than this means the outcome hook has not been running;
+#: the oldest are dropped rather than kept forever.
+MAX_OPEN = 200
+
+#: An intent nobody has resolved in a week refers to a session long gone.
+MAX_AGE_SECONDS = 7 * 24 * 3600
+
+
+def path(root) -> Path:
+    return Path(root) / ".mengram" / FILE
+
+
+def load(root) -> list[dict]:
+    try:
+        data = json.loads(path(root).read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    return [i for i in data if isinstance(i, dict) and i.get("tool_use_id")] \
+        if isinstance(data, list) else []
+
+
+def save(root, intents: list[dict]) -> None:
+    p = path(root)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    keep = [i for i in intents if now - float(i.get("opened_at") or now) < MAX_AGE_SECONDS]
+    keep = keep[-MAX_OPEN:]
+    tmp = p.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(keep, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp, p)
+
+
+def open_intent(root, *, tool_use_id: str, procedure: str, step: int, command: str,
+                session_id: str | None = None, transcript_path: str | None = None,
+                offset: int = 0) -> dict:
+    """Record that `command` is about to run as `step` of `procedure`.
+
+    `offset` is where the transcript ended when the intent was opened, so the
+    result can later be found without reading the whole session.
+    """
+    intent = {
+        "tool_use_id": tool_use_id,
+        "procedure": procedure,
+        "step": int(step),
+        "command": (command or "")[:500],
+        "session_id": session_id,
+        "transcript_path": transcript_path,
+        "offset": int(offset or 0),
+        "opened_at": time.time(),
+    }
+    intents = [i for i in load(root) if i.get("tool_use_id") != tool_use_id]
+    intents.append(intent)
+    save(root, intents)
+    return intent
+
+
+def close_intent(root, tool_use_id: str) -> dict | None:
+    """Remove and return the intent for this call, or None if there is none."""
+    intents = load(root)
+    found = None
+    rest = []
+    for i in intents:
+        if i.get("tool_use_id") == tool_use_id and found is None:
+            found = i
+        else:
+            rest.append(i)
+    if found is not None:
+        save(root, rest)
+    return found
+
+
+def open_intents(root) -> list[dict]:
+    return load(root)

--- a/local/transcript.py
+++ b/local/transcript.py
@@ -64,8 +64,39 @@ def _reason(body: str) -> str | None:
     return text.splitlines()[-1].strip()[:200] or None
 
 
+def _body(content) -> str:
+    """A tool result's text, whether the host wrote a string or a list of blocks."""
+    if isinstance(content, list):
+        return " ".join(str(b.get("text") or "") for b in content if isinstance(b, dict))
+    return str(content or "")
+
+
+def ran_and_failed(body: str) -> bool:
+    """Did this error result come from a command that ran and exited non-zero?
+
+    Only a body that begins `Exit code N` did. A host writes `is_error` on a
+    great deal else: a permission the classifier refused, a push a branch rule
+    blocked, the user declining at the prompt, a call that timed out. Measured
+    on one real project: 14 refusals and 12 blocked pushes against 7 genuine
+    exits. None of those commands ran, so none of them is evidence about the
+    step — and each one, counted, would have cost a workflow its trust.
+    """
+    return bool(_EXIT_CODE.match((body or "").lstrip()))
+
+
+def classify(is_error, body: str) -> str:
+    """`"ok"`, `"failed"` (ran, non-zero exit) or `"not_run"` (refused, declined, timed out)."""
+    if not is_error:
+        return "ok"
+    return "failed" if ran_and_failed(body) else "not_run"
+
+
 def _scan(transcript_path, start: int):
-    """`({tool_use_id: command}, [(tool_use_id, body)])` for failures from `start`."""
+    """`({tool_use_id: command}, [(tool_use_id, body)])` for failures from `start`.
+
+    Only commands that ran and exited non-zero are failures here; see
+    `ran_and_failed` for what an error result can otherwise be.
+    """
     commands: dict[str, str] = {}
     errors: list[tuple[str, str]] = []
     try:
@@ -89,11 +120,48 @@ def _scan(transcript_path, start: int):
                         if cmd:
                             commands[block.get("id")] = cmd
                     elif block.get("type") == "tool_result" and block.get("is_error"):
-                        errors.append((block.get("tool_use_id"),
-                                       str(block.get("content") or "")))
+                        body = _body(block.get("content"))
+                        if ran_and_failed(body):
+                            errors.append((block.get("tool_use_id"), body))
     except OSError:
         return {}, []
     return commands, errors
+
+
+def result_for(transcript_path, tool_use_id: str, start: int = 0) -> tuple[str, str] | None:
+    """The result the transcript holds for one tool call: `(kind, body)`.
+
+    `kind` is what `classify` returns. None when there is no result yet — the
+    command may still be running, or the session ended before it finished.
+    Reads from a little before `start`, the transcript's size when the call
+    was noted, so a long session is not re-read for every lookup.
+    """
+    if not tool_use_id:
+        return None
+    try:
+        with open(transcript_path, "r", errors="ignore") as fh:
+            begin = max(0, int(start or 0) - LOOKBACK_BYTES)
+            fh.seek(begin)
+            if begin:
+                fh.readline()
+            for line in fh:
+                if tool_use_id not in line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except Exception:
+                    continue
+                content = (entry.get("message") or {}).get("content")
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if (isinstance(block, dict) and block.get("type") == "tool_result"
+                            and block.get("tool_use_id") == tool_use_id):
+                        body = _body(block.get("content"))
+                        return classify(block.get("is_error"), body), body
+    except OSError:
+        return None
+    return None
 
 
 def new_failures(transcript_path, cursor: dict) -> tuple[list[tuple[str, str | None]], dict]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mengram-ai"
-version = "2.41.6"
+version = "2.42.0"
 description = "Human-like memory for AI agents — auto-save, auto-recall, cognitive profile. Claude Code hooks, MCP server (29 tools), OpenClaw plugin, semantic/episodic/procedural memory. Free open-source Mem0 alternative."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_intents.py
+++ b/tests/test_intents.py
@@ -1,0 +1,367 @@
+"""Intent before the command, outcome after — joined by the host's call id.
+
+The gate judges a command once, at PreToolUse. Until now that judgement was
+thrown away and re-derived after the fact by matching text out of the
+transcript, which also counted every `is_error` result as a failure —
+including the classifier refusing a command and the user declining one,
+neither of which ran. These tests pin the new contract: an intent is opened
+for exactly the commands the recorder would record, closed by id, and only a
+result that begins `Exit code N` ever costs a step.
+"""
+import io
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import cli
+from local import intents
+from local import transcript as tr
+
+RELEASE_STEPS = [
+    {"action": "run the test suite", "detail": "pytest -q tests/"},
+    {"action": "build the artifacts", "detail": "python3 -m build"},
+    {"action": "upload to PyPI", "detail": "twine upload dist/*"},
+    {"action": "write the announcement post"},
+]
+
+
+def _folder(tmp_path):
+    from local.store import LocalStore
+    store = LocalStore(str(tmp_path))
+    store.save_extracted_procedure("Release to PyPI", "shipping a version",
+                                   [dict(s) for s in RELEASE_STEPS])
+    store.save()
+    return store
+
+
+def _read(tmp_path):
+    from local.store import LocalStore
+    return LocalStore(str(tmp_path)).procedures()[0]
+
+
+def _use(tid, command):
+    return {"message": {"content": [
+        {"type": "tool_use", "name": "Bash", "id": tid, "input": {"command": command}}]}}
+
+
+def _result(tid, body, error=True):
+    return {"message": {"content": [
+        {"type": "tool_result", "tool_use_id": tid, "is_error": error, "content": body}]}}
+
+
+def _write(path, entries, mode="w"):
+    with open(path, mode) as fh:
+        for e in entries:
+            fh.write(json.dumps(e) + "\n")
+
+
+def _hook(monkeypatch, capsys, name, payload, memory):
+    monkeypatch.delenv("MENGRAM_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("MENGRAM_POLICY_PATTERN", raising=False)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(sys, "argv", ["mengram", name, "--memory", str(memory), "--verbose"])
+    with pytest.raises(SystemExit) as e:
+        cli.main()
+    assert e.value.code == 0
+    out = capsys.readouterr().out.strip()
+    return json.loads(out).get("systemMessage", "") if out else ""
+
+
+def _pre(command, tid="toolu_1", transcript=None):
+    return {"hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_use_id": tid,
+            "session_id": "s1", "transcript_path": transcript,
+            "tool_input": {"command": command}}
+
+
+def _post(command, tid="toolu_1", transcript=None, response=None):
+    return {"hook_event_name": "PostToolUse", "tool_name": "Bash", "tool_use_id": tid,
+            "session_id": "s1", "transcript_path": transcript,
+            "tool_input": {"command": command},
+            "tool_response": response if response is not None else
+            {"stdout": "ok", "stderr": "", "interrupted": False,
+             "isImage": False, "noOutputExpected": False}}
+
+
+# --- what an error result means --------------------------------------------
+
+@pytest.mark.parametrize("body", [
+    "Exit code 1\nTraceback (most recent call last)",
+    "Exit code 127\n(eval):1: command not found: railway",
+    "  Exit code 2",
+])
+def test_a_non_zero_exit_is_a_failure(body):
+    assert tr.ran_and_failed(body)
+    assert tr.classify(True, body) == "failed"
+
+
+@pytest.mark.parametrize("body", [
+    "Permission for this action was denied by the auto-mode classifier.",
+    "Pushing to 'main' is blocked: this branch auto-deploys.",
+    "The user doesn't want to proceed with this tool use.",
+    "Command timed out after 2m 0.0s",
+    "",
+])
+def test_a_command_that_never_ran_is_not_a_failure(body):
+    assert not tr.ran_and_failed(body)
+    assert tr.classify(True, body) == "not_run"
+
+
+def test_a_success_is_a_success_whatever_the_body_says():
+    assert tr.classify(False, "Exit code 1 appears in this output") == "ok"
+
+
+def test_list_shaped_result_bodies_are_read():
+    assert tr._body([{"type": "text", "text": "Exit code 1\nboom"}]) == "Exit code 1\nboom"
+    assert tr.ran_and_failed(tr._body([{"type": "text", "text": "Exit code 1"}]))
+
+
+def test_the_transcript_sweep_no_longer_charges_refusals(tmp_path):
+    """The live bug: a refused command counted as a failed step."""
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "pytest -q tests/"), _result("a", "Exit code 1\nold")])
+    _, cursor = tr.new_failures(t, {})                       # first run: history seen
+    _write(t, [_use("b", "twine upload dist/*"),
+               _result("b", "Permission for this action was denied by the auto-mode classifier."),
+               _use("c", "pytest -q tests/"),
+               _result("c", "The user doesn't want to proceed with this tool use."),
+               _use("d", "python3 -m build"), _result("d", "Exit code 1\nno module build")],
+           mode="a")
+    failures, _ = tr.new_failures(t, cursor)
+    assert failures == [("python3 -m build", "no module build")]
+
+
+# --- finding one call's result by id ---------------------------------------
+
+def test_result_for_finds_the_call_by_id(tmp_path):
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "pytest -q"), _result("a", "Exit code 1\n3 failed"),
+               _use("b", "twine upload dist/*"), _result("b", "uploaded", error=False),
+               _use("c", "git push"), _result("c", "The user doesn't want to proceed.")])
+    assert tr.result_for(t, "a") == ("failed", "Exit code 1\n3 failed")
+    assert tr.result_for(t, "b") == ("ok", "uploaded")
+    assert tr.result_for(t, "c")[0] == "not_run"
+    assert tr.result_for(t, "nope") is None
+    assert tr.result_for(tmp_path / "missing.jsonl", "a") is None
+
+
+def test_result_for_reads_from_the_noted_offset(tmp_path):
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("a", "x" * 70000), _result("a", "Exit code 1\nold")])
+    offset = t.stat().st_size
+    _write(t, [_use("b", "pytest -q"), _result("b", "Exit code 1\nfresh")], mode="a")
+    assert tr.result_for(t, "b", offset) == ("failed", "Exit code 1\nfresh")
+
+
+# --- the intent file --------------------------------------------------------
+
+def test_open_close_round_trip(tmp_path):
+    intents.open_intent(tmp_path, tool_use_id="t1", procedure="Release to PyPI",
+                        step=3, command="twine upload dist/*", offset=12)
+    assert [i["tool_use_id"] for i in intents.open_intents(tmp_path)] == ["t1"]
+    got = intents.close_intent(tmp_path, "t1")
+    assert got["procedure"] == "Release to PyPI" and got["step"] == 3 and got["offset"] == 12
+    assert intents.open_intents(tmp_path) == []
+    assert intents.close_intent(tmp_path, "t1") is None
+
+
+def test_reopening_the_same_id_replaces_it(tmp_path):
+    intents.open_intent(tmp_path, tool_use_id="t1", procedure="A", step=1, command="a")
+    intents.open_intent(tmp_path, tool_use_id="t1", procedure="B", step=2, command="b")
+    assert [i["procedure"] for i in intents.open_intents(tmp_path)] == ["B"]
+
+
+def test_the_file_is_bounded_and_forgets_the_stale(tmp_path):
+    for n in range(intents.MAX_OPEN + 5):
+        intents.open_intent(tmp_path, tool_use_id=f"t{n}", procedure="A", step=1, command="a")
+    assert len(intents.open_intents(tmp_path)) == intents.MAX_OPEN
+    old = intents.open_intents(tmp_path)
+    old[0]["opened_at"] = time.time() - intents.MAX_AGE_SECONDS - 1
+    intents.save(tmp_path, old)
+    assert len(intents.open_intents(tmp_path)) == intents.MAX_OPEN - 1
+
+
+def test_a_corrupt_file_reads_as_empty(tmp_path):
+    intents.path(tmp_path).parent.mkdir(parents=True)
+    intents.path(tmp_path).write_text("{not json")
+    assert intents.open_intents(tmp_path) == []
+
+
+# --- PreToolUse notes the intent -------------------------------------------
+
+def test_pretooluse_notes_which_step_the_command_is(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("x", "ls")])
+    _hook(monkeypatch, capsys, "auto-policy", _pre("twine upload dist/*", "toolu_9", str(t)), tmp_path)
+    [intent] = intents.open_intents(tmp_path)
+    assert intent["tool_use_id"] == "toolu_9"
+    assert intent["procedure"] == "Release to PyPI" and intent["step"] == 3
+    assert intent["transcript_path"] == str(t) and intent["offset"] == t.stat().st_size
+
+
+def test_pretooluse_notes_nothing_for_a_command_that_is_no_step(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    _hook(monkeypatch, capsys, "auto-policy", _pre("echo done", "toolu_9"), tmp_path)
+    _hook(monkeypatch, capsys, "auto-policy", _pre("git status", "toolu_10"), tmp_path)
+    assert intents.open_intents(tmp_path) == []
+
+
+def test_pretooluse_notes_nothing_without_a_call_id(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    payload = _pre("twine upload dist/*")
+    del payload["tool_use_id"]
+    _hook(monkeypatch, capsys, "auto-policy", payload, tmp_path)
+    assert intents.open_intents(tmp_path) == []
+
+
+def test_the_gate_still_asks_after_noting_the_intent(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(_pre("twine upload dist/*"))))
+    monkeypatch.setattr(sys, "argv", ["mengram", "auto-policy", "--memory", str(tmp_path)])
+    with pytest.raises(SystemExit):
+        cli.main()
+    out = json.loads(capsys.readouterr().out)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert len(intents.open_intents(tmp_path)) == 1
+
+
+# --- PostToolUse closes it by id --------------------------------------------
+
+def test_posttooluse_closes_the_intent_and_records_its_step(monkeypatch, capsys, tmp_path):
+    """The step comes from the intent, not from matching the text again."""
+    _folder(tmp_path)
+    intents.open_intent(tmp_path, tool_use_id="toolu_9", procedure="Release to PyPI",
+                        step=2, command="anything")
+    msg = _hook(monkeypatch, capsys, "auto-outcome", _post("make wheel", "toolu_9"), tmp_path)
+    assert "'Release to PyPI' step 2 recorded as success" in msg
+    assert _read(tmp_path)["steps"][1]["success_count"] == 1
+    assert intents.open_intents(tmp_path) == []
+
+
+def test_posttooluse_without_an_intent_still_matches_the_text(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    msg = _hook(monkeypatch, capsys, "auto-outcome", _post("twine upload dist/*", "toolu_9"), tmp_path)
+    assert "step 3 recorded as success" in msg
+
+
+def test_an_unclear_outcome_closes_the_intent_and_records_nothing(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    intents.open_intent(tmp_path, tool_use_id="toolu_9", procedure="Release to PyPI",
+                        step=3, command="twine upload dist/*")
+    msg = _hook(monkeypatch, capsys, "auto-outcome",
+                _post("twine upload dist/*", "toolu_9", response={"stdout": "", "interrupted": True}),
+                tmp_path)
+    assert "outcome unclear" in msg
+    assert intents.open_intents(tmp_path) == []
+    assert _read(tmp_path)["steps"][2].get("success_count") in (None, 0)
+
+
+# --- an earlier intent whose command failed --------------------------------
+
+def _seed_cursor(tmp_path, t):
+    """Start the transcript sweep past the current history, as a real session would."""
+    _, cursor = tr.new_failures(t, {})
+    tr.write_cursor(tmp_path, cursor)
+
+
+def test_a_failed_command_is_charged_from_its_intent(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("z", "ls")])
+    _seed_cursor(tmp_path, t)
+    offset = t.stat().st_size
+    intents.open_intent(tmp_path, tool_use_id="toolu_fail", procedure="Release to PyPI",
+                        step=1, command="pytest -q tests/", transcript_path=str(t), offset=offset)
+    # The command failed: no PostToolUse for it, only a transcript line.
+    _write(t, [_use("toolu_fail", "pytest -q tests/"),
+               _result("toolu_fail", "Exit code 1\n3 failed, 12 passed"),
+               _use("toolu_next", "ls -la"), _result("toolu_next", "files", error=False)], mode="a")
+    msg = _hook(monkeypatch, capsys, "auto-outcome", _post("ls -la", "toolu_next", str(t)), tmp_path)
+    assert "1 failure(s) from open intents" in msg
+    proc = _read(tmp_path)
+    assert proc["steps"][0]["fail_count"] == 1
+    assert proc["last_failure"] == "3 failed, 12 passed"
+    assert intents.open_intents(tmp_path) == []
+    # The sweep saw the same id and did not charge it again.
+    assert "toolu_fail" in tr.read_cursor(tmp_path)["seen"]
+    msg = _hook(monkeypatch, capsys, "auto-outcome", _post("ls -la", "toolu_next2", str(t)), tmp_path)
+    assert "failure" not in msg
+    assert _read(tmp_path)["steps"][0]["fail_count"] == 1
+
+
+def test_a_refused_command_is_closed_and_charged_nothing(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("z", "ls")])
+    _seed_cursor(tmp_path, t)
+    intents.open_intent(tmp_path, tool_use_id="toolu_no", procedure="Release to PyPI",
+                        step=3, command="twine upload dist/*", transcript_path=str(t),
+                        offset=t.stat().st_size)
+    _write(t, [_use("toolu_no", "twine upload dist/*"),
+               _result("toolu_no", "The user doesn't want to proceed with this tool use.")], mode="a")
+    _hook(monkeypatch, capsys, "auto-outcome", _post("ls", "toolu_next", str(t)), tmp_path)
+    assert intents.open_intents(tmp_path) == []
+    proc = _read(tmp_path)
+    assert proc["steps"][2].get("fail_count") in (None, 0)
+    assert not proc.get("last_failure")
+
+
+def test_a_success_on_record_is_closed_but_not_counted_twice(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("z", "ls")])
+    _seed_cursor(tmp_path, t)
+    intents.open_intent(tmp_path, tool_use_id="toolu_ok", procedure="Release to PyPI",
+                        step=3, command="twine upload dist/*", transcript_path=str(t),
+                        offset=t.stat().st_size)
+    _write(t, [_use("toolu_ok", "twine upload dist/*"), _result("toolu_ok", "done", error=False)],
+           mode="a")
+    _hook(monkeypatch, capsys, "auto-outcome", _post("ls", "toolu_next", str(t)), tmp_path)
+    assert intents.open_intents(tmp_path) == []
+    assert _read(tmp_path)["steps"][2].get("success_count") in (None, 0)
+
+
+def test_an_intent_with_no_result_yet_stays_open(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("z", "ls")])
+    _seed_cursor(tmp_path, t)
+    intents.open_intent(tmp_path, tool_use_id="toolu_running", procedure="Release to PyPI",
+                        step=1, command="pytest -q tests/", transcript_path=str(t),
+                        offset=t.stat().st_size)
+    _hook(monkeypatch, capsys, "auto-outcome", _post("ls", "toolu_next", str(t)), tmp_path)
+    assert [i["tool_use_id"] for i in intents.open_intents(tmp_path)] == ["toolu_running"]
+
+
+def test_an_intent_nobody_resolved_for_a_day_is_dropped(monkeypatch, capsys, tmp_path):
+    _folder(tmp_path)
+    t = tmp_path / "t.jsonl"
+    _write(t, [_use("z", "ls")])
+    _seed_cursor(tmp_path, t)
+    intents.open_intent(tmp_path, tool_use_id="toolu_lost", procedure="Release to PyPI",
+                        step=1, command="pytest -q tests/", transcript_path=str(t))
+    stale = intents.open_intents(tmp_path)
+    stale[0]["opened_at"] = time.time() - cli._INTENT_UNRESOLVED_SECONDS - 1
+    intents.save(tmp_path, stale)
+    _hook(monkeypatch, capsys, "auto-outcome", _post("ls", "toolu_next", str(t)), tmp_path)
+    assert intents.open_intents(tmp_path) == []
+    assert _read(tmp_path)["steps"][0].get("fail_count") in (None, 0)
+
+
+def test_a_failure_from_a_finished_session_is_charged_by_a_later_one(monkeypatch, capsys, tmp_path):
+    """The intent carries its own transcript path: the next session settles it."""
+    _folder(tmp_path)
+    old = tmp_path / "old.jsonl"
+    _write(old, [_use("toolu_old", "python3 -m build"),
+                 _result("toolu_old", "Exit code 1\nno module named build")])
+    intents.open_intent(tmp_path, tool_use_id="toolu_old", procedure="Release to PyPI",
+                        step=2, command="python3 -m build", transcript_path=str(old), offset=0)
+    new = tmp_path / "new.jsonl"
+    _write(new, [_use("toolu_n", "ls")])
+    _hook(monkeypatch, capsys, "auto-outcome", _post("ls", "toolu_n", str(new)), tmp_path)
+    assert _read(tmp_path)["steps"][1]["fail_count"] == 1
+    assert intents.open_intents(tmp_path) == []


### PR DESCRIPTION
## What
- **Bug fix:** the transcript sweep counted every `is_error` result on a Bash call as a failed step: classifier refusals (14×), blocked pushes (12×), the user declining (2×) on one real project, against 7 genuine failures. Only a body starting `Exit code N` counts now.
- **Intent → outcome by id:** `auto-policy` (PreToolUse) notes which step the command is in `.mengram/intents.json` keyed by `tool_use_id`; `auto-outcome` (PostToolUse) closes it by id and credits that step without re-matching text. Open intents whose command failed (no event arrives for those) are settled from the transcript by id on the next event — in this session or a later one. Successes found this way are closed but not counted, so a call whose own event is still coming is never double-credited.

## Tests
27 new in `tests/test_intents.py`; suite 541 passed, 3 pre-existing `TestParseVault` failures unchanged.

## Not verified live yet
That Claude Code's PreToolUse payload carries `tool_use_id` (docs say both hooks do; PostToolUse measured). Without it the hook degrades to the previous transcript sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGreuwZ5i2yHCNbkkwDNvt